### PR TITLE
docs(roadmap): add #25 (albums missing MBID listing) to icebox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,10 +26,10 @@ courant** :
 2. **Catégoriser** avec :
    - un label de domaine : `area:lastfm`, `area:playlists`,
      `area:stats`, `area:integrations`, `area:cron`, `area:export` ;
-   - un label d'effort : `size:S` (< 1 jour), `size:M` (1-2 jours),
-     `size:L` (3+ jours) ;
-   - éventuellement `type:bug` / `type:enhancement` /
-     `type:tech-debt`.
+   - un label d'effort : `effort:S` (< 1 jour), `effort:M` (1-2 jours),
+     `effort:L` (3+ jours) ;
+   - éventuellement `bug` / `enhancement` (labels GitHub par défaut,
+     sans préfixe `type:`).
 3. **Mettre à jour [`ROADMAP.md`](ROADMAP.md)** : ajouter la ligne
    dans la table de la section `## Icebox` correspondante, avec la
    référence `[#NN]` en bas du fichier (format déjà en usage).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,12 @@ l'ordre d'attaque recommandé.
 | [#10] | Détail d'un run Last.fm import : actions Lidarr par artiste     | M      |
 | [#23] | Sync bidirectionnelle Last.fm loved ↔ Navidrome starred         | L      |
 
+### Stats / Curation
+
+| #   | Titre                                                              | Effort |
+|-----|--------------------------------------------------------------------|--------|
+| [#25] | Page « métadonnées incomplètes » : albums sans MBID groupés par artiste | M      |
+
 ### Playlists
 
 | #   | Titre                                                              | Effort |
@@ -130,6 +136,7 @@ quand on tagge des releases) :
 [#21]: https://github.com/kgaut/navidrome-playlist-generator/issues/21
 [#22]: https://github.com/kgaut/navidrome-playlist-generator/issues/22
 [#23]: https://github.com/kgaut/navidrome-playlist-generator/issues/23
+[#25]: https://github.com/kgaut/navidrome-playlist-generator/issues/25
 [#26]: https://github.com/kgaut/navidrome-playlist-generator/issues/26
 [#27]: https://github.com/kgaut/navidrome-playlist-generator/issues/27
 [#28]: https://github.com/kgaut/navidrome-playlist-generator/issues/28


### PR DESCRIPTION
Nouvelle section "Stats / Curation" dans l'icebox pour héberger
les pages d'aide à la curation de bibliothèque. Premier item :
une page listant les albums dont le MBID est absent, groupés
par artiste et triés par nombre d'écoutes Navidrome, pour
permettre une correction prioritaire dans un outil externe
(Picard, beets…).

https://claude.ai/code/session_01QBk41pgFgdLdvfCTfWXi94