### PR TITLE
feat(history): synthèse d'un import Last.fm avec totaux et pourcentages (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Encart **« Synthèse »** sur la page `/history/{id}` d'un run
+  `lastfm-import` : nombre absolu de scrobbles récupérés depuis Last.fm
+  + valeur absolue ET pourcentage rapporté à `fetched` pour chaque
+  bucket (insérés, doublons, non matchés, ignorés, matchés =
+  insérés+doublons), barre empilée 4-couleurs en lecture rapide.
+  Calcul délégué à `App\Service\LastFmImportSummary::fromRun()`
+  (résiste aux runs sans `fetched` ou avec métriques manquantes).
+  Closes #47.
 - Variable d'environnement `APP_TIMEZONE` (défaut `UTC`). Appliquée
   au boot du `Kernel` (PHP `date_default_timezone_set`) ET à Twig
   (filtre `|date` via `twig.date.timezone`). Les timestamps restent

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -8,6 +8,7 @@ use App\Lidarr\LidarrClient;
 use App\Lidarr\LidarrConfig;
 use App\Repository\LastFmImportTrackRepository;
 use App\Repository\RunHistoryRepository;
+use App\Service\LastFmImportSummary;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -99,6 +100,7 @@ class HistoryController extends AbstractController
 
         return $this->render('history/detail.html.twig', [
             'entry' => $entry,
+            'summary' => LastFmImportSummary::fromRun($entry),
             'tracks' => $tracks,
             'tracks_truncated' => $tracksTruncated,
             'tracks_limit' => self::DETAIL_TRACK_LIMIT,

--- a/src/Service/LastFmImportSummary.php
+++ b/src/Service/LastFmImportSummary.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\RunHistory;
+
+final class LastFmImportSummary
+{
+    /**
+     * @return array{
+     *   fetched: int,
+     *   matched: array{n: int, pct: float},
+     *   inserted: array{n: int, pct: float},
+     *   duplicates: array{n: int, pct: float},
+     *   unmatched: array{n: int, pct: float},
+     *   skipped: array{n: int, pct: float},
+     * }|null
+     */
+    public static function fromRun(RunHistory $entry): ?array
+    {
+        if ($entry->getType() !== RunHistory::TYPE_LASTFM_IMPORT) {
+            return null;
+        }
+
+        $metrics = $entry->getMetrics() ?? [];
+        $fetched = self::int($metrics['fetched'] ?? 0);
+        $inserted = self::int($metrics['inserted'] ?? 0);
+        $duplicates = self::int($metrics['duplicates'] ?? 0);
+        $unmatched = self::int($metrics['unmatched'] ?? 0);
+        $skipped = self::int($metrics['skipped'] ?? 0);
+        $matched = $inserted + $duplicates;
+
+        $pct = static fn (int $n): float => $fetched > 0 ? round($n * 100 / $fetched, 1) : 0.0;
+
+        return [
+            'fetched' => $fetched,
+            'matched' => ['n' => $matched, 'pct' => $pct($matched)],
+            'inserted' => ['n' => $inserted, 'pct' => $pct($inserted)],
+            'duplicates' => ['n' => $duplicates, 'pct' => $pct($duplicates)],
+            'unmatched' => ['n' => $unmatched, 'pct' => $pct($unmatched)],
+            'skipped' => ['n' => $skipped, 'pct' => $pct($skipped)],
+        ];
+    }
+
+    private static function int(mixed $v): int
+    {
+        return is_numeric($v) ? (int) $v : 0;
+    }
+}

--- a/templates/history/detail.html.twig
+++ b/templates/history/detail.html.twig
@@ -38,6 +38,54 @@
         {% endif %}
     </div>
 
+    {# ---------- Summary card for Last.fm imports ---------- #}
+    {% if summary is not null %}
+        <div class="bg-white shadow rounded p-6 mt-6 max-w-3xl">
+            <h2 class="text-lg font-semibold mb-1">Synthèse</h2>
+            <p class="text-sm text-slate-500 mb-4">
+                <strong>{{ summary.fetched|number_format(0, '.', ' ') }}</strong>
+                scrobble{{ summary.fetched > 1 ? 's' : '' }} récupéré{{ summary.fetched > 1 ? 's' : '' }} depuis Last.fm
+            </p>
+
+            {% if summary.fetched > 0 %}
+                <div class="flex h-3 rounded overflow-hidden bg-slate-100 mb-4" title="Répartition des scrobbles">
+                    <div class="bg-emerald-500" style="width: {{ summary.inserted.pct }}%"></div>
+                    <div class="bg-slate-400" style="width: {{ summary.duplicates.pct }}%"></div>
+                    <div class="bg-amber-500" style="width: {{ summary.unmatched.pct }}%"></div>
+                    <div class="bg-sky-400" style="width: {{ summary.skipped.pct }}%"></div>
+                </div>
+            {% endif %}
+
+            <ul class="text-sm grid grid-cols-1 sm:grid-cols-2 gap-y-1 max-w-md">
+                <li>
+                    <span class="inline-block w-3 h-3 bg-emerald-500 rounded-sm mr-2 align-middle"></span>
+                    Insérés : <strong>{{ summary.inserted.n|number_format(0, '.', ' ') }}</strong>
+                    <span class="text-slate-500">({{ summary.inserted.pct }}%)</span>
+                </li>
+                <li>
+                    <span class="inline-block w-3 h-3 bg-slate-400 rounded-sm mr-2 align-middle"></span>
+                    Doublons : <strong>{{ summary.duplicates.n|number_format(0, '.', ' ') }}</strong>
+                    <span class="text-slate-500">({{ summary.duplicates.pct }}%)</span>
+                </li>
+                <li>
+                    <span class="inline-block w-3 h-3 bg-amber-500 rounded-sm mr-2 align-middle"></span>
+                    Non matchés : <strong>{{ summary.unmatched.n|number_format(0, '.', ' ') }}</strong>
+                    <span class="text-slate-500">({{ summary.unmatched.pct }}%)</span>
+                </li>
+                <li>
+                    <span class="inline-block w-3 h-3 bg-sky-400 rounded-sm mr-2 align-middle"></span>
+                    Ignorés : <strong>{{ summary.skipped.n|number_format(0, '.', ' ') }}</strong>
+                    <span class="text-slate-500">({{ summary.skipped.pct }}%)</span>
+                </li>
+                <li class="sm:col-span-2 mt-2 pt-2 border-t border-slate-200">
+                    Matchés <span class="text-xs text-slate-500">(insérés + doublons)</span> :
+                    <strong>{{ summary.matched.n|number_format(0, '.', ' ') }}</strong>
+                    <span class="text-slate-500">({{ summary.matched.pct }}%)</span>
+                </li>
+            </ul>
+        </div>
+    {% endif %}
+
     {# ---------- Per-track section for Last.fm imports ---------- #}
     {% if entry.type == 'lastfm-import' and (status_counts|default({})) is not empty %}
         <div class="bg-white shadow rounded p-6 mt-6 max-w-5xl">

--- a/tests/Service/LastFmImportSummaryTest.php
+++ b/tests/Service/LastFmImportSummaryTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\RunHistory;
+use App\Service\LastFmImportSummary;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class LastFmImportSummaryTest extends TestCase
+{
+    public function testReturnsNullForNonLastFmImportRun(): void
+    {
+        $entry = new RunHistory(RunHistory::TYPE_PLAYLIST, 'pl-1', 'Top last 30 days');
+        $entry->setMetrics(['fetched' => 100, 'inserted' => 50]);
+
+        $this->assertNull(LastFmImportSummary::fromRun($entry));
+    }
+
+    public function testComputesAllBucketsAndMatchedDerivation(): void
+    {
+        $entry = $this->makeImportRun([
+            'fetched' => 1000,
+            'inserted' => 700,
+            'duplicates' => 100,
+            'unmatched' => 150,
+            'skipped' => 50,
+        ]);
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame(1000, $s['fetched']);
+        $this->assertSame(700, $s['inserted']['n']);
+        $this->assertSame(70.0, $s['inserted']['pct']);
+        $this->assertSame(100, $s['duplicates']['n']);
+        $this->assertSame(10.0, $s['duplicates']['pct']);
+        $this->assertSame(150, $s['unmatched']['n']);
+        $this->assertSame(15.0, $s['unmatched']['pct']);
+        $this->assertSame(50, $s['skipped']['n']);
+        $this->assertSame(5.0, $s['skipped']['pct']);
+        $this->assertSame(800, $s['matched']['n']);
+        $this->assertSame(80.0, $s['matched']['pct']);
+    }
+
+    public function testFetchedZeroDoesNotDivideByZero(): void
+    {
+        $entry = $this->makeImportRun([
+            'fetched' => 0,
+            'inserted' => 0,
+            'duplicates' => 0,
+            'unmatched' => 0,
+            'skipped' => 0,
+        ]);
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame(0, $s['fetched']);
+        foreach (['matched', 'inserted', 'duplicates', 'unmatched', 'skipped'] as $k) {
+            $this->assertSame(0.0, $s[$k]['pct'], "$k pct should be 0 when fetched=0");
+        }
+    }
+
+    public function testNullMetricsTreatedAsZeros(): void
+    {
+        $entry = new RunHistory(RunHistory::TYPE_LASTFM_IMPORT, 'lf-1', 'Import 2026-05-01');
+        // metrics not set -> null
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame(0, $s['fetched']);
+        $this->assertSame(0, $s['inserted']['n']);
+    }
+
+    public function testMissingKeysDefaultToZero(): void
+    {
+        $entry = $this->makeImportRun([
+            'fetched' => 10,
+            'inserted' => 5,
+            // duplicates / unmatched / skipped intentionally absent
+        ]);
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame(0, $s['duplicates']['n']);
+        $this->assertSame(0, $s['unmatched']['n']);
+        $this->assertSame(0, $s['skipped']['n']);
+        $this->assertSame(5, $s['matched']['n']);
+    }
+
+    public function testNonNumericMetricsCoercedToZero(): void
+    {
+        $entry = $this->makeImportRun([
+            'fetched' => 'invalid',
+            'inserted' => null,
+            'duplicates' => [1, 2],
+            'unmatched' => 5,
+        ]);
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame(0, $s['fetched']);
+        $this->assertSame(0, $s['inserted']['n']);
+        $this->assertSame(0, $s['duplicates']['n']);
+        $this->assertSame(5, $s['unmatched']['n']);
+    }
+
+    /**
+     * @param array{fetched:int, inserted:int, expectedPct:float} $case
+     */
+    #[DataProvider('roundingCases')]
+    public function testPercentageRoundingToOneDecimal(array $case): void
+    {
+        $entry = $this->makeImportRun([
+            'fetched' => $case['fetched'],
+            'inserted' => $case['inserted'],
+        ]);
+
+        $s = LastFmImportSummary::fromRun($entry);
+
+        $this->assertNotNull($s);
+        $this->assertSame($case['expectedPct'], $s['inserted']['pct']);
+    }
+
+    /**
+     * @return iterable<string, array{0: array{fetched:int, inserted:int, expectedPct:float}}>
+     */
+    public static function roundingCases(): iterable
+    {
+        yield 'one third' => [['fetched' => 3, 'inserted' => 1, 'expectedPct' => 33.3]];
+        yield 'two thirds' => [['fetched' => 3, 'inserted' => 2, 'expectedPct' => 66.7]];
+        yield 'one out of seven' => [['fetched' => 7, 'inserted' => 1, 'expectedPct' => 14.3]];
+        yield 'half' => [['fetched' => 2, 'inserted' => 1, 'expectedPct' => 50.0]];
+        yield 'all' => [['fetched' => 100, 'inserted' => 100, 'expectedPct' => 100.0]];
+    }
+
+    /**
+     * @param array<string, mixed> $metrics
+     */
+    private function makeImportRun(array $metrics): RunHistory
+    {
+        $entry = new RunHistory(RunHistory::TYPE_LASTFM_IMPORT, 'lf-1', 'Import 2026-05-01');
+        $entry->setMetrics($metrics);
+        return $entry;
+    }
+}


### PR DESCRIPTION
## Summary

- Sur `/history/{id}` d'un run `lastfm-import`, nouvel encart « Synthèse » entre la card métadonnées et la table per-track.
- Affiche `fetched` en absolu + pour chaque bucket (`inserted`, `duplicates`, `unmatched`, `skipped`) la valeur absolue ET le pourcentage rapporté à `fetched`. Ligne dérivée « Matchés » = insérés + doublons.
- Barre empilée 4-couleurs (emerald/slate/amber/sky) pour lecture rapide, alignée sur la palette des badges existants.
- Calcul extrait dans `App\Service\LastFmImportSummary::fromRun()` (testable sans Kernel). Résiste aux runs sans `fetched`, aux métriques absentes, aux valeurs non-numériques (division par zéro évitée).
- Pas de migration : toutes les données nécessaires sont déjà dans `RunHistory.metrics` (cf. `ImportLastFmCommand:159-166`).

## Test plan

- [x] 11 nouveaux tests unitaires sur `LastFmImportSummary` (43 assertions) couvrant : run non-lastfm-import → null, calcul des buckets, dérivation `matched`, fetched=0 sans erreur, métriques null, clés manquantes, valeurs non-numériques, arrondi à 1 décimale (1/3, 2/3, 1/7…).
- [x] Rendu du template Twig vérifié sur entités synthétiques (1000 fetched + edge case fetched=0) : pas d'exception, tous les labels présents, pourcentages corrects.
- [x] `composer ci` → 175 tests, 427 assertions, 0 failure (phpcs + phpstan + phpunit).
- [x] Entrée ajoutée à `CHANGELOG.md` sous `[Unreleased]`.

Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)