### PR TITLE
docs(roadmap): synthèse d'un import Last.fm sur la page détail (#47)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,6 +40,7 @@ l'ordre d'attaque recommandé.
 |-----|--------------------------------------------------------------------|--------|
 | [#3]  | Sync incrémentale Last.fm → Navidrome                           | M      |
 | [#4]  | Page permanente : diff Last.fm vs lib Navidrome                 | M      |
+| [#47] | Synthèse d'un import Last.fm sur la page détail (totaux + %)    | M      |
 
 ### Stats / Curation
 
@@ -124,3 +125,4 @@ quand on tagge des releases) :
 [#29]: https://github.com/kgaut/navidrome-playlist-generator/issues/29
 [#30]: https://github.com/kgaut/navidrome-playlist-generator/issues/30
 [#31]: https://github.com/kgaut/navidrome-playlist-generator/issues/31
+[#47]: https://github.com/kgaut/navidrome-playlist-generator/issues/47


### PR DESCRIPTION
Le détail d'un run lastfm-import affiche aujourd'hui des compteurs
bruts ; on veut un encart synthèse (fetched + matched/unmatched/
duplicate avec pourcentages + barre empilée) pour comparer
rapidement deux imports. Toutes les métriques sont déjà persistées
dans RunHistory.metrics, donc c'est purement template +
contrôleur.

https://claude.ai/code/session_016yDQJKrU9e6KNoFcEKQgoW