### PR TITLE
docs(readme): script Bash de cron host avec arrêt de Navidrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,87 @@ Les migrations Doctrine sont jouées automatiquement à chaque démarrage
 (idempotent). Le volume `playlist-data` préserve la configuration entre
 redémarrages.
 
+### Cron externe avec arrêt de Navidrome (optionnel)
+
+Le service `navidrome-tools-cron` livré dans le compose lance déjà
+supercronic et exécute les jobs en parallèle de Navidrome. Si vous
+préférez piloter les jobs depuis le **crontab de l'hôte** (par exemple
+parce qu'au moins un job — typiquement `app:lastfm:import` — a besoin
+que Navidrome soit arrêté pour écrire dans sa SQLite sans risque de
+lock), voici un script complet à appeler depuis le crontab de la
+machine.
+
+> Pré-requis : Navidrome **et** les services `navidrome-tools-*` doivent
+> être déclarés dans le **même** `docker-compose.yml` (« même stack »).
+> Si vous adoptez ce script, **désactivez** le service
+> `navidrome-tools-cron` (sinon ses jobs supercronic et ceux du host
+> cron se marcheront dessus).
+
+`/usr/local/bin/navidrome-tools-cron.sh` :
+
+```bash
+#!/usr/bin/env bash
+#
+# Stoppe Navidrome, lance les commandes cron de navidrome-tools,
+# redémarre Navidrome — quoi qu'il arrive.
+#
+# Exemple de ligne crontab (root) :
+#     0 4 * * * /usr/local/bin/navidrome-tools-cron.sh >> /var/log/navidrome-tools-cron.log 2>&1
+
+set -euo pipefail
+
+# --- Configuration ---
+STACK_DIR="/srv/navidrome"            # dossier contenant docker-compose.yml
+NAVIDROME_SERVICE="navidrome"         # nom du service Navidrome dans la stack
+TOOLS_SERVICE="navidrome-tools-web"   # service tool sur lequel taper les commandes
+COMPOSE=(docker compose)              # mettre (docker-compose) pour l'ancien CLI
+
+cd "$STACK_DIR"
+
+log() { echo "[$(date -Is)] $*"; }
+
+# Toujours relancer Navidrome, même si une commande échoue ou que le
+# script est interrompu.
+restart_navidrome() {
+    log "Redémarrage de ${NAVIDROME_SERVICE}"
+    "${COMPOSE[@]}" up -d "$NAVIDROME_SERVICE"
+}
+trap restart_navidrome EXIT
+
+log "Arrêt de ${NAVIDROME_SERVICE}"
+"${COMPOSE[@]}" stop "$NAVIDROME_SERVICE"
+
+log "Génération des playlists dues"
+"${COMPOSE[@]}" exec -T "$TOOLS_SERVICE" php bin/console app:playlist:run-all
+
+log "Recalcul du cache statistiques"
+"${COMPOSE[@]}" exec -T "$TOOLS_SERVICE" php bin/console app:stats:compute
+
+log "Purge de l'historique des runs"
+"${COMPOSE[@]}" exec -T "$TOOLS_SERVICE" php bin/console app:history:purge
+
+log "Terminé"
+```
+
+Rendez-le exécutable une fois copié :
+
+```bash
+sudo chmod +x /usr/local/bin/navidrome-tools-cron.sh
+```
+
+Notes :
+
+- `trap … EXIT` garantit que Navidrome est relancé même si une commande
+  Symfony plante ou si le script reçoit un `SIGTERM`.
+- `docker compose exec -T` réutilise le conteneur `navidrome-tools-web`
+  déjà démarré (toutes les variables d'environnement requises y sont
+  déjà). Pas besoin d'un `run --rm` qui relancerait l'entrypoint et
+  rejouerait les migrations à chaque tick.
+- Adaptez la liste de commandes selon vos besoins — vous pouvez par
+  exemple ajouter un `app:lastfm:import <user> --api-key=…` une fois
+  par jour, qui profitera de l'arrêt de Navidrome pour écrire en toute
+  sécurité dans `navidrome.db`.
+
 ## Développement local avec Lando (recommandé)
 
 [Lando](https://lando.dev/) fournit l'environnement Symfony complet


### PR DESCRIPTION
## Résumé

Ajoute dans le README un exemple complet de script Bash à appeler
depuis le crontab de l'hôte. Le script :

- arrête le service `navidrome` du compose,
- lance les commandes cron de navidrome-tools (`app:playlist:run-all`,
  `app:stats:compute`, `app:history:purge`) via `docker compose exec`
  sur le conteneur `navidrome-tools-web` déjà en place,
- redémarre toujours Navidrome via un `trap … EXIT`, même si une
  commande échoue ou si le script est interrompu.

Cas d'usage principal : permettre à des jobs qui écrivent dans la DB
SQLite Navidrome (notamment `app:lastfm:import`) de tourner sans
risque de lock concurrent. Le README rappelle qu'il faut alors
désactiver le service `navidrome-tools-cron` pour éviter que
supercronic et le host crontab se marchent dessus.

## Test plan

- [ ] Relire la nouvelle section dans le README rendu sur GitHub.
- [ ] Sur une stack réelle, vérifier que le script tel que copié
      stoppe bien Navidrome, exécute les trois commandes, puis le
      redémarre.
- [ ] Forcer une commande à échouer (`exit 1`) et vérifier que
      Navidrome est tout de même relancé par le trap.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ARZJXC5G8fs24gCSPaD1fv)_