### PR TITLE
feat(config): APP_TIMEZONE env var (PHP + Twig display tz)

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,8 @@
 ###> symfony/framework-bundle ###
 APP_ENV=dev
 APP_SECRET=ChangeMeInProduction0123456789abcdef
+# Display timezone applied at boot (PHP + Twig |date). Default UTC.
+APP_TIMEZONE=UTC
 ###< symfony/framework-bundle ###
 
 ###> Navidrome source ###

--- a/.env.dist
+++ b/.env.dist
@@ -3,6 +3,11 @@
 ###> Symfony ###
 APP_ENV=prod
 APP_SECRET=                   # generate with: openssl rand -hex 32
+# Display timezone applied at boot to PHP (date_default_timezone_set)
+# AND to the Twig |date filter. Stored timestamps remain UTC ;
+# the conversion only happens at render. Default UTC.
+# Example values: Europe/Paris, America/New_York, Asia/Tokyo.
+APP_TIMEZONE=UTC
 ###< Symfony ###
 
 ###> Navidrome source (read-only access to its SQLite DB + Subsonic API) ###

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -22,6 +22,8 @@ services:
         APP_ENV: dev
         APP_DEBUG: '1'
         APP_SECRET: dev-secret-change-me-please-1234567890
+        # Display timezone (PHP + Twig). Default UTC. Try Europe/Paris.
+        APP_TIMEZONE: 'UTC'
         NAVIDROME_DB_PATH: /app/var/navidrome.db
         NAVIDROME_URL: http://host.lando.internal:4533
         NAVIDROME_USER: admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Variable d'environnement `APP_TIMEZONE` (défaut `UTC`). Appliquée
+  au boot du `Kernel` (PHP `date_default_timezone_set`) ET à Twig
+  (filtre `|date` via `twig.date.timezone`). Les timestamps restent
+  stockés en UTC ; la conversion ne se fait qu'à l'affichage. Une
+  valeur invalide retombe silencieusement sur UTC. Exemples :
+  `Europe/Paris`, `America/New_York`, `Asia/Tokyo`.
 - Sync **bidirectionnelle Last.fm loved ↔ Navidrome starred**
   (adds-only, idempotent). Le morceau ❤ sur Last.fm devient ★ dans
   Navidrome (et inversement). Aucun morceau n'est jamais déstarré ni

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ pouvez les éditer puis les activer.
 | `APP_SECRET`         | oui         | Secret Symfony (32 caractères hex). `openssl rand -hex 32`.              |
 | `APP_ENV`            | non (`prod`)| `prod` ou `dev`.                                                         |
 | `APP_MODE`           | non (`web`) | `web` (FrankenPHP) ou `cron` (supercronic).                              |
+| `APP_TIMEZONE`       | non (`UTC`) | Fuseau d'affichage (PHP + Twig). Ex. `Europe/Paris`. Stockage reste UTC. |
 | `NAVIDROME_DB_PATH`  | oui         | Chemin du fichier SQLite Navidrome dans le conteneur. Bind-mounter `:ro`.|
 | `NAVIDROME_URL`      | oui         | URL HTTP(S) de Navidrome (sans slash final).                             |
 | `NAVIDROME_USER`     | oui         | Utilisateur Navidrome dont on lit les écoutes et qui possède les playlists. |

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,9 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
+    date:
+        # Convert dates to APP_TIMEZONE when rendered via the |date filter,
+        # so UTC-stored timestamps display in the operator's local time.
+        timezone: '%env(APP_TIMEZONE)%'
     globals:
         navidrome_url: '%navidrome.url%'
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -9,6 +9,7 @@ services:
       APP_MODE: web
       APP_ENV: prod
       APP_SECRET: ${APP_SECRET:?set APP_SECRET in .env}
+      APP_TIMEZONE: ${APP_TIMEZONE:-UTC}
       NAVIDROME_DB_PATH: /data/navidrome.db
       NAVIDROME_URL: ${NAVIDROME_URL:-http://navidrome:4533}
       NAVIDROME_USER: ${NAVIDROME_USER:-admin}
@@ -44,6 +45,7 @@ services:
       APP_MODE: cron
       APP_ENV: prod
       APP_SECRET: ${APP_SECRET:?set APP_SECRET in .env}
+      APP_TIMEZONE: ${APP_TIMEZONE:-UTC}
       NAVIDROME_DB_PATH: /data/navidrome.db
       NAVIDROME_URL: ${NAVIDROME_URL:-http://navidrome:4533}
       NAVIDROME_USER: ${NAVIDROME_USER:-admin}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
         <server name="APP_ENV" value="test" force="true"/>
         <server name="SHELL_VERBOSITY" value="-1"/>
         <env name="APP_SECRET" value="test-secret-do-not-use-in-prod-1234567890"/>
+        <env name="APP_TIMEZONE" value="UTC"/>
         <env name="APP_AUTH_USER" value="admin"/>
         <env name="APP_AUTH_PASSWORD" value="changeme"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data_test.db"/>

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -8,4 +8,24 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
+
+    public function boot(): void
+    {
+        // Apply APP_TIMEZONE before any controller / command runs so
+        // every `new \DateTimeImmutable()` and Twig `|date` filter (with
+        // its own default coming from twig.yaml) use the operator's
+        // timezone instead of the container's UTC default.
+        $tz = $_SERVER['APP_TIMEZONE'] ?? $_ENV['APP_TIMEZONE'] ?? 'UTC';
+        if (is_string($tz) && $tz !== '') {
+            try {
+                new \DateTimeZone($tz);
+                date_default_timezone_set($tz);
+            } catch (\Exception) {
+                // Invalid value — fall back to UTC silently rather than crash.
+                date_default_timezone_set('UTC');
+            }
+        }
+
+        parent::boot();
+    }
 }

--- a/tests/KernelTimezoneTest.php
+++ b/tests/KernelTimezoneTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests;
+
+use App\Kernel;
+use PHPUnit\Framework\TestCase;
+
+class KernelTimezoneTest extends TestCase
+{
+    private string $previousTimezone = 'UTC';
+    private mixed $previousServerEnv = null;
+
+    protected function setUp(): void
+    {
+        $this->previousTimezone = date_default_timezone_get();
+        $this->previousServerEnv = $_SERVER['APP_TIMEZONE'] ?? null;
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->previousTimezone);
+        if ($this->previousServerEnv === null) {
+            unset($_SERVER['APP_TIMEZONE']);
+        } else {
+            $_SERVER['APP_TIMEZONE'] = $this->previousServerEnv;
+        }
+    }
+
+    public function testBootAppliesAppTimezoneEnvVar(): void
+    {
+        $_SERVER['APP_TIMEZONE'] = 'Europe/Paris';
+        $kernel = new Kernel('test', false);
+        $kernel->boot();
+        $this->assertSame('Europe/Paris', date_default_timezone_get());
+        $kernel->shutdown();
+    }
+
+    public function testBootFallsBackToUtcOnInvalidTimezone(): void
+    {
+        $_SERVER['APP_TIMEZONE'] = 'Mars/Olympus_Mons';
+        $kernel = new Kernel('test', false);
+        $kernel->boot();
+        $this->assertSame('UTC', date_default_timezone_get());
+        $kernel->shutdown();
+    }
+
+    public function testBootDefaultsToUtcWhenEnvMissing(): void
+    {
+        unset($_SERVER['APP_TIMEZONE']);
+        // Pretend the previous boot left a non-UTC tz behind.
+        date_default_timezone_set('Asia/Tokyo');
+        $kernel = new Kernel('test', false);
+        $kernel->boot();
+        $this->assertSame('UTC', date_default_timezone_get());
+        $kernel->shutdown();
+    }
+}


### PR DESCRIPTION
## Summary

Configure le fuseau d'affichage du tool via une env var
`APP_TIMEZONE` (défaut `UTC`). Le **stockage reste UTC partout** —
la conversion se fait uniquement au rendu.

- `Kernel::boot()` applique `date_default_timezone_set()` avant tout
  controller / commande, avec fallback silencieux sur UTC si la
  valeur est invalide.
- `twig.yaml` configure `twig.date.timezone` pour que `|date()`
  convertisse les `DateTimeImmutable` UTC à l'affichage.
- Env var déclarée dans les 5 endroits habituels (`.env`,
  `.env.dist`, `phpunit.xml.dist`, `.lando.yml.dist`,
  `docker-compose.example.yml`) + documentation dans le tableau
  README et le `CHANGELOG`.

Pas de changement de schéma, pas de service à reconfigurer.
Setting `APP_TIMEZONE=Europe/Paris` suffit pour voir tous les
timestamps (run history, scrobbles, wrapped, sync loved/star…) en
heure locale.

## Test plan

- [x] `composer ci` vert (146 tests / 344 assertions, +3 nouveaux)
- [x] `KernelTimezoneTest` couvre : valeur valide appliquée, valeur
  invalide → UTC, var absente → UTC
- [ ] Smoke manuel : poser `APP_TIMEZONE=Europe/Paris` et vérifier
  qu'un run sur `/history` affiche `startedAt` en heure locale (et
  non plus UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)