### PR TITLE
fix(history): exclure les métriques non-scalaires de la colonne /history (closes #45)

### DIFF
--- a/templates/history/index.html.twig
+++ b/templates/history/index.html.twig
@@ -73,7 +73,7 @@
                         </td>
                         <td class="px-3 py-1.5 text-xs text-slate-500">
                             {% if entry.metrics %}
-                                {% for k, v in entry.metrics|filter(v => v is not null and v != '') %}{{ k }}={{ v }} {% endfor %}
+                                {% for k, v in entry.metrics|filter(v => v is not null and v is not iterable and v != '') %}{{ k }}={{ v }} {% endfor %}
                             {% endif %}
                         </td>
                         <td class="px-3 py-1.5 text-right">


### PR DESCRIPTION
## Summary

- Sur `/history`, le warning PHP `Array to string conversion` était levé dès qu'un run avait une métrique array (cas typique : `unmatched_artists` pour les runs `lastfm-import`).
- `templates/history/index.html.twig` rend la colonne « Métriques » sous forme `k=v k=v…` via un `{% for k, v in entry.metrics|filter(...) %}{{ k }}={{ v }}{% endfor %}`. Le filtre laissait passer les arrays, et `{{ v }}` les coercait en string → warning.
- Ajout de `v is not iterable` au filtre. Les arrays disparaissent du listing une-ligne ; la page de détail (`/history/{id}`) continue de les rendre proprement (`json_encode` + section dédiée « Artistes non matchés »).
- 1 ligne modifiée.

## Test plan

- [x] Reproduit le warning sur `main` avec un mini-render Twig (array passé → `Warning: Array to string conversion`).
- [x] Avec le fix : l'array est filtré, les scalaires (`inserted=42`, `label=hello`) restent visibles, plus de warning.
- [x] `composer ci` → 164 tests, 384 assertions, 0 failure (phpcs + phpstan + phpunit).
- [x] Vérifié `templates/history/detail.html.twig` : utilise `json_encode`, pas affecté.

Closes #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)