### PR TITLE
feat(matching): fuzzy Levenshtein + alias manuels Last.fm

### DIFF
--- a/.env
+++ b/.env
@@ -59,4 +59,8 @@ LASTFM_USER=
 # Pause (in seconds) between two consecutive page fetches of the
 # user.getRecentTracks Last.fm API. Default 10. Set to 0 to disable.
 LASTFM_PAGE_DELAY_SECONDS=10
+# Maximum Levenshtein distance for the fuzzy fallback (artist + title).
+# Tried only after MBID / triplet / couple lookups fail. 0 = disabled,
+# 3 = recommended starting point.
+LASTFM_FUZZY_MAX_DISTANCE=0
 ###< Last.fm ###

--- a/.env.dist
+++ b/.env.dist
@@ -57,4 +57,9 @@ LASTFM_USER=
 # Pause (in seconds) between two consecutive page fetches of the
 # user.getRecentTracks Last.fm API. Default 10. Set to 0 to disable.
 LASTFM_PAGE_DELAY_SECONDS=10
+# Maximum Levenshtein distance for the fuzzy fallback (artist + title).
+# Tried only after MBID / triplet / couple lookups fail. 0 = disabled,
+# 3 = recommended starting point. Increase for noisy libs but expect
+# false-positives.
+LASTFM_FUZZY_MAX_DISTANCE=0
 ###< Last.fm ###

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -47,6 +47,8 @@ services:
         # Pause (in seconds) between two consecutive Last.fm API page
         # fetches. Default 10, set to 0 to disable.
         LASTFM_PAGE_DELAY_SECONDS: '10'
+        # Maximum Levenshtein distance for the fuzzy fallback. 0 = disabled.
+        LASTFM_FUZZY_MAX_DISTANCE: '0'
 
   cron:
     type: php:8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Matching Last.fm : table d'**alias manuels** Last.fm → media_file
+  Navidrome (`lastfm_alias`). Consultée en priorité absolue avant
+  toutes les heuristiques (MBID, triplet, couple, fuzzy). Une cible
+  vide signifie « ignorer ce scrobble silencieusement » (compté en
+  `skipped` plutôt qu'en `unmatched`, utile pour les podcasts ou le
+  bruit). Page CRUD `/lastfm/aliases` (liste paginée + recherche +
+  formulaire). Bouton « ✏️ Mapper » à côté de chaque scrobble non
+  matché sur `/history/{id}` qui pré-remplit le formulaire.
+  Lookup case/accent/ponctuation-insensitive via la même
+  normalisation que `findMediaFileByArtistTitle()`. Closes #18.
 - Matching Last.fm : fallback **fuzzy Levenshtein** sur (artist,
   title) en dernier recours, après les paliers MBID / triplet /
   couple. Pré-filtre les candidats sur le préfixe 3 chars (artist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Matching Last.fm : fallback **fuzzy Levenshtein** sur (artist,
+  title) en dernier recours, après les paliers MBID / triplet /
+  couple. Pré-filtre les candidats sur le préfixe 3 chars (artist
+  ou title) pour éviter de scanner toute la lib. Opt-in via la
+  nouvelle env var `LASTFM_FUZZY_MAX_DISTANCE` (défaut `0` =
+  désactivé, `3` = seuil raisonnable). Permet de matcher
+  `Hozier / Take Me to Chruch` ↔ `Hozier / Take Me to Church`,
+  `Tchaïkovski` ↔ `Tchaikovsky`, etc. Closes #16.
 - Matching Last.fm : désambiguation par triplet
   `(artist, title, album)`. Nouvelle méthode
   `NavidromeRepository::findMediaFileByArtistTitleAlbum()` qui

--- a/README.md
+++ b/README.md
@@ -322,9 +322,26 @@ la variable d'environnement `LASTFM_API_KEY`. De même, le username peut
    (`LASTFM_PAGE_DELAY_SECONDS`, défaut 10s) sépare deux pages
    consécutives pour éviter de surcharger l'API ; passez à 0 pour
    désactiver.
-2. **Matching** sur la lib Navidrome :
-   - d'abord par MusicBrainz ID si Last.fm le fournit ;
-   - sinon par couple `(artist, title)` normalisé (lowercase + trim).
+2. **Matching** sur la lib Navidrome (essais successifs jusqu'à
+   succès) :
+   1. **MusicBrainz ID** si Last.fm le fournit (le plus fiable) ;
+   2. **Triplet** `(artist, title, album)` normalisé — départage les
+      morceaux qui existent sur plusieurs albums (single + version
+      album + compilation) ;
+   3. **Couple** `(artist, title)` normalisé, avec tie-break
+      `album_artist = artist` puis `id ASC` ;
+   4. **Fallback fuzzy** Levenshtein artist+title (opt-in via
+      `LASTFM_FUZZY_MAX_DISTANCE`, défaut 0 = désactivé, 3 = seuil
+      raisonnable). Coûteux : ne s'active que sur les scrobbles qui
+      ont échoué aux 3 paliers précédents.
+
+   La normalisation utilisée à toutes les étapes : lowercase + trim
+   + décomposition Unicode NFKD + strip des diacritiques (Beyoncé ↔
+   Beyonce) + strip de la ponctuation (AC/DC ↔ ACDC) + collapse des
+   espaces. Les helpers `stripFeaturedArtists()` /
+   `stripFeaturingFromTitle()` / `stripVersionMarkers()` retirent en
+   plus les suffixes parasites côté Last.fm (`feat. X`, `(Radio
+   Edit)`, `- Remastered 2011`, `(Live at …)`, `(Acoustic)`, etc.).
 3. **Déduplication** : un scrobble n'est pas réinséré s'il existe déjà
    dans la table `scrobbles` une ligne avec le même `media_file_id` et
    un `submission_time` à ±`--tolerance` secondes (60 par défaut). Cela

--- a/README.md
+++ b/README.md
@@ -324,6 +324,10 @@ la variable d'environnement `LASTFM_API_KEY`. De même, le username peut
    désactiver.
 2. **Matching** sur la lib Navidrome (essais successifs jusqu'à
    succès) :
+   0. **Alias manuel** : si une entrée existe dans la table
+      `lastfm_alias` (page `/lastfm/aliases`) pour le couple
+      `(artist, title)` normalisé, elle court-circuite tout. Cible
+      vide = scrobble compté en `skipped` (utile pour les podcasts).
    1. **MusicBrainz ID** si Last.fm le fournit (le plus fiable) ;
    2. **Triplet** `(artist, title, album)` normalisé — départage les
       morceaux qui existent sur plusieurs albums (single + version

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -30,9 +30,7 @@ l'ordre d'attaque recommandé.
 |-----|--------------------------------------------------------------------|--------|
 | [#20] | Cache de résolution (positif + négatif)                         | S      |
 | [#22] | Profil strict / default / lax configurable                      | S      |
-| [#16] | Fuzzy match Levenshtein avec seuil                              | M      |
 | [#17] | MBID manquant via `track.getInfo` / `track.getCorrection`       | M      |
-| [#18] | Table d'alias manuels Last.fm → media_file                      | M      |
 | [#21] | Re-tenter les unmatched cumulés sans re-télécharger l'historique | M      |
 | [#19] | Suggestions automatiques + apprentissage par confirmation       | L      |
 
@@ -120,9 +118,7 @@ quand on tagge des releases) :
 [#9]: https://github.com/kgaut/navidrome-playlist-generator/issues/9
 [#10]: https://github.com/kgaut/navidrome-playlist-generator/issues/10
 [#11]: https://github.com/kgaut/navidrome-playlist-generator/issues/11
-[#16]: https://github.com/kgaut/navidrome-playlist-generator/issues/16
 [#17]: https://github.com/kgaut/navidrome-playlist-generator/issues/17
-[#18]: https://github.com/kgaut/navidrome-playlist-generator/issues/18
 [#19]: https://github.com/kgaut/navidrome-playlist-generator/issues/19
 [#20]: https://github.com/kgaut/navidrome-playlist-generator/issues/20
 [#21]: https://github.com/kgaut/navidrome-playlist-generator/issues/21

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,6 @@ l'ordre d'attaque recommandé.
 |-----|--------------------------------------------------------------------|--------|
 | [#3]  | Sync incrémentale Last.fm → Navidrome                           | M      |
 | [#4]  | Page permanente : diff Last.fm vs lib Navidrome                 | M      |
-| [#10] | Détail d'un run Last.fm import : actions Lidarr par artiste     | M      |
 | [#23] | Sync bidirectionnelle Last.fm loved ↔ Navidrome starred         | L      |
 
 ### Stats / Curation
@@ -116,7 +115,6 @@ quand on tagge des releases) :
 [#7]: https://github.com/kgaut/navidrome-playlist-generator/issues/7
 [#8]: https://github.com/kgaut/navidrome-playlist-generator/issues/8
 [#9]: https://github.com/kgaut/navidrome-playlist-generator/issues/9
-[#10]: https://github.com/kgaut/navidrome-playlist-generator/issues/10
 [#11]: https://github.com/kgaut/navidrome-playlist-generator/issues/11
 [#17]: https://github.com/kgaut/navidrome-playlist-generator/issues/17
 [#19]: https://github.com/kgaut/navidrome-playlist-generator/issues/19

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ parameters:
     app.stats_refresh_schedule: '%env(STATS_REFRESH_SCHEDULE)%'
     app.run_history_retention_days: '%env(int:RUN_HISTORY_RETENTION_DAYS)%'
     lastfm.page_delay_seconds: '%env(int:LASTFM_PAGE_DELAY_SECONDS)%'
+    lastfm.fuzzy_max_distance: '%env(int:LASTFM_FUZZY_MAX_DISTANCE)%'
     lidarr.url: '%env(LIDARR_URL)%'
     lidarr.api_key: '%env(LIDARR_API_KEY)%'
     lidarr.root_folder_path: '%env(LIDARR_ROOT_FOLDER_PATH)%'
@@ -82,3 +83,7 @@ services:
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'
+
+    App\LastFm\LastFmImporter:
+        arguments:
+            $fuzzyMaxDistance: '%lastfm.fuzzy_max_distance%'

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -27,6 +27,7 @@ services:
       LASTFM_API_KEY: ${LASTFM_API_KEY:-}
       LASTFM_USER: ${LASTFM_USER:-}
       LASTFM_PAGE_DELAY_SECONDS: ${LASTFM_PAGE_DELAY_SECONDS:-10}
+      LASTFM_FUZZY_MAX_DISTANCE: ${LASTFM_FUZZY_MAX_DISTANCE:-0}
     volumes:
       # Mount Navidrome's SQLite DB read-only.
       - ${NAVIDROME_DATA_DIR:-/srv/navidrome/data}/navidrome.db:/data/navidrome.db:ro
@@ -59,6 +60,7 @@ services:
       LASTFM_API_KEY: ${LASTFM_API_KEY:-}
       LASTFM_USER: ${LASTFM_USER:-}
       LASTFM_PAGE_DELAY_SECONDS: ${LASTFM_PAGE_DELAY_SECONDS:-10}
+      LASTFM_FUZZY_MAX_DISTANCE: ${LASTFM_FUZZY_MAX_DISTANCE:-0}
     volumes:
       - ${NAVIDROME_DATA_DIR:-/srv/navidrome/data}/navidrome.db:/data/navidrome.db:ro
       - navidrome-tools-data:/app/var

--- a/migrations/Version20260502000000.php
+++ b/migrations/Version20260502000000.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260502000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add lastfm_alias table for manual Last.fm → media_file mappings.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE lastfm_alias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                source_artist VARCHAR(255) NOT NULL,
+                source_title VARCHAR(255) NOT NULL,
+                source_artist_norm VARCHAR(255) NOT NULL,
+                source_title_norm VARCHAR(255) NOT NULL,
+                target_media_file_id VARCHAR(255) DEFAULT NULL,
+                created_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_lastfm_alias_source_norm ON lastfm_alias (source_artist_norm, source_title_norm)');
+        $this->addSql('CREATE INDEX idx_lastfm_alias_source_norm ON lastfm_alias (source_artist_norm, source_title_norm)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE lastfm_alias');
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,6 +29,7 @@
         <env name="LASTFM_API_KEY" value=""/>
         <env name="LASTFM_USER" value=""/>
         <env name="LASTFM_PAGE_DELAY_SECONDS" value="0"/>
+        <env name="LASTFM_FUZZY_MAX_DISTANCE" value="0"/>
     </php>
 
     <testsuites>

--- a/src/Command/ImportLastFmCommand.php
+++ b/src/Command/ImportLastFmCommand.php
@@ -132,6 +132,8 @@ class ImportLastFmCommand extends Command
                     toleranceSeconds: $tolerance,
                     dryRun: $dryRun,
                     progress: function (int $f, int $i, int $d, int $u) use ($io): void {
+                        // Progress signature is fixed (4 ints) — skipped is shown
+                        // only in the final summary.
                         $io->writeln(sprintf(
                             '  fetched=%d  inserted=%d  duplicates=%d  unmatched=%d',
                             $f,
@@ -159,6 +161,7 @@ class ImportLastFmCommand extends Command
                     'inserted' => $r->inserted,
                     'duplicates' => $r->duplicates,
                     'unmatched' => $r->unmatched,
+                    'skipped' => $r->skipped,
                     'unmatched_artists' => $r->unmatchedArtistsRanking(100),
                     'dry_run' => $dryRun,
                     'date_min' => $dateMin?->format('Y-m-d'),
@@ -173,12 +176,13 @@ class ImportLastFmCommand extends Command
 
         $io->newLine();
         $io->success(sprintf(
-            '%s done. fetched=%d inserted=%d duplicates=%d unmatched=%d',
+            '%s done. fetched=%d inserted=%d duplicates=%d unmatched=%d skipped=%d',
             $dryRun ? 'Dry-run' : 'Import',
             $report->fetched,
             $report->inserted,
             $report->duplicates,
             $report->unmatched,
+            $report->skipped,
         ));
 
         $this->renderUnmatched($io, $report, (string) $input->getOption('show-unmatched'));

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -80,7 +80,7 @@ class HistoryController extends AbstractController
                 ? (string) $request->query->get('status')
                 : $defaultStatus;
 
-            if (!in_array($statusFilter, ['', LastFmImportTrack::STATUS_INSERTED, LastFmImportTrack::STATUS_DUPLICATE, LastFmImportTrack::STATUS_UNMATCHED], true)) {
+            if (!in_array($statusFilter, ['', LastFmImportTrack::STATUS_INSERTED, LastFmImportTrack::STATUS_DUPLICATE, LastFmImportTrack::STATUS_UNMATCHED, LastFmImportTrack::STATUS_SKIPPED], true)) {
                 $statusFilter = '';
             }
 
@@ -108,6 +108,7 @@ class HistoryController extends AbstractController
                 LastFmImportTrack::STATUS_INSERTED => 'Insérés',
                 LastFmImportTrack::STATUS_DUPLICATE => 'Doublons',
                 LastFmImportTrack::STATUS_UNMATCHED => 'Non matchés',
+                LastFmImportTrack::STATUS_SKIPPED => 'Ignorés',
             ],
             'unmatched_artists' => $unmatchedArtists,
             'lidarr_configured' => $this->lidarrConfig->isConfigured(),

--- a/src/Controller/LastFmAliasController.php
+++ b/src/Controller/LastFmAliasController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\LastFmAlias;
+use App\Form\LastFmAliasType;
+use App\Repository\LastFmAliasRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmAliasController extends AbstractController
+{
+    private const PER_PAGE = 25;
+
+    #[Route('/lastfm/aliases', name: 'app_lastfm_alias_index', methods: ['GET'])]
+    public function index(Request $request, LastFmAliasRepository $repo): Response
+    {
+        $query = trim((string) $request->query->get('q', ''));
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $aliases = $repo->search($query, $page, self::PER_PAGE);
+        $total = $repo->countSearch($query);
+        $totalPages = (int) max(1, ceil($total / self::PER_PAGE));
+
+        return $this->render('lastfm/aliases/index.html.twig', [
+            'aliases' => $aliases,
+            'total' => $total,
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => ['q' => $query],
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/new', name: 'app_lastfm_alias_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, LastFmAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $form = $this->createForm(LastFmAliasType::class, null, [
+            'alias' => null,
+        ]);
+
+        // Pre-fill from query string when coming from a "Mapper" button.
+        if ($request->isMethod('GET')) {
+            $prefillArtist = (string) $request->query->get('source_artist', '');
+            $prefillTitle = (string) $request->query->get('source_title', '');
+            if ($prefillArtist !== '') {
+                $form->get('source_artist')->setData($prefillArtist);
+            }
+            if ($prefillTitle !== '') {
+                $form->get('source_title')->setData($prefillTitle);
+            }
+        }
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $sourceTitle = (string) $form->get('source_title')->getData();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = $skip ? null : trim((string) $form->get('target_media_file_id')->getData());
+
+            $existing = $repo->findByScrobble($sourceArtist, $sourceTitle);
+            if ($existing !== null) {
+                $this->addFlash('error', sprintf(
+                    'Un alias existe déjà pour « %s — %s ». Modifiez-le au lieu d\'en créer un nouveau.',
+                    $sourceArtist,
+                    $sourceTitle,
+                ));
+
+                return $this->redirectToRoute('app_lastfm_alias_edit', ['id' => $existing->getId()]);
+            }
+
+            $alias = new LastFmAlias($sourceArtist, $sourceTitle, $target);
+            try {
+                $em->persist($alias);
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un alias normalisé identique existe déjà — modifiez-le.');
+
+                return $this->redirectToRoute('app_lastfm_alias_index', ['q' => $sourceArtist]);
+            }
+
+            $this->addFlash('success', sprintf(
+                'Alias créé : « %s — %s » → %s.',
+                $sourceArtist,
+                $sourceTitle,
+                $skip ? 'IGNORÉ' : ($target ?? ''),
+            ));
+
+            return $this->redirectToRoute('app_lastfm_alias_index');
+        }
+
+        return $this->render('lastfm/aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => null,
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/{id}/edit', name: 'app_lastfm_alias_edit', methods: ['GET', 'POST'])]
+    public function edit(int $id, Request $request, LastFmAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        $form = $this->createForm(LastFmAliasType::class, null, [
+            'alias' => $alias,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $sourceTitle = (string) $form->get('source_title')->getData();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = $skip ? null : trim((string) $form->get('target_media_file_id')->getData());
+
+            $alias->setSource($sourceArtist, $sourceTitle);
+            $alias->setTargetMediaFileId($target);
+
+            try {
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un autre alias couvre déjà cette paire normalisée.');
+
+                return $this->redirectToRoute('app_lastfm_alias_index');
+            }
+
+            $this->addFlash('success', sprintf('Alias « %s — %s » mis à jour.', $sourceArtist, $sourceTitle));
+
+            return $this->redirectToRoute('app_lastfm_alias_index');
+        }
+
+        return $this->render('lastfm/aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/{id}/delete', name: 'app_lastfm_alias_delete', methods: ['POST'])]
+    public function delete(int $id, Request $request, LastFmAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        if (!$this->isCsrfTokenValid('delete-alias-' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $label = sprintf('%s — %s', $alias->getSourceArtist(), $alias->getSourceTitle());
+        $em->remove($alias);
+        $em->flush();
+        $this->addFlash('success', sprintf('Alias « %s » supprimé.', $label));
+
+        return $this->redirectToRoute('app_lastfm_alias_index');
+    }
+}

--- a/src/Controller/LastFmImportController.php
+++ b/src/Controller/LastFmImportController.php
@@ -94,6 +94,7 @@ class LastFmImportController extends AbstractController
                             'inserted' => $r->inserted,
                             'duplicates' => $r->duplicates,
                             'unmatched' => $r->unmatched,
+                            'skipped' => $r->skipped,
                             'unmatched_artists' => $r->unmatchedArtistsRanking(100),
                             'dry_run' => $isDry,
                             'date_min' => $dateMin?->format('Y-m-d'),

--- a/src/Entity/LastFmAlias.php
+++ b/src/Entity/LastFmAlias.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Entity;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmAliasRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Manual mapping from a Last.fm (artist, title) couple to a Navidrome
+ * media_file id. Resolved before any heuristic during import. Setting
+ * `targetMediaFileId` to null means « ignore scrobbles matching this
+ * couple » (useful for podcasts or noise).
+ *
+ * `sourceArtistNorm` / `sourceTitleNorm` mirror the raw fields run
+ * through {@see NavidromeRepository::normalize()} and are unique
+ * together — looked up by the importer for an O(1) match.
+ */
+#[ORM\Entity(repositoryClass: LastFmAliasRepository::class)]
+#[ORM\Table(name: 'lastfm_alias')]
+#[ORM\UniqueConstraint(name: 'uniq_lastfm_alias_source_norm', columns: ['source_artist_norm', 'source_title_norm'])]
+#[ORM\Index(columns: ['source_artist_norm', 'source_title_norm'], name: 'idx_lastfm_alias_source_norm')]
+class LastFmAlias
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtist;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitle;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtistNorm;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitleNorm;
+
+    /**
+     * Navidrome media_file id. Null means « skip scrobbles matching
+     * (sourceArtist, sourceTitle) » — they will be counted as `skipped`
+     * in the import report instead of `unmatched`.
+     */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $targetMediaFileId = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(string $sourceArtist, string $sourceTitle, ?string $targetMediaFileId)
+    {
+        $this->setSource($sourceArtist, $sourceTitle);
+        $this->targetMediaFileId = $targetMediaFileId !== null && $targetMediaFileId !== '' ? $targetMediaFileId : null;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function setSource(string $sourceArtist, string $sourceTitle): void
+    {
+        $this->sourceArtist = trim($sourceArtist);
+        $this->sourceTitle = trim($sourceTitle);
+        $this->sourceArtistNorm = NavidromeRepository::normalize($sourceArtist);
+        $this->sourceTitleNorm = NavidromeRepository::normalize($sourceTitle);
+    }
+
+    public function setTargetMediaFileId(?string $id): void
+    {
+        $this->targetMediaFileId = $id !== null && $id !== '' ? $id : null;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSourceArtist(): string
+    {
+        return $this->sourceArtist;
+    }
+
+    public function getSourceTitle(): string
+    {
+        return $this->sourceTitle;
+    }
+
+    public function getSourceArtistNorm(): string
+    {
+        return $this->sourceArtistNorm;
+    }
+
+    public function getSourceTitleNorm(): string
+    {
+        return $this->sourceTitleNorm;
+    }
+
+    public function getTargetMediaFileId(): ?string
+    {
+        return $this->targetMediaFileId;
+    }
+
+    public function isSkip(): bool
+    {
+        return $this->targetMediaFileId === null;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Entity/LastFmImportTrack.php
+++ b/src/Entity/LastFmImportTrack.php
@@ -21,6 +21,7 @@ class LastFmImportTrack
     public const STATUS_INSERTED = 'inserted';
     public const STATUS_DUPLICATE = 'duplicate';
     public const STATUS_UNMATCHED = 'unmatched';
+    public const STATUS_SKIPPED = 'skipped';
 
     #[ORM\Id]
     #[ORM\GeneratedValue]

--- a/src/Form/LastFmAliasType.php
+++ b/src/Form/LastFmAliasType.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\LastFmAlias;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @extends AbstractType<LastFmAlias|null>
+ */
+class LastFmAliasType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var LastFmAlias|null $alias */
+        $alias = $options['alias'];
+        $isSkip = $alias !== null && $alias->isSkip();
+
+        $builder
+            ->add('source_artist', TextType::class, [
+                'label' => 'Artiste (Last.fm)',
+                'help' => 'Tel qu\'écrit par Last.fm. Comparé sans accents / casse / ponctuation.',
+                'data' => $alias?->getSourceArtist() ?? '',
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('source_title', TextType::class, [
+                'label' => 'Titre (Last.fm)',
+                'data' => $alias?->getSourceTitle() ?? '',
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('skip', CheckboxType::class, [
+                'label' => 'Ignorer ce scrobble (au lieu de le mapper)',
+                'help' => 'Cochez pour que ces scrobbles soient comptés en « Ignorés » plutôt qu\'écrits dans la lib (utile pour les podcasts ou le bruit).',
+                'required' => false,
+                'data' => $isSkip,
+            ])
+            ->add('target_media_file_id', TextType::class, [
+                'label' => 'ID du media_file Navidrome',
+                'help' => 'Cherchez le morceau dans Navidrome ; l\'ID figure dans l\'URL (ex. /app/#/track/abc-123-def → abc-123-def). Laissez vide si vous cochez « Ignorer ».',
+                'data' => $alias !== null && !$alias->isSkip() ? $alias->getTargetMediaFileId() : '',
+                'required' => false,
+            ]);
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $form = $event->getForm();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = trim((string) $form->get('target_media_file_id')->getData());
+            if (!$skip && $target === '') {
+                $form->get('target_media_file_id')->addError(
+                    new FormError('Renseignez un ID de media_file ou cochez « Ignorer ce scrobble ».'),
+                );
+            }
+            if ($skip && $target !== '') {
+                $form->get('target_media_file_id')->addError(
+                    new FormError('Décochez « Ignorer » pour mapper vers un media_file.'),
+                );
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'alias' => null,
+        ]);
+        $resolver->setAllowedTypes('alias', [LastFmAlias::class, 'null']);
+    }
+}

--- a/src/LastFm/ImportReport.php
+++ b/src/LastFm/ImportReport.php
@@ -8,6 +8,7 @@ class ImportReport
     public int $inserted = 0;
     public int $duplicates = 0;
     public int $unmatched = 0;
+    public int $skipped = 0;
 
     /** @var array<string, array{artist: string, title: string, album: string, count: int}> */
     private array $unmatchedAggregate = [];

--- a/src/LastFm/LastFmImporter.php
+++ b/src/LastFm/LastFmImporter.php
@@ -3,6 +3,7 @@
 namespace App\LastFm;
 
 use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmAliasRepository;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -15,6 +16,7 @@ class LastFmImporter
         private readonly NavidromeRepository $navidrome,
         ?LoggerInterface $logger = null,
         private readonly int $fuzzyMaxDistance = 0,
+        private readonly ?LastFmAliasRepository $aliasRepository = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
@@ -54,24 +56,38 @@ class LastFmImporter
             $report->fetched++;
 
             $mediaFileId = null;
-            if ($scrobble->mbid !== null) {
+            $status = null;
+
+            // Manual alias overrides every heuristic. A `null` target means
+            // « ignore this scrobble silently » (skipped status).
+            $alias = $this->aliasRepository?->findByScrobble($scrobble->artist, $scrobble->title);
+            if ($alias !== null) {
+                if ($alias->isSkip()) {
+                    $report->skipped++;
+                    $status = 'skipped';
+                } else {
+                    $mediaFileId = $alias->getTargetMediaFileId();
+                }
+            }
+
+            if ($status === null && $mediaFileId === null && $scrobble->mbid !== null) {
                 $mediaFileId = $this->navidrome->findMediaFileByMbid($scrobble->mbid);
             }
             // Try the artist+title+album triplet before the bare couple — the
             // same song can live on a studio album AND a compilation AND a
             // single, and the album disambiguates which row the user played.
-            if ($mediaFileId === null && $scrobble->album !== '') {
+            if ($status === null && $mediaFileId === null && $scrobble->album !== '') {
                 $mediaFileId = $this->navidrome->findMediaFileByArtistTitleAlbum(
                     $scrobble->artist,
                     $scrobble->title,
                     $scrobble->album,
                 );
             }
-            if ($mediaFileId === null) {
+            if ($status === null && $mediaFileId === null) {
                 $mediaFileId = $this->navidrome->findMediaFileByArtistTitle($scrobble->artist, $scrobble->title);
             }
             // Last resort: fuzzy Levenshtein, opt-in via LASTFM_FUZZY_MAX_DISTANCE.
-            if ($mediaFileId === null && $this->fuzzyMaxDistance > 0) {
+            if ($status === null && $mediaFileId === null && $this->fuzzyMaxDistance > 0) {
                 $mediaFileId = $this->navidrome->findMediaFileFuzzy(
                     $scrobble->artist,
                     $scrobble->title,
@@ -79,7 +95,13 @@ class LastFmImporter
                 );
             }
 
-            if ($mediaFileId === null) {
+            if ($status === 'skipped') {
+                // Explicit skip via alias → no DB write, no unmatched report.
+                $this->logger->debug('Skipped scrobble (alias): {artist} — {title}', [
+                    'artist' => $scrobble->artist,
+                    'title' => $scrobble->title,
+                ]);
+            } elseif ($mediaFileId === null) {
                 $report->recordUnmatched($scrobble);
                 $this->logger->debug('Unmatched scrobble: {artist} — {title}', [
                     'artist' => $scrobble->artist,

--- a/src/LastFm/LastFmImporter.php
+++ b/src/LastFm/LastFmImporter.php
@@ -14,6 +14,7 @@ class LastFmImporter
         private readonly LastFmClient $client,
         private readonly NavidromeRepository $navidrome,
         ?LoggerInterface $logger = null,
+        private readonly int $fuzzyMaxDistance = 0,
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
@@ -68,6 +69,14 @@ class LastFmImporter
             }
             if ($mediaFileId === null) {
                 $mediaFileId = $this->navidrome->findMediaFileByArtistTitle($scrobble->artist, $scrobble->title);
+            }
+            // Last resort: fuzzy Levenshtein, opt-in via LASTFM_FUZZY_MAX_DISTANCE.
+            if ($mediaFileId === null && $this->fuzzyMaxDistance > 0) {
+                $mediaFileId = $this->navidrome->findMediaFileFuzzy(
+                    $scrobble->artist,
+                    $scrobble->title,
+                    $this->fuzzyMaxDistance,
+                );
             }
 
             if ($mediaFileId === null) {

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -951,6 +951,64 @@ class NavidromeRepository
      * "Bicycle Race - Remastered 2011" while Navidrome stores the bare form.
      */
     /**
+     * Last-resort fuzzy match by Levenshtein distance on (artist, title).
+     * Pulls candidate rows whose normalized artist or title shares the same
+     * 3-char prefix to avoid scanning the whole library, then picks the row
+     * with the smallest combined edit distance under $maxDistance.
+     *
+     * Off when $maxDistance <= 0 (returns null without querying). Returns
+     * null when no candidate is within range.
+     */
+    public function findMediaFileFuzzy(string $artist, string $title, int $maxDistance): ?string
+    {
+        if ($maxDistance <= 0) {
+            return null;
+        }
+
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        // PHP's levenshtein() is capped at 255 chars; bail out on longer
+        // strings rather than crash. (Real-world artist/title rarely exceed
+        // 100 chars; this is a safety net.)
+        if ($artistN === '' || $titleN === '' || strlen($artistN) > 255 || strlen($titleN) > 255) {
+            return null;
+        }
+
+        $artistPrefix = mb_substr($artistN, 0, 3);
+        $titlePrefix = mb_substr($titleN, 0, 3);
+        if ($artistPrefix === '' && $titlePrefix === '') {
+            return null;
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT id, artist, title FROM media_file
+             WHERE substr(np_normalize(artist), 1, 3) = :ap
+                OR substr(np_normalize(title), 1, 3) = :tp',
+            ['ap' => $artistPrefix, 'tp' => $titlePrefix],
+        );
+
+        $bestId = null;
+        $bestScore = PHP_INT_MAX;
+        foreach ($rows as $row) {
+            $candArtist = self::normalize((string) ($row['artist'] ?? ''));
+            $candTitle = self::normalize((string) ($row['title'] ?? ''));
+            if (
+                $candArtist === '' || $candTitle === ''
+                || strlen($candArtist) > 255 || strlen($candTitle) > 255
+            ) {
+                continue;
+            }
+            $score = levenshtein($candArtist, $artistN) + levenshtein($candTitle, $titleN);
+            if ($score <= $maxDistance && $score < $bestScore) {
+                $bestId = (string) $row['id'];
+                $bestScore = $score;
+            }
+        }
+
+        return $bestId;
+    }
+
+    /**
      * Disambiguate a (artist, title) lookup with the album. Used as a
      * tighter pre-step to {@see findMediaFileByArtistTitle()} when the
      * scrobble carries a non-empty album: the same song can be present on

--- a/src/Repository/LastFmAliasRepository.php
+++ b/src/Repository/LastFmAliasRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LastFmAlias;
+use App\Navidrome\NavidromeRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LastFmAlias>
+ */
+class LastFmAliasRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LastFmAlias::class);
+    }
+
+    /**
+     * Look up an alias for a Last.fm scrobble. Both inputs are normalized
+     * with {@see NavidromeRepository::normalize()} so the lookup is
+     * accent/case/punctuation-insensitive.
+     */
+    public function findByScrobble(string $artist, string $title): ?LastFmAlias
+    {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
+        if ($artistNorm === '' || $titleNorm === '') {
+            return null;
+        }
+
+        return $this->findOneBy([
+            'sourceArtistNorm' => $artistNorm,
+            'sourceTitleNorm' => $titleNorm,
+        ]);
+    }
+
+    /**
+     * Paginated search by raw substring on either source field. Used by
+     * the alias admin page.
+     *
+     * @return list<LastFmAlias>
+     */
+    public function search(string $query, int $page, int $perPage): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->orderBy('a.createdAt', 'DESC')
+            ->setFirstResult(max(0, ($page - 1) * $perPage))
+            ->setMaxResults($perPage);
+
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.sourceTitle) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        /** @var list<LastFmAlias> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    public function countSearch(string $query): int
+    {
+        $qb = $this->createQueryBuilder('a')->select('COUNT(a.id)');
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.sourceTitle) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -46,7 +46,18 @@
                         </div>
                     </div>
 
-                    <a href="{{ path('app_lastfm_import') }}" class="hover:underline">Import Last.fm</a>
+                    {# Last.fm dropdown — import + alias mappings #}
+                    <div class="relative group">
+                        <button type="button"
+                                class="hover:underline flex items-center gap-1 cursor-pointer"
+                                aria-haspopup="true">
+                            Last.fm <span class="text-xs">▾</span>
+                        </button>
+                        <div class="absolute right-0 top-full mt-1 w-44 bg-slate-800 text-slate-100 rounded shadow-lg invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition py-1 z-30">
+                            <a href="{{ path('app_lastfm_import') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Import</a>
+                            <a href="{{ path('app_lastfm_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias</a>
+                        </div>
+                    </div>
                     <a href="{{ path('app_history') }}" class="hover:underline">Historique</a>
                     <a href="{{ path('app_settings') }}" class="hover:underline">Réglages</a>
                     <span class="text-slate-400">{{ app.user.userIdentifier }}</span>

--- a/templates/history/detail.html.twig
+++ b/templates/history/detail.html.twig
@@ -91,12 +91,14 @@
                             <th class="px-3 py-2">Artiste</th>
                             <th class="px-3 py-2">Album</th>
                             <th class="px-3 py-2">MBID</th>
+                            <th class="px-3 py-2"></th>
                         </tr>
                         </thead>
                         <tbody class="divide-y">
                         {% for t in tracks %}
                             {% set badge = t.status == 'inserted' ? 'bg-emerald-100 text-emerald-800'
                                 : t.status == 'duplicate' ? 'bg-slate-200 text-slate-700'
+                                : t.status == 'skipped' ? 'bg-sky-100 text-sky-800'
                                 : 'bg-amber-100 text-amber-800' %}
                             <tr>
                                 <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
@@ -117,6 +119,13 @@
                                 <td class="px-3 py-1.5 text-slate-500">{{ t.album ?? '—' }}</td>
                                 <td class="px-3 py-1.5 text-xs text-slate-400">
                                     {{ t.mbid ? t.mbid|slice(0, 8) ~ '…' : '—' }}
+                                </td>
+                                <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                                    {% if t.status == 'unmatched' %}
+                                        <a href="{{ path('app_lastfm_alias_new', {source_artist: t.artist, source_title: t.title}) }}"
+                                           class="text-xs px-2 py-0.5 rounded bg-slate-700 text-white hover:bg-slate-800"
+                                           title="Créer un alias manuel pour ce scrobble">✏️ Mapper</a>
+                                    {% endif %}
                                 </td>
                             </tr>
                         {% endfor %}

--- a/templates/lastfm/aliases/form.html.twig
+++ b/templates/lastfm/aliases/form.html.twig
@@ -1,0 +1,61 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ alias ? 'Modifier alias' : 'Nouvel alias' }} Last.fm{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-sky-700 hover:underline">
+            ← Retour à la liste des alias
+        </a>
+    </div>
+
+    <h1 class="text-2xl font-semibold mb-2">
+        {{ alias ? 'Modifier l\'alias' : 'Nouvel alias Last.fm → Navidrome' }}
+    </h1>
+    <p class="text-sm text-slate-500 mb-6">
+        Forcez la résolution d'une paire (artiste, titre) Last.fm vers un media_file Navidrome
+        spécifique. Consulté avant toutes les heuristiques de matching.
+    </p>
+
+    <div class="bg-white shadow rounded p-6 max-w-2xl">
+        {{ form_start(form) }}
+            <div class="space-y-4">
+                <div>
+                    {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
+                    {{ form_errors(form.source_artist) }}
+                </div>
+                <div>
+                    {{ form_label(form.source_title, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_title, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    {{ form_errors(form.source_title) }}
+                </div>
+
+                <div class="border-t pt-4">
+                    <label class="flex items-center gap-2 text-sm">
+                        {{ form_widget(form.skip, {attr: {class: 'h-4 w-4'}}) }}
+                        <span>{{ form.skip.vars.label }}</span>
+                    </label>
+                    <p class="text-xs text-slate-500 mt-1 ml-6">{{ form_help(form.skip) }}</p>
+                </div>
+
+                <div>
+                    {{ form_label(form.target_media_file_id, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.target_media_file_id, {attr: {class: 'w-full border rounded px-2 py-1 text-sm font-mono'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_media_file_id) }}</p>
+                    {{ form_errors(form.target_media_file_id) }}
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3 mt-6">
+                <button type="submit" class="px-4 py-2 rounded bg-slate-900 text-white text-sm">
+                    {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias' }}
+                </button>
+                <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-slate-500 hover:underline">
+                    Annuler
+                </a>
+            </div>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/lastfm/aliases/index.html.twig
+++ b/templates/lastfm/aliases/index.html.twig
@@ -1,0 +1,91 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Alias Last.fm{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Alias Last.fm → Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ total|number_format(0, '.', ' ') }} alias définis. Consultés en priorité avant toutes les heuristiques de matching.
+            </p>
+        </div>
+        <a href="{{ path('app_lastfm_alias_new') }}"
+           class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">+ Nouvel alias</a>
+    </div>
+
+    <form method="get" class="bg-white shadow rounded p-4 mb-4 flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[200px]">
+            <label class="block text-xs uppercase text-slate-500">Recherche</label>
+            <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste ou titre source…"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_lastfm_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
+    </form>
+
+    {% if aliases is empty %}
+        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+            {% if filters.q %}
+                Aucun alias ne correspond à « {{ filters.q }} ».
+            {% else %}
+                Aucun alias défini pour l'instant. Cliquez « + Nouvel alias » ou utilisez le bouton « ✏️ Mapper »
+                à côté d'un scrobble non matché dans le détail d'un import Last.fm.
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2">Source (artiste)</th>
+                    <th class="px-3 py-2">Source (titre)</th>
+                    <th class="px-3 py-2">Cible</th>
+                    <th class="px-3 py-2">Créé le</th>
+                    <th class="px-3 py-2"></th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for alias in aliases %}
+                    <tr>
+                        <td class="px-3 py-1.5">{{ alias.sourceArtist }}</td>
+                        <td class="px-3 py-1.5">{{ alias.sourceTitle }}</td>
+                        <td class="px-3 py-1.5 font-mono text-xs">
+                            {% if alias.skip %}
+                                <span class="px-2 py-0.5 rounded bg-amber-100 text-amber-800">IGNORÉ</span>
+                            {% else %}
+                                {{ alias.targetMediaFileId }}
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">{{ alias.createdAt|date('Y-m-d H:i') }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            <a href="{{ path('app_lastfm_alias_edit', {id: alias.id}) }}"
+                               class="text-xs text-sky-700 hover:underline">Modifier</a>
+                            <form method="post" action="{{ path('app_lastfm_alias_delete', {id: alias.id}) }}"
+                                  class="inline-block ml-2"
+                                  onsubmit="return confirm('Supprimer cet alias ?');">
+                                <input type="hidden" name="_token" value="{{ csrf_token('delete-alias-' ~ alias.id) }}">
+                                <button type="submit" class="text-xs text-rose-700 hover:underline">Supprimer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -76,7 +76,7 @@
     {% if report %}
         <div class="bg-white shadow rounded p-6 mb-6">
             <h2 class="font-semibold mb-3">Rapport d'import</h2>
-            <div class="grid grid-cols-2 md:grid-cols-4 gap-3 text-center">
+            <div class="grid grid-cols-2 md:grid-cols-5 gap-3 text-center">
                 <div class="bg-slate-100 rounded p-3">
                     <div class="text-xs uppercase text-slate-500">Récupérés</div>
                     <div class="text-2xl font-semibold">{{ report.fetched|number_format(0, '.', ' ') }}</div>
@@ -92,6 +92,10 @@
                 <div class="bg-amber-50 rounded p-3">
                     <div class="text-xs uppercase text-amber-700">Non trouvés</div>
                     <div class="text-2xl font-semibold text-amber-800">{{ report.unmatched|number_format(0, '.', ' ') }}</div>
+                </div>
+                <div class="bg-indigo-50 rounded p-3" title="Scrobbles ignorés via un alias avec cible vide">
+                    <div class="text-xs uppercase text-indigo-700">Ignorés</div>
+                    <div class="text-2xl font-semibold text-indigo-800">{{ report.skipped|number_format(0, '.', ' ') }}</div>
                 </div>
             </div>
         </div>

--- a/tests/Entity/LastFmAliasTest.php
+++ b/tests/Entity/LastFmAliasTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\Entity;
+
+use App\Entity\LastFmAlias;
+use PHPUnit\Framework\TestCase;
+
+class LastFmAliasTest extends TestCase
+{
+    public function testConstructorNormalizesSourceFields(): void
+    {
+        $a = new LastFmAlias('Beyoncé', 'Halo (Live)', 'mf-1');
+
+        $this->assertSame('Beyoncé', $a->getSourceArtist());
+        $this->assertSame('Halo (Live)', $a->getSourceTitle());
+        // Normalized form: lowercase + accents stripped + punctuation stripped + collapsed spaces.
+        $this->assertSame('beyonce', $a->getSourceArtistNorm());
+        $this->assertSame('halo live', $a->getSourceTitleNorm());
+        $this->assertSame('mf-1', $a->getTargetMediaFileId());
+        $this->assertFalse($a->isSkip());
+    }
+
+    public function testNullTargetMeansSkip(): void
+    {
+        $a = new LastFmAlias('Some Podcast', 'Episode 42', null);
+        $this->assertTrue($a->isSkip());
+        $this->assertNull($a->getTargetMediaFileId());
+    }
+
+    public function testEmptyTargetIsCoercedToSkip(): void
+    {
+        $a = new LastFmAlias('Some Podcast', 'Episode 42', '');
+        $this->assertTrue($a->isSkip());
+        $this->assertNull($a->getTargetMediaFileId());
+    }
+
+    public function testSetSourceRecomputesNormalization(): void
+    {
+        $a = new LastFmAlias('Old Artist', 'Old Title', 'mf-1');
+        $a->setSource('Café Tacvba', 'La Ingrata');
+
+        $this->assertSame('Café Tacvba', $a->getSourceArtist());
+        $this->assertSame('cafe tacvba', $a->getSourceArtistNorm());
+        $this->assertSame('la ingrata', $a->getSourceTitleNorm());
+    }
+
+    public function testSetTargetMediaFileIdAcceptsNullAndString(): void
+    {
+        $a = new LastFmAlias('A', 'B', 'mf-1');
+        $a->setTargetMediaFileId(null);
+        $this->assertTrue($a->isSkip());
+        $a->setTargetMediaFileId('mf-2');
+        $this->assertSame('mf-2', $a->getTargetMediaFileId());
+        $a->setTargetMediaFileId(''); // empty string also coerces to skip
+        $this->assertTrue($a->isSkip());
+    }
+}

--- a/tests/LastFm/InMemoryAliasRepository.php
+++ b/tests/LastFm/InMemoryAliasRepository.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Tests\LastFm;
+
+use App\Entity\LastFmAlias;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmAliasRepository;
+
+/**
+ * Stub LastFmAliasRepository that skips parent::__construct (no Doctrine
+ * registry needed) and looks up aliases against an in-memory list.
+ */
+final class InMemoryAliasRepository extends LastFmAliasRepository
+{
+    /** @param LastFmAlias[] $aliases */
+    public function __construct(private readonly array $aliases)
+    {
+        // Skip parent::__construct — we don't need the Doctrine registry.
+    }
+
+    public function findByScrobble(string $artist, string $title): ?LastFmAlias
+    {
+        $artistN = NavidromeRepository::normalize($artist);
+        $titleN = NavidromeRepository::normalize($title);
+        foreach ($this->aliases as $a) {
+            if ($a->getSourceArtistNorm() === $artistN && $a->getSourceTitleNorm() === $titleN) {
+                return $a;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/LastFm/LastFmImporterTest.php
+++ b/tests/LastFm/LastFmImporterTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\LastFm;
 
+use App\Entity\LastFmAlias;
 use App\LastFm\LastFmImporter;
 use App\LastFm\LastFmScrobble;
 use App\Navidrome\NavidromeRepository;
@@ -111,6 +112,55 @@ class LastFmImporterTest extends TestCase
             ['Discovery', 'mf-album'],
             ['One More Time', 'mf-single'],
         ], $events);
+    }
+
+    public function testManualAliasOverridesAllHeuristics(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        // The « real » match by heuristics would be mf-real, but the user
+        // has explicitly mapped (Bad Spelling, Track) → mf-target.
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-real', 'Track', 'Bad Spelling');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-target', 'Track', 'Other Artist');
+
+        $alias = new LastFmAlias('Bad Spelling', 'Track', 'mf-target');
+        $aliasRepo = new InMemoryAliasRepository([$alias]);
+
+        $client = new FakeLastFmClient([
+            new LastFmScrobble('Bad Spelling', 'Track', '', null, new \DateTimeImmutable('2024-06-01 12:00:00')),
+        ]);
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $events = [];
+        (new LastFmImporter($client, $repo, null, 0, $aliasRepo))->import(
+            'k',
+            'u',
+            dryRun: true,
+            onScrobble: function (LastFmScrobble $s, string $status, ?string $mfid) use (&$events): void {
+                $events[] = [$status, $mfid];
+            },
+        );
+
+        $this->assertSame([['inserted', 'mf-target']], $events);
+    }
+
+    public function testManualAliasWithNullTargetSkipsScrobble(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-real', 'My Podcast Episode 42', 'Some Podcast');
+
+        $alias = new LastFmAlias('Some Podcast', 'My Podcast Episode 42', null);
+        $aliasRepo = new InMemoryAliasRepository([$alias]);
+
+        $client = new FakeLastFmClient([
+            new LastFmScrobble('Some Podcast', 'My Podcast Episode 42', '', null, new \DateTimeImmutable('2024-06-01 12:00:00')),
+        ]);
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $report = (new LastFmImporter($client, $repo, null, 0, $aliasRepo))->import('k', 'u', dryRun: true);
+
+        $this->assertSame(0, $report->inserted);
+        $this->assertSame(0, $report->unmatched);
+        $this->assertSame(1, $report->skipped);
     }
 
     public function testFuzzyFallbackKicksInOnlyWhenEnabled(): void

--- a/tests/LastFm/LastFmImporterTest.php
+++ b/tests/LastFm/LastFmImporterTest.php
@@ -113,6 +113,29 @@ class LastFmImporterTest extends TestCase
         ], $events);
     }
 
+    public function testFuzzyFallbackKicksInOnlyWhenEnabled(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Take Me to Church', 'Hozier');
+
+        // Typo on artist name, no MBID, no album → exact heuristics all fail.
+        $client = new FakeLastFmClient([
+            new LastFmScrobble('Hosier', 'Take Me to Church', '', null, new \DateTimeImmutable('2024-06-01 10:00:00')),
+        ]);
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+
+        // Without fuzzy: unmatched.
+        $report = (new LastFmImporter($client, $repo))->import('k', 'u', dryRun: true);
+        $this->assertSame(1, $report->unmatched);
+        $this->assertSame(0, $report->inserted);
+
+        // With fuzzy max distance 2: matched.
+        $report = (new LastFmImporter($client, $repo, null, 2))->import('k', 'u', dryRun: true);
+        $this->assertSame(0, $report->unmatched);
+        $this->assertSame(1, $report->inserted);
+    }
+
     public function testOnScrobbleCallbackFiresWithStatusAndMediaFileId(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);

--- a/tests/Navidrome/NavidromeRepositoryTest.php
+++ b/tests/Navidrome/NavidromeRepositoryTest.php
@@ -437,4 +437,57 @@ class NavidromeRepositoryTest extends TestCase
         $repo = new NavidromeRepository($this->dbPath, 'admin');
         $this->assertNull($repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'One More Time', ''));
     }
+
+    public function testFindMediaFileFuzzyMatchesSmallTypos(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Take Me to Church', 'Hozier');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // 1 typo on artist + 1 typo on title = distance 2, under threshold 3.
+        $this->assertSame('mf-1', $repo->findMediaFileFuzzy('Hosier', 'Take Me to Chruch', 3));
+    }
+
+    public function testFindMediaFileFuzzyReturnsNullWhenDisabled(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Take Me to Church', 'Hozier');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // 0 → fuzzy is off, returns null even on a near-perfect typo.
+        $this->assertNull($repo->findMediaFileFuzzy('Hosier', 'Take Me to Church', 0));
+        $this->assertNull($repo->findMediaFileFuzzy('Hosier', 'Take Me to Church', -1));
+    }
+
+    public function testFindMediaFileFuzzyReturnsNullWhenAboveThreshold(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Take Me to Church', 'Hozier');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // Distance way above 3 → null.
+        $this->assertNull($repo->findMediaFileFuzzy('Completely Different Artist', 'Some Other Song', 3));
+    }
+
+    public function testFindMediaFileFuzzyPicksClosestMatch(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-far', 'Some Song', 'Far Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-near', 'Some Sang', 'Far Artist'); // distance 1
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-exact', 'Some Song', 'Far Artist'); // distance 0 (exact)
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // Should pick the lowest-distance candidate.
+        $this->assertSame('mf-far', $repo->findMediaFileFuzzy('Far Artist', 'Some Song', 3));
+    }
+
+    public function testFindMediaFileFuzzyOnEmptyInputs(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track', 'Artist');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertNull($repo->findMediaFileFuzzy('', 'Track', 3));
+        $this->assertNull($repo->findMediaFileFuzzy('Artist', '', 3));
+    }
 }


### PR DESCRIPTION
## Summary

Deux dernières grandes briques du méta #11 sur le matching scrobble
Last.fm → `media_file` Navidrome :

- **#16** — fallback **fuzzy Levenshtein** opt-in via la nouvelle env
  var `LASTFM_FUZZY_MAX_DISTANCE` (défaut `0` = désactivé). Tenté en
  dernier ressort après MBID / triplet / couple. Pré-filtre les
  candidats sur le préfixe 3 chars (artist OU title via
  `np_normalize`) puis calcule
  `levenshtein(candArtist, artist) + levenshtein(candTitle, title)`
  côté PHP. Matche `Hozier / Take Me to Chruch` ↔ `Hozier / Take Me
  to Church`, `Tchaïkovski` ↔ `Tchaikovsky`, etc.
- **#18** — table d'**alias manuels** `lastfm_alias` (id,
  source_artist, source_title, source_artist_norm, source_title_norm,
  target_media_file_id nullable, created_at) avec UNIQUE sur les
  deux colonnes normalisées. Consultée en priorité absolue avant
  toutes les heuristiques. Cible vide = scrobble compté en `skipped`
  (utile podcasts / bruit) au lieu de `unmatched`. Page CRUD
  `/lastfm/aliases` (liste paginée + recherche + formulaire), lien
  dans la nav (dropdown « Last.fm »), bouton « ✏️ Mapper » sur les
  scrobbles non matchés de `/history/{id}` qui pré-remplit le
  formulaire. Nouvelle constante `LastFmImportTrack::STATUS_SKIPPED`,
  card « Ignorés » dans le rapport `/lastfm/import`, filtre dans le
  sélecteur de statut sur le détail run, metric `skipped` persistée
  + affichée par le CLI.

Ordre final du matching : alias manuel → MBID → triplet → couple →
fuzzy → unmatched.

## Test plan

- [x] `composer ci` vert : phpcs + phpstan (level 6) + phpunit
  (125 tests / 288 assertions, +13 nouveaux tests)
- [x] Migration `Version20260502000000` jouée localement, table
  `lastfm_alias` créée
- [x] Routes `app_lastfm_alias_*` enregistrées (`debug:router`)
- [ ] Smoke test manuel : créer un alias depuis `/history/{id}`,
  re-lancer un import et vérifier que le scrobble est bien résolu via
  l'alias (à faire avant le merge)
- [ ] Smoke test manuel : créer un alias avec cible vide pour un
  podcast régulier et confirmer qu'il passe en `skipped`

Closes #16, closes #18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)