### PR TITLE
test(kernel): unset les 3 sources d'APP_TIMEZONE dans les tests (closes #43)

### DIFF
--- a/tests/KernelTimezoneTest.php
+++ b/tests/KernelTimezoneTest.php
@@ -9,26 +9,26 @@ class KernelTimezoneTest extends TestCase
 {
     private string $previousTimezone = 'UTC';
     private mixed $previousServerEnv = null;
+    private mixed $previousEnvEnv = null;
+    private string|false $previousGetenv = false;
 
     protected function setUp(): void
     {
         $this->previousTimezone = date_default_timezone_get();
         $this->previousServerEnv = $_SERVER['APP_TIMEZONE'] ?? null;
+        $this->previousEnvEnv = $_ENV['APP_TIMEZONE'] ?? null;
+        $this->previousGetenv = getenv('APP_TIMEZONE');
     }
 
     protected function tearDown(): void
     {
         date_default_timezone_set($this->previousTimezone);
-        if ($this->previousServerEnv === null) {
-            unset($_SERVER['APP_TIMEZONE']);
-        } else {
-            $_SERVER['APP_TIMEZONE'] = $this->previousServerEnv;
-        }
+        $this->restoreEnv('APP_TIMEZONE', $this->previousServerEnv, $this->previousEnvEnv, $this->previousGetenv);
     }
 
     public function testBootAppliesAppTimezoneEnvVar(): void
     {
-        $_SERVER['APP_TIMEZONE'] = 'Europe/Paris';
+        $this->setAppTimezone('Europe/Paris');
         $kernel = new Kernel('test', false);
         $kernel->boot();
         $this->assertSame('Europe/Paris', date_default_timezone_get());
@@ -37,7 +37,7 @@ class KernelTimezoneTest extends TestCase
 
     public function testBootFallsBackToUtcOnInvalidTimezone(): void
     {
-        $_SERVER['APP_TIMEZONE'] = 'Mars/Olympus_Mons';
+        $this->setAppTimezone('Mars/Olympus_Mons');
         $kernel = new Kernel('test', false);
         $kernel->boot();
         $this->assertSame('UTC', date_default_timezone_get());
@@ -46,12 +46,42 @@ class KernelTimezoneTest extends TestCase
 
     public function testBootDefaultsToUtcWhenEnvMissing(): void
     {
-        unset($_SERVER['APP_TIMEZONE']);
+        // Unset all three sources — Kernel::boot() reads $_SERVER first, then $_ENV,
+        // then falls back to 'UTC'. The OS-level env (getenv/putenv) is unset for
+        // belt-and-braces in case future code switches to it.
+        unset($_SERVER['APP_TIMEZONE'], $_ENV['APP_TIMEZONE']);
+        putenv('APP_TIMEZONE');
         // Pretend the previous boot left a non-UTC tz behind.
         date_default_timezone_set('Asia/Tokyo');
         $kernel = new Kernel('test', false);
         $kernel->boot();
         $this->assertSame('UTC', date_default_timezone_get());
         $kernel->shutdown();
+    }
+
+    private function setAppTimezone(string $value): void
+    {
+        $_SERVER['APP_TIMEZONE'] = $value;
+        $_ENV['APP_TIMEZONE'] = $value;
+        putenv('APP_TIMEZONE=' . $value);
+    }
+
+    private function restoreEnv(string $name, mixed $serverPrev, mixed $envPrev, string|false $getenvPrev): void
+    {
+        if ($serverPrev === null) {
+            unset($_SERVER[$name]);
+        } else {
+            $_SERVER[$name] = $serverPrev;
+        }
+        if ($envPrev === null) {
+            unset($_ENV[$name]);
+        } else {
+            $_ENV[$name] = $envPrev;
+        }
+        if ($getenvPrev === false) {
+            putenv($name);
+        } else {
+            putenv($name . '=' . $getenvPrev);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fix du test `KernelTimezoneTest::testBootDefaultsToUtcWhenEnvMissing` qui échouait sur tout environnement où l'OS exporte déjà `APP_TIMEZONE` (cas du conteneur Lando local, mais aussi potentiellement la CI).
- Le test ne touchait que `$_SERVER`, alors que `Kernel::boot()` lit `$_SERVER → $_ENV → 'UTC'`. Les `<env>` du `phpunit.xml.dist` n'override pas une variable d'environnement déjà présente, donc `$_ENV['APP_TIMEZONE']` restait à `Europe/Paris` (valeur Lando) et le Kernel l'appliquait.
- `setUp/tearDown` sauvegardent et restaurent les 3 sources ($_SERVER, $_ENV, getenv/putenv) ; le test « missing » les unset toutes ; helper `setAppTimezone()` pour les deux tests positifs.
- Aucun changement côté `src/` : le comportement de `Kernel::boot()` (cascade $_SERVER → $_ENV → 'UTC') est correct.

## Test plan

- [x] `vendor/bin/phpunit tests/KernelTimezoneTest.php` → 3/3 OK
- [x] `composer ci` → 164 tests, 384 assertions, 0 failure (phpcs + phpstan + phpunit)
- [x] Vérifié que la régression existait sur `origin/main` (commit `41c433b`) et qu'elle est corrigée par ce PR

Closes #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)