### PR TITLE
feat(history): actions Lidarr par artiste non matché sur /history/{id}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Section « Artistes non matchés » sur la page `/history/{id}` d'un run
+  `lastfm-import` : top 100 artistes agrégés (scrobbles sommés),
+  persistés dans `metrics.unmatched_artists`. Pour chaque artiste,
+  badge `✓ déjà dans Lidarr` + lien vers la fiche, ou bouton
+  `+ Lidarr` (qui redirige vers la même page de détail après ajout).
+  Encarts dédiés si Lidarr non configuré ou injoignable. Closes #10.
 - `CHANGELOG.md` au format Keep a Changelog ; documentation du workflow
   de release dans `CLAUDE.md` (§5) et lien depuis le `README.md`.
 - `AGENTS.md` (convention transverse pour les assistants IA) avec la

--- a/src/Command/ImportLastFmCommand.php
+++ b/src/Command/ImportLastFmCommand.php
@@ -159,6 +159,7 @@ class ImportLastFmCommand extends Command
                     'inserted' => $r->inserted,
                     'duplicates' => $r->duplicates,
                     'unmatched' => $r->unmatched,
+                    'unmatched_artists' => $r->unmatchedArtistsRanking(100),
                     'dry_run' => $dryRun,
                     'date_min' => $dateMin?->format('Y-m-d'),
                     'date_max' => $dateMax?->format('Y-m-d'),

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -4,6 +4,8 @@ namespace App\Controller;
 
 use App\Entity\LastFmImportTrack;
 use App\Entity\RunHistory;
+use App\Lidarr\LidarrClient;
+use App\Lidarr\LidarrConfig;
 use App\Repository\LastFmImportTrackRepository;
 use App\Repository\RunHistoryRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -15,6 +17,12 @@ class HistoryController extends AbstractController
 {
     private const PER_PAGE = 50;
     private const DETAIL_TRACK_LIMIT = 500;
+
+    public function __construct(
+        private readonly LidarrConfig $lidarrConfig,
+        private readonly LidarrClient $lidarrClient,
+    ) {
+    }
 
     #[Route('/history', name: 'app_history', methods: ['GET'])]
     public function index(Request $request, RunHistoryRepository $repository): Response
@@ -56,6 +64,8 @@ class HistoryController extends AbstractController
         $statusFilter = null;
         $qFilter = null;
         $tracksTruncated = false;
+        $unmatchedArtists = [];
+        $lidarrReachable = true;
 
         if ($entry->getType() === RunHistory::TYPE_LASTFM_IMPORT) {
             $statusCounts = $tracksRepo->countByStatusForRun($entry);
@@ -82,6 +92,8 @@ class HistoryController extends AbstractController
                 self::DETAIL_TRACK_LIMIT,
             );
             $tracksTruncated = count($tracks) >= self::DETAIL_TRACK_LIMIT;
+
+            $unmatchedArtists = $this->buildUnmatchedArtists($entry, $lidarrReachable);
         }
 
         return $this->render('history/detail.html.twig', [
@@ -97,6 +109,50 @@ class HistoryController extends AbstractController
                 LastFmImportTrack::STATUS_DUPLICATE => 'Doublons',
                 LastFmImportTrack::STATUS_UNMATCHED => 'Non matchés',
             ],
+            'unmatched_artists' => $unmatchedArtists,
+            'lidarr_configured' => $this->lidarrConfig->isConfigured(),
+            'lidarr_reachable' => $lidarrReachable,
         ]);
+    }
+
+    /**
+     * @return list<array{artist: string, scrobbles: int, lidarr_url: string|null}>
+     */
+    private function buildUnmatchedArtists(RunHistory $entry, bool &$lidarrReachable): array
+    {
+        $metrics = $entry->getMetrics() ?? [];
+        $raw = $metrics['unmatched_artists'] ?? [];
+        if (!is_array($raw) || $raw === []) {
+            return [];
+        }
+
+        $index = null;
+        if ($this->lidarrConfig->isConfigured()) {
+            try {
+                $index = $this->lidarrClient->indexExistingArtists();
+            } catch (\Throwable) {
+                $lidarrReachable = false;
+                $index = null;
+            }
+        }
+
+        $rows = [];
+        foreach ($raw as $row) {
+            if (!is_array($row) || !isset($row['artist'])) {
+                continue;
+            }
+            $artist = (string) $row['artist'];
+            $key = mb_strtolower(trim($artist));
+            $match = $index[$key] ?? null;
+            $rows[] = [
+                'artist' => $artist,
+                'scrobbles' => (int) ($row['scrobbles'] ?? 0),
+                'lidarr_url' => $match !== null && $match['foreignArtistId'] !== ''
+                    ? $this->lidarrConfig->artistDetailUrl($match['foreignArtistId'])
+                    : null,
+            ];
+        }
+
+        return $rows;
     }
 }

--- a/src/Controller/LastFmImportController.php
+++ b/src/Controller/LastFmImportController.php
@@ -94,6 +94,7 @@ class LastFmImportController extends AbstractController
                             'inserted' => $r->inserted,
                             'duplicates' => $r->duplicates,
                             'unmatched' => $r->unmatched,
+                            'unmatched_artists' => $r->unmatchedArtistsRanking(100),
                             'dry_run' => $isDry,
                             'date_min' => $dateMin?->format('Y-m-d'),
                             'date_max' => $dateMax?->format('Y-m-d'),

--- a/src/Controller/LidarrController.php
+++ b/src/Controller/LidarrController.php
@@ -20,17 +20,22 @@ class LidarrController extends AbstractController
     #[Route('/lidarr/add-artist', name: 'app_lidarr_add_artist', methods: ['POST'])]
     public function addArtist(Request $request): Response
     {
+        $redirectRunId = (int) $request->request->get('_redirect_run_id', 0);
+        $back = $redirectRunId > 0
+            ? $this->redirectToRoute('app_history_detail', ['id' => $redirectRunId])
+            : $this->redirectToRoute('app_lastfm_import');
+
         if (!$this->config->isConfigured()) {
             $this->addFlash('error', 'Lidarr n\'est pas configuré (LIDARR_URL / LIDARR_API_KEY).');
 
-            return $this->redirectToRoute('app_lastfm_import');
+            return $back;
         }
 
         $artist = trim((string) $request->request->get('artist', ''));
         if ($artist === '') {
             $this->addFlash('error', 'Nom d\'artiste manquant.');
 
-            return $this->redirectToRoute('app_lastfm_import');
+            return $back;
         }
 
         if (!$this->isCsrfTokenValid('lidarr_add', (string) $request->request->get('_token'))) {
@@ -48,6 +53,6 @@ class LidarrController extends AbstractController
             $this->addFlash('error', sprintf('Lidarr : %s', $e->getMessage()));
         }
 
-        return $this->redirectToRoute('app_lastfm_import');
+        return $back;
     }
 }

--- a/src/LastFm/ImportReport.php
+++ b/src/LastFm/ImportReport.php
@@ -49,4 +49,31 @@ class ImportReport
     {
         return count($this->unmatchedAggregate);
     }
+
+    /**
+     * Unmatched artists, scrobble counts summed across every unmatched
+     * (artist, title) pair, ordered by scrobble count DESC then artist ASC.
+     *
+     * @return list<array{artist: string, scrobbles: int}>
+     */
+    public function unmatchedArtistsRanking(?int $limit = null): array
+    {
+        /** @var array<string, array{artist: string, scrobbles: int}> $byArtist */
+        $byArtist = [];
+        foreach ($this->unmatchedAggregate as $row) {
+            $key = mb_strtolower(trim($row['artist']));
+            if (!isset($byArtist[$key])) {
+                $byArtist[$key] = ['artist' => $row['artist'], 'scrobbles' => 0];
+            }
+            $byArtist[$key]['scrobbles'] += $row['count'];
+        }
+
+        $rows = array_values($byArtist);
+        usort($rows, static function (array $a, array $b): int {
+            return $b['scrobbles'] <=> $a['scrobbles']
+                ?: strcasecmp($a['artist'], $b['artist']);
+        });
+
+        return $limit === null ? $rows : array_slice($rows, 0, $limit);
+    }
 }

--- a/src/Lidarr/LidarrClient.php
+++ b/src/Lidarr/LidarrClient.php
@@ -57,6 +57,37 @@ class LidarrClient
     }
 
     /**
+     * Index every artist already known to Lidarr by normalised name
+     * (lowercased + trimmed) so callers can resolve "is artist X already
+     * in Lidarr?" in O(1) without one HTTP call per name.
+     *
+     * @return array<string, array{id: int, foreignArtistId: string, artistName: string}>
+     */
+    public function indexExistingArtists(): array
+    {
+        $resp = $this->request('GET', '/api/v1/artist');
+
+        $index = [];
+        foreach ($resp as $r) {
+            if (!is_array($r) || !isset($r['artistName'])) {
+                continue;
+            }
+            $name = (string) $r['artistName'];
+            $key = mb_strtolower(trim($name));
+            if ($key === '') {
+                continue;
+            }
+            $index[$key] = [
+                'id' => (int) ($r['id'] ?? 0),
+                'foreignArtistId' => (string) ($r['foreignArtistId'] ?? ''),
+                'artistName' => $name,
+            ];
+        }
+
+        return $index;
+    }
+
+    /**
      * Add an artist to Lidarr. Pass a hit returned by searchArtist().
      *
      * @param array<string, mixed> $hit

--- a/src/Lidarr/LidarrConfig.php
+++ b/src/Lidarr/LidarrConfig.php
@@ -18,4 +18,9 @@ final class LidarrConfig
     {
         return $this->url !== '' && $this->apiKey !== '';
     }
+
+    public function artistDetailUrl(string $foreignArtistId): string
+    {
+        return rtrim($this->url, '/') . '/artist/' . $foreignArtistId;
+    }
 }

--- a/templates/history/detail.html.twig
+++ b/templates/history/detail.html.twig
@@ -131,4 +131,92 @@
             {% endif %}
         </div>
     {% endif %}
+
+    {# ---------- Unmatched artists section for Last.fm imports ---------- #}
+    {% if entry.type == 'lastfm-import' and unmatched_artists is not empty %}
+        <div class="bg-white shadow rounded p-6 mt-6 max-w-5xl">
+            <h2 class="text-lg font-semibold mb-1">
+                Artistes non matchés (top {{ unmatched_artists|length }})
+            </h2>
+            <p class="text-xs text-slate-500 mb-4">
+                Agrégés à partir des scrobbles Last.fm de ce run qui n'ont pas
+                trouvé de morceau correspondant dans Navidrome.
+            </p>
+
+            {% if not lidarr_configured %}
+                <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+                    Configurer <code>LIDARR_URL</code> et <code>LIDARR_API_KEY</code>
+                    pour activer les actions Lidarr.
+                </div>
+            {% elseif not lidarr_reachable %}
+                <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+                    Lidarr injoignable — actions désactivées.
+                </div>
+            {% endif %}
+
+            <div class="overflow-x-auto">
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                    <tr>
+                        <th class="px-3 py-2 w-10">#</th>
+                        <th class="px-3 py-2">Artiste</th>
+                        <th class="px-3 py-2">Scrobbles</th>
+                        <th class="px-3 py-2">Statut Lidarr</th>
+                        <th class="px-3 py-2">Action</th>
+                    </tr>
+                    </thead>
+                    <tbody class="divide-y">
+                    {% for row in unmatched_artists %}
+                        <tr>
+                            <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
+                            <td class="px-3 py-1.5">
+                                <a href="https://www.last.fm/music/{{ row.artist|url_encode }}"
+                                   class="hover:underline" target="_blank" rel="noopener">{{ row.artist }}</a>
+                            </td>
+                            <td class="px-3 py-1.5 text-slate-600">{{ row.scrobbles }}</td>
+                            <td class="px-3 py-1.5">
+                                {% if not lidarr_configured or not lidarr_reachable %}
+                                    <span class="text-xs text-slate-400">—</span>
+                                {% elseif row.lidarr_url %}
+                                    <span class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800">
+                                        ✓ déjà dans Lidarr
+                                    </span>
+                                {% else %}
+                                    <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">
+                                        ✗ absent
+                                    </span>
+                                {% endif %}
+                            </td>
+                            <td class="px-3 py-1.5">
+                                {% if lidarr_configured and lidarr_reachable and row.lidarr_url %}
+                                    <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
+                                       class="text-xs px-2 py-1 rounded bg-sky-600 text-white hover:bg-sky-700">
+                                        Fiche Lidarr
+                                    </a>
+                                {% elseif lidarr_configured and lidarr_reachable %}
+                                    <form method="post" action="{{ path('app_lidarr_add_artist') }}"
+                                          class="inline"
+                                          onsubmit="return confirm('Ajouter « {{ row.artist|e('js') }} » à Lidarr ?');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('lidarr_add') }}">
+                                        <input type="hidden" name="artist" value="{{ row.artist }}">
+                                        <input type="hidden" name="_redirect_run_id" value="{{ entry.id }}">
+                                        <button type="submit"
+                                                class="text-xs px-2 py-1 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                            + Lidarr
+                                        </button>
+                                    </form>
+                                {% else %}
+                                    <button type="button" disabled
+                                            class="text-xs px-2 py-1 rounded bg-slate-200 text-slate-400 cursor-not-allowed">
+                                        + Lidarr
+                                    </button>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
 {% endblock %}

--- a/tests/LastFm/ImportReportTest.php
+++ b/tests/LastFm/ImportReportTest.php
@@ -45,6 +45,43 @@ class ImportReportTest extends TestCase
         $this->assertSame(6, $top3[0]['count']);
     }
 
+    public function testUnmatchedArtistsRankingSumsAcrossTitles(): void
+    {
+        $report = new ImportReport();
+        // Daft Punk: 3 distinct titles, 5 scrobbles total.
+        $report->recordUnmatched($this->scrobble('Daft Punk', 'One More Time'));
+        $report->recordUnmatched($this->scrobble('daft punk', 'one more time'));
+        $report->recordUnmatched($this->scrobble('Daft Punk', 'Around The World'));
+        $report->recordUnmatched($this->scrobble('Daft Punk', 'Harder Better'));
+        $report->recordUnmatched($this->scrobble('Daft Punk', 'Harder Better'));
+        // Aphex Twin: 1 scrobble.
+        $report->recordUnmatched($this->scrobble(' Aphex Twin ', 'Xtal'));
+
+        $ranking = $report->unmatchedArtistsRanking();
+        $this->assertCount(2, $ranking);
+        $this->assertSame('Daft Punk', $ranking[0]['artist']);
+        $this->assertSame(5, $ranking[0]['scrobbles']);
+        $this->assertSame(' Aphex Twin ', $ranking[1]['artist']);
+        $this->assertSame(1, $ranking[1]['scrobbles']);
+    }
+
+    public function testUnmatchedArtistsRankingHonoursLimit(): void
+    {
+        $report = new ImportReport();
+        for ($i = 0; $i < 10; $i++) {
+            $report->recordUnmatched($this->scrobble("Artist $i", "Track $i"));
+        }
+        // Boost Artist 0 so it ranks first regardless of insertion order.
+        for ($j = 0; $j < 4; $j++) {
+            $report->recordUnmatched($this->scrobble('Artist 0', 'Other'));
+        }
+
+        $top3 = $report->unmatchedArtistsRanking(3);
+        $this->assertCount(3, $top3);
+        $this->assertSame('Artist 0', $top3[0]['artist']);
+        $this->assertSame(5, $top3[0]['scrobbles']);
+    }
+
     private function scrobble(string $artist, string $title): LastFmScrobble
     {
         return new LastFmScrobble(

--- a/tests/Lidarr/LidarrClientTest.php
+++ b/tests/Lidarr/LidarrClientTest.php
@@ -99,6 +99,34 @@ class LidarrClientTest extends TestCase
         $this->assertSame('Daft Punk', $result['artistName']);
     }
 
+    public function testIndexExistingArtistsByNormalisedName(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                ['id' => 1, 'foreignArtistId' => 'mb-1', 'artistName' => 'Daft Punk'],
+                ['id' => 2, 'foreignArtistId' => 'mb-2', 'artistName' => '  Aphex Twin '],
+                ['id' => 3, 'noName' => true],
+                ['id' => 4, 'foreignArtistId' => 'mb-4', 'artistName' => ''],
+            ]) ?: '', ['response_headers' => ['content-type: application/json']]),
+        ]);
+
+        $index = (new LidarrClient($http, $this->config()))->indexExistingArtists();
+
+        $this->assertCount(2, $index);
+        $this->assertArrayHasKey('daft punk', $index);
+        $this->assertSame('mb-1', $index['daft punk']['foreignArtistId']);
+        $this->assertSame(1, $index['daft punk']['id']);
+        $this->assertSame('Daft Punk', $index['daft punk']['artistName']);
+        $this->assertArrayHasKey('aphex twin', $index);
+        $this->assertSame('mb-2', $index['aphex twin']['foreignArtistId']);
+    }
+
+    public function testArtistDetailUrl(): void
+    {
+        $url = $this->config(url: 'http://lidarr:8686/')->artistDetailUrl('mb-123');
+        $this->assertSame('http://lidarr:8686/artist/mb-123', $url);
+    }
+
     private function config(string $url = 'http://lidarr:8686', string $apiKey = 'k'): LidarrConfig
     {
         return new LidarrConfig(


### PR DESCRIPTION
Closes #10.

## Résumé

La page `/history/{id}` d'un run `lastfm-import` n'affichait jusqu'ici que les compteurs agrégés (`fetched / inserted / duplicates / unmatched`) et le listing par-track. Le ranking des artistes non matchés vivait uniquement en mémoire dans `ImportReport` pendant l'exécution de l'import et disparaissait ensuite.

Cette PR persiste un top 100 d'artistes non matchés (agrégés, scrobbles sommés tous titres confondus) dans `RunHistory.metrics.unmatched_artists`, et expose sur la page de détail une nouvelle section avec les bonnes actions Lidarr par artiste.

## Changements

### Backend

- **`ImportReport::unmatchedArtistsRanking(?int $limit)`** : nouvelle méthode qui agrège l'aggregat existant par artiste (clé normalisée `mb_strtolower(trim(...))`), trie DESC par scrobbles puis ASC par nom, et applique un éventuel `array_slice`.
- **`ImportLastFmCommand` + `LastFmImportController`** : la closure `extractMetrics` passée à `RunHistoryRecorder::record()` ajoute désormais `unmatched_artists => $r->unmatchedArtistsRanking(100)`. Plafond explicite à 100 pour ne pas gonfler la table `run_history`.
- **`LidarrClient::indexExistingArtists()`** : nouveau lookup `GET /api/v1/artist` qui indexe la library Lidarr par nom normalisé. Appelé une seule fois par rendu de la page → résolution O(1) de tous les unmatched.
- **`LidarrConfig::artistDetailUrl(string $foreignArtistId)`** : helper qui construit `{LIDARR_URL}/artist/{MBID}`.
- **`HistoryController`** : prend désormais `LidarrConfig` + `LidarrClient` en DI. Pour les runs `lastfm-import`, lit `entry.metrics.unmatched_artists` et enrichit chaque ligne avec un `lidarr_url` (ou `null`). Try/catch silencieux autour du lookup Lidarr → si Lidarr est injoignable, la page reste fonctionnelle et un encart d'erreur s'affiche.
- **`LidarrController::addArtist()`** : nouveau champ caché optionnel `_redirect_run_id`. S'il est > 0, redirection vers `app_history_detail` au lieu de `app_lastfm_import` — l'utilisateur revient sur la même page de détail et voit le badge passer au vert au reload.

### UI

Nouvelle section dans `templates/history/detail.html.twig` (gardée par `entry.type == 'lastfm-import' and unmatched_artists is not empty`) avec un tableau cohérent visuellement avec le tableau per-track existant :

- Colonnes : `# | Artiste | Scrobbles | Statut Lidarr | Action`.
- Statut : badge vert `✓ déjà dans Lidarr` ou gris `✗ absent` (ou `—` si Lidarr KO).
- Action : lien `Fiche Lidarr` (target=_blank), bouton `+ Lidarr` (form POST avec CSRF + `_redirect_run_id`), ou bouton désactivé.
- Encart amber si `LIDARR_URL` vide ; encart rose si Lidarr injoignable.

### Tests

- `ImportReportTest::testUnmatchedArtistsRankingSumsAcrossTitles` + `testUnmatchedArtistsRankingHonoursLimit`.
- `LidarrClientTest::testIndexExistingArtistsByNormalisedName` + `testArtistDetailUrl` (couvre `LidarrConfig::artistDetailUrl()` aussi).

`composer ci` vert : phpcs + phpstan + 80 tests / 219 assertions.

### Hors périmètre (rappel issue)

- Backfill rétroactif : les runs créés avant cette PR n'auront pas `unmatched_artists` dans leurs metrics et la section sera simplement vide pour eux.
- Statut de download Lidarr en temps réel : trop complexe, déjà visible côté Lidarr.
- Bouton « + Lidarr » par track : Lidarr ne télécharge pas des tracks unitaires.

## Test plan

- [ ] Lancer `php bin/console app:lastfm:import <user> --dry-run --max-scrobbles=200` et vérifier que `metrics.unmatched_artists` est bien stocké (`sqlite3 var/data.db "select metrics from run_history order by id desc limit 1"`).
- [ ] Naviguer sur `/history/{id}` du run → la nouvelle section liste les artistes.
- [ ] Avec `LIDARR_URL=` vide → encart amber « Configurer LIDARR_URL ».
- [ ] Avec Lidarr configuré + un artiste absent → cliquer « + Lidarr » → ajout effectif, redirection vers `/history/{id}`, flash success.
- [ ] Recharger → l'artiste apparaît avec badge « ✓ déjà dans Lidarr » et lien fiche.
- [ ] Couper Lidarr → recharger → encart rose, pas de 500.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LfbEKp78bkXWzpATGwwoju)_