### PR TITLE
feat(lastfm): page /lastfm/unmatched avec filtres et actions Lidarr/Mapper (closes #56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- Page **`/lastfm/unmatched`** (menu Last.fm → Unmatched) : audit
+  cumulé de tous les scrobbles non matchés sur l'ensemble des imports,
+  agrégés par `(artist, title, album)` avec compteur et dernier
+  `played_at`. Filtres GET `artist` / `title` / `album` (substring
+  case-insensitive), pagination 50 par page. Actions par ligne :
+  « ✏️ Mapper » (alias manuel) et « + Lidarr » (qui redirige sur la
+  page après ajout, via le nouveau hidden field `_redirect_unmatched`
+  géré par `LidarrController`). Statut Lidarr ✓/✗/— affiché par ligne
+  en réutilisant `LidarrClient::indexExistingArtists()`. Implémentée
+  par `LastFmImportTrackRepository::findUnmatchedAggregated()` +
+  helper statique testable `queryUnmatchedAggregated()`. Lien depuis
+  la carte « Re-tenter le matching cumulé » sur `/lastfm/import`.
+  Closes #56.
 - Commande **`app:lastfm:rematch`** (+ UI sur `/history/{id}` et
   `/lastfm/import`, + cron via `LASTFM_REMATCH_SCHEDULE`) qui ré-applique
   la cascade de matching courante sur les rows `lastfm_import_track`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,16 @@ Fonctionnalités livrées :
   (table `lastfm_import_track`, FK CASCADE) avec filtre par statut
   (inserted / duplicate / unmatched, défaut « non matchés »
   s'il y en a) et recherche full-text artiste/titre.
+- **Page `/lastfm/unmatched`** : audit cumulé de **tous** les
+  scrobbles `unmatched` (toutes runs confondues), agrégés par
+  `(artist, title, album)` avec compteur de scrobbles + dernier
+  `played_at`. Filtres GET `artist` / `title` / `album` (substring
+  case-insensitive), pagination 50 par page. Boutons par ligne :
+  « ✏️ Mapper » (alias) et « + Lidarr » (avec redirect retour vers la
+  page). Statut Lidarr (✓/✗/—) en réutilisant
+  `LidarrClient::indexExistingArtists()`. Implémentée par
+  `LastFmImportTrackRepository::queryUnmatchedAggregated()` (helper
+  statique testable + méthode publique d'instance).
 - **Re-match des unmatched** (`app:lastfm:rematch`,
   `POST /lastfm/rematch`) : ré-applique la cascade de matching
   (`App\LastFm\ScrobbleMatcher`, extraite pour mutualisation avec

--- a/README.md
+++ b/README.md
@@ -395,6 +395,27 @@ lando symfony app:lastfm:import myuser --api-key=XXX \
 lando symfony app:lastfm:import myuser --api-key=XXX --show-unmatched=all
 ```
 
+## Liste cumulée des unmatched
+
+La page **`/lastfm/unmatched`** (menu Last.fm → Unmatched) liste tous
+les scrobbles non matchés sur l'ensemble des imports passés, agrégés
+par `(artiste, titre, album)` avec compteur de scrobbles. Filtres en
+GET sur `artist`, `title`, `album` (substring case-insensitive) et
+pagination 50 par page.
+
+Pour chaque ligne :
+
+- **« ✏️ Mapper »** ouvre le formulaire d'alias manuel pré-rempli avec
+  l'artiste et le titre.
+- **« + Lidarr »** envoie l'artiste à Lidarr (si configuré) et
+  redirige sur la page après ajout.
+- Le statut Lidarr (✓ déjà / ✗ absent / —) est affiché par ligne en
+  cherchant l'artiste dans le catalogue Lidarr existant.
+
+Couplée à la commande `app:lastfm:rematch` (ci-dessous), ces deux
+pages forment le workflow de récupération : identifier ce qui manque
+→ créer alias / ajouter à Lidarr → relancer le rematch.
+
 ## Re-match des unmatched
 
 Quand on ajoute des morceaux à Navidrome après un import (ou qu'on

--- a/src/Controller/LastFmUnmatchedController.php
+++ b/src/Controller/LastFmUnmatchedController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Controller;
+
+use App\Lidarr\LidarrClient;
+use App\Lidarr\LidarrConfig;
+use App\Repository\LastFmImportTrackRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmUnmatchedController extends AbstractController
+{
+    private const PER_PAGE = 50;
+
+    public function __construct(
+        private readonly LastFmImportTrackRepository $trackRepo,
+        private readonly LidarrConfig $lidarrConfig,
+        private readonly LidarrClient $lidarrClient,
+    ) {
+    }
+
+    #[Route('/lastfm/unmatched', name: 'app_lastfm_unmatched', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $filters = [
+            'artist' => trim((string) $request->query->get('artist', '')) ?: null,
+            'title' => trim((string) $request->query->get('title', '')) ?: null,
+            'album' => trim((string) $request->query->get('album', '')) ?: null,
+        ];
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $result = $this->trackRepo->findUnmatchedAggregated(
+            artist: $filters['artist'],
+            title: $filters['title'],
+            album: $filters['album'],
+            page: $page,
+            perPage: self::PER_PAGE,
+        );
+        $totalPages = (int) ceil(max(1, $result['total']) / self::PER_PAGE);
+
+        $lidarrConfigured = $this->lidarrConfig->isConfigured();
+        $lidarrReachable = true;
+        $lidarrIndex = null;
+        if ($lidarrConfigured) {
+            try {
+                $lidarrIndex = $this->lidarrClient->indexExistingArtists();
+            } catch (\Throwable) {
+                $lidarrReachable = false;
+            }
+        }
+
+        $rows = [];
+        foreach ($result['items'] as $r) {
+            $key = mb_strtolower(trim($r['artist']));
+            $match = $lidarrIndex[$key] ?? null;
+            $rows[] = [
+                'artist' => $r['artist'],
+                'title' => $r['title'],
+                'album' => $r['album'],
+                'scrobbles' => $r['scrobbles'],
+                'last_played' => $r['last_played'],
+                'lidarr_url' => $match !== null && $match['foreignArtistId'] !== ''
+                    ? $this->lidarrConfig->artistDetailUrl($match['foreignArtistId'])
+                    : null,
+            ];
+        }
+
+        return $this->render('lastfm/unmatched.html.twig', [
+            'rows' => $rows,
+            'total' => $result['total'],
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => $filters,
+            'lidarr_configured' => $lidarrConfigured,
+            'lidarr_reachable' => $lidarrReachable,
+        ]);
+    }
+}

--- a/src/Controller/LidarrController.php
+++ b/src/Controller/LidarrController.php
@@ -21,9 +21,14 @@ class LidarrController extends AbstractController
     public function addArtist(Request $request): Response
     {
         $redirectRunId = (int) $request->request->get('_redirect_run_id', 0);
-        $back = $redirectRunId > 0
-            ? $this->redirectToRoute('app_history_detail', ['id' => $redirectRunId])
-            : $this->redirectToRoute('app_lastfm_import');
+        $redirectUnmatched = (bool) $request->request->get('_redirect_unmatched', false);
+        if ($redirectRunId > 0) {
+            $back = $this->redirectToRoute('app_history_detail', ['id' => $redirectRunId]);
+        } elseif ($redirectUnmatched) {
+            $back = $this->redirectToRoute('app_lastfm_unmatched');
+        } else {
+            $back = $this->redirectToRoute('app_lastfm_import');
+        }
 
         if (!$this->config->isConfigured()) {
             $this->addFlash('error', 'Lidarr n\'est pas configuré (LIDARR_URL / LIDARR_API_KEY).');

--- a/src/Repository/LastFmImportTrackRepository.php
+++ b/src/Repository/LastFmImportTrackRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\LastFmImportTrack;
 use App\Entity\RunHistory;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
 
 /**
@@ -84,6 +85,101 @@ class LastFmImportTrackRepository extends ServiceEntityRepository
         }
 
         return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+
+    /**
+     * Aggregate unmatched tracks across all runs by (artist, title, album).
+     * Each result row groups every scrobble that shares the same triplet,
+     * with a count and the most recent played_at — that's the actionable
+     * unit on /lastfm/unmatched (one alias creation = one (artist, title)
+     * couple, not one per scrobble row).
+     *
+     * Filters use case-insensitive substring match. Pagination is 1-based.
+     *
+     * @return array{
+     *     items: list<array{artist:string, title:string, album:?string, scrobbles:int, last_played:\DateTimeImmutable}>,
+     *     total: int
+     * }
+     */
+    public function findUnmatchedAggregated(
+        ?string $artist = null,
+        ?string $title = null,
+        ?string $album = null,
+        int $page = 1,
+        int $perPage = 50,
+    ): array {
+        return self::queryUnmatchedAggregated(
+            $this->getEntityManager()->getConnection(),
+            $artist,
+            $title,
+            $album,
+            $page,
+            $perPage,
+        );
+    }
+
+    /**
+     * Static SQL helper exposed for testability — same contract as
+     * {@see findUnmatchedAggregated()} but takes the Connection directly so
+     * tests can wire a SQLite fixture without booting the Doctrine ORM.
+     *
+     * @return array{
+     *     items: list<array{artist:string, title:string, album:?string, scrobbles:int, last_played:\DateTimeImmutable}>,
+     *     total: int
+     * }
+     */
+    public static function queryUnmatchedAggregated(
+        Connection $conn,
+        ?string $artist,
+        ?string $title,
+        ?string $album,
+        int $page,
+        int $perPage,
+    ): array {
+        $page = max(1, $page);
+        $perPage = max(1, $perPage);
+
+        $where = "status = 'unmatched'";
+        $params = [];
+        if ($artist !== null && $artist !== '') {
+            $where .= ' AND LOWER(artist) LIKE :artist';
+            $params['artist'] = '%' . mb_strtolower($artist) . '%';
+        }
+        if ($title !== null && $title !== '') {
+            $where .= ' AND LOWER(title) LIKE :title';
+            $params['title'] = '%' . mb_strtolower($title) . '%';
+        }
+        if ($album !== null && $album !== '') {
+            $where .= " AND LOWER(COALESCE(album, '')) LIKE :album";
+            $params['album'] = '%' . mb_strtolower($album) . '%';
+        }
+
+        $totalSql = 'SELECT COUNT(*) FROM ('
+            . "SELECT 1 FROM lastfm_import_track WHERE $where "
+            . 'GROUP BY artist, title, album'
+            . ') sub';
+        $total = (int) $conn->fetchOne($totalSql, $params);
+
+        $offset = ($page - 1) * $perPage;
+        $itemsSql = 'SELECT artist, title, album, COUNT(*) AS scrobbles, MAX(played_at) AS last_played '
+            . "FROM lastfm_import_track WHERE $where "
+            . 'GROUP BY artist, title, album '
+            . 'ORDER BY scrobbles DESC, last_played DESC '
+            . 'LIMIT :limit OFFSET :offset';
+        $itemsParams = $params + ['limit' => $perPage, 'offset' => $offset];
+
+        $items = [];
+        foreach ($conn->fetchAllAssociative($itemsSql, $itemsParams) as $row) {
+            $items[] = [
+                'artist' => (string) $row['artist'],
+                'title' => (string) $row['title'],
+                'album' => ($row['album'] ?? null) !== null && $row['album'] !== '' ? (string) $row['album'] : null,
+                'scrobbles' => (int) $row['scrobbles'],
+                'last_played' => new \DateTimeImmutable((string) $row['last_played']),
+            ];
+        }
+
+        return ['items' => $items, 'total' => $total];
     }
 
     /**

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -65,6 +65,7 @@
                         </button>
                         <div class="absolute right-0 top-full mt-1 w-44 bg-slate-800 text-slate-100 rounded shadow-lg invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition py-1 z-30">
                             <a href="{{ path('app_lastfm_import') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Import</a>
+                            <a href="{{ path('app_lastfm_unmatched') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Unmatched</a>
                             <a href="{{ path('app_lastfm_love_sync') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Sync loved/star</a>
                             <a href="{{ path('app_lastfm_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias</a>
                         </div>

--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -80,14 +80,20 @@
             <p class="text-xs text-rose-700 mb-3">
                 ⚠️ Navidrome doit être <strong>arrêté</strong> avant de lancer le rematch.
             </p>
-            <form method="post" action="{{ path('app_lastfm_rematch') }}"
-                  onsubmit="return confirm('Lancer le rematch sur les {{ unmatched_cumulative }} scrobbles non matchés cumulés ?');">
-                <input type="hidden" name="_token" value="{{ csrf_token('lastfm_rematch') }}">
-                <button type="submit"
-                        class="px-4 py-2 rounded bg-emerald-600 text-white text-sm hover:bg-emerald-700">
-                    🔁 Re-tenter le matching de tous les unmatched
-                </button>
-            </form>
+            <div class="flex flex-wrap items-center gap-3">
+                <form method="post" action="{{ path('app_lastfm_rematch') }}"
+                      onsubmit="return confirm('Lancer le rematch sur les {{ unmatched_cumulative }} scrobbles non matchés cumulés ?');">
+                    <input type="hidden" name="_token" value="{{ csrf_token('lastfm_rematch') }}">
+                    <button type="submit"
+                            class="px-4 py-2 rounded bg-emerald-600 text-white text-sm hover:bg-emerald-700">
+                        🔁 Re-tenter le matching de tous les unmatched
+                    </button>
+                </form>
+                <a href="{{ path('app_lastfm_unmatched') }}"
+                   class="text-sm text-sky-700 hover:underline">
+                    Voir la liste détaillée →
+                </a>
+            </div>
         </div>
     {% endif %}
 

--- a/templates/lastfm/unmatched.html.twig
+++ b/templates/lastfm/unmatched.html.twig
@@ -1,0 +1,138 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Scrobbles non matchés{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Scrobbles non matchés</h1>
+            <p class="text-sm text-slate-500">
+                {{ total|number_format(0, '.', ' ') }}
+                groupe{{ total > 1 ? 's' : '' }}
+                (artiste, titre, album) cumulé{{ total > 1 ? 's' : '' }} sur tous les imports.
+                Pour chaque ligne : créez un alias manuel, ajoutez l'artiste à Lidarr, ou
+                lancez un re-match cumulé via la page <a href="{{ path('app_lastfm_import') }}" class="underline">Import</a>.
+            </p>
+        </div>
+    </div>
+
+    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500">Artiste</label>
+            <input type="search" name="artist" value="{{ filters.artist }}" placeholder="ex. Gentleman"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500">Titre</label>
+            <input type="search" name="title" value="{{ filters.title }}" placeholder="ex. Berlin"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500">Album</label>
+            <input type="search" name="album" value="{{ filters.album }}" placeholder="ex. Rainbow Warrior"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <div class="flex gap-2">
+            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <a href="{{ path('app_lastfm_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+        </div>
+    </form>
+
+    {% if not lidarr_configured %}
+        <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+            Lidarr n'est pas configuré (<code>LIDARR_URL</code> / <code>LIDARR_API_KEY</code>) —
+            les actions Lidarr sont désactivées.
+        </div>
+    {% elseif not lidarr_reachable %}
+        <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+            Lidarr injoignable — actions désactivées le temps qu'il revienne.
+        </div>
+    {% endif %}
+
+    {% if rows is empty %}
+        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+            Aucun scrobble non matché pour ce filtre 🎉
+        </div>
+    {% else %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2 w-10">#</th>
+                    <th class="px-3 py-2">Artiste</th>
+                    <th class="px-3 py-2">Titre</th>
+                    <th class="px-3 py-2">Album</th>
+                    <th class="px-3 py-2 text-right">Scrobbles</th>
+                    <th class="px-3 py-2">Dernier joué</th>
+                    <th class="px-3 py-2">Lidarr</th>
+                    <th class="px-3 py-2 text-right">Actions</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for row in rows %}
+                    <tr>
+                        <td class="px-3 py-1.5 text-slate-400">{{ (page - 1) * 50 + loop.index }}</td>
+                        <td class="px-3 py-1.5">
+                            <a href="https://www.last.fm/music/{{ row.artist|url_encode }}"
+                               class="hover:underline" target="_blank" rel="noopener">{{ row.artist }}</a>
+                        </td>
+                        <td class="px-3 py-1.5">
+                            <a href="https://www.last.fm/music/{{ row.artist|url_encode }}/_/{{ row.title|url_encode }}"
+                               class="hover:underline" target="_blank" rel="noopener">{{ row.title }}</a>
+                        </td>
+                        <td class="px-3 py-1.5 text-slate-500">{{ row.album ?? '—' }}</td>
+                        <td class="px-3 py-1.5 text-right">{{ row.scrobbles }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500" title="{{ row.last_played|date('Y-m-d H:i:s') }}">
+                            {{ row.last_played|date('Y-m-d') }}
+                        </td>
+                        <td class="px-3 py-1.5">
+                            {% if not lidarr_configured or not lidarr_reachable %}
+                                <span class="text-xs text-slate-400">—</span>
+                            {% elseif row.lidarr_url %}
+                                <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
+                                   class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
+                                    ✓ déjà
+                                </a>
+                            {% else %}
+                                <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">✗ absent</span>
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            <a href="{{ path('app_lastfm_alias_new', {source_artist: row.artist, source_title: row.title}) }}"
+                               class="text-xs px-2 py-0.5 rounded bg-slate-700 text-white hover:bg-slate-800 mr-1"
+                               title="Créer un alias manuel pour ce scrobble">✏️ Mapper</a>
+                            {% if lidarr_configured and lidarr_reachable and not row.lidarr_url %}
+                                <form method="post" action="{{ path('app_lidarr_add_artist') }}"
+                                      class="inline"
+                                      onsubmit="return confirm('Ajouter « {{ row.artist|e('js') }} » à Lidarr ?');">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('lidarr_add') }}">
+                                    <input type="hidden" name="artist" value="{{ row.artist }}">
+                                    <input type="hidden" name="_redirect_unmatched" value="1">
+                                    <button type="submit"
+                                            class="text-xs px-2 py-0.5 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                        + Lidarr
+                                    </button>
+                                </form>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_lastfm_unmatched', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_lastfm_unmatched', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/Repository/LastFmImportTrackRepositoryTest.php
+++ b/tests/Repository/LastFmImportTrackRepositoryTest.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Repository\LastFmImportTrackRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+
+class LastFmImportTrackRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/lastfm-track-repo-' . uniqid() . '.db';
+        $this->conn = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => $this->dbPath,
+        ]);
+        $this->conn->executeStatement(<<<'SQL'
+            CREATE TABLE lastfm_import_track (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                run_history_id INTEGER NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                album VARCHAR(255) NULL,
+                mbid VARCHAR(64) NULL,
+                played_at DATETIME NOT NULL,
+                status VARCHAR(16) NOT NULL,
+                matched_media_file_id VARCHAR(255) NULL
+            )
+        SQL);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testAggregatesByArtistTitleAlbumAndCountsScrobbles(): void
+    {
+        // Same triplet 3×, another triplet 1×.
+        $this->insert('Gentleman', 'Berlin', null, '2026-01-01 10:00:00', 'unmatched');
+        $this->insert('Gentleman', 'Berlin', null, '2026-02-01 10:00:00', 'unmatched');
+        $this->insert('Gentleman', 'Berlin', null, '2026-03-01 10:00:00', 'unmatched');
+        $this->insert('Hozier', 'Take Me to Church', 'Hozier', '2026-01-15 10:00:00', 'unmatched');
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 1, 10);
+
+        $this->assertSame(2, $r['total']);
+        $this->assertSame('Gentleman', $r['items'][0]['artist']);
+        $this->assertSame('Berlin', $r['items'][0]['title']);
+        $this->assertNull($r['items'][0]['album']);
+        $this->assertSame(3, $r['items'][0]['scrobbles']);
+        $this->assertSame('2026-03-01 10:00:00', $r['items'][0]['last_played']->format('Y-m-d H:i:s'));
+
+        $this->assertSame('Hozier', $r['items'][1]['artist']);
+        $this->assertSame('Hozier', $r['items'][1]['album']);
+        $this->assertSame(1, $r['items'][1]['scrobbles']);
+    }
+
+    public function testIgnoresNonUnmatchedRows(): void
+    {
+        $this->insert('Inserted Artist', 'Track', null, '2026-01-01 10:00:00', 'inserted');
+        $this->insert('Duplicate Artist', 'Track', null, '2026-01-01 10:00:00', 'duplicate');
+        $this->insert('Skipped Artist', 'Track', null, '2026-01-01 10:00:00', 'skipped');
+        $this->insert('Unmatched Artist', 'Track', null, '2026-01-01 10:00:00', 'unmatched');
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 1, 10);
+
+        $this->assertSame(1, $r['total']);
+        $this->assertSame('Unmatched Artist', $r['items'][0]['artist']);
+    }
+
+    public function testFiltersByArtistCaseInsensitive(): void
+    {
+        $this->insert('Gentleman', 'Berlin', null, '2026-01-01 10:00:00', 'unmatched');
+        $this->insert('Hozier', 'Take Me to Church', null, '2026-01-01 10:00:00', 'unmatched');
+        $this->insert('Gent Other', 'Track', null, '2026-01-01 10:00:00', 'unmatched');
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, 'gent', null, null, 1, 10);
+        $this->assertSame(2, $r['total']);
+        $artists = array_column($r['items'], 'artist');
+        $this->assertContains('Gentleman', $artists);
+        $this->assertContains('Gent Other', $artists);
+    }
+
+    public function testFiltersByTitleAndAlbum(): void
+    {
+        $this->insert('Artist', 'Berlin', 'Album X', '2026-01-01 10:00:00', 'unmatched');
+        $this->insert('Artist', 'Berlin', 'Album Y', '2026-01-01 10:00:00', 'unmatched');
+        $this->insert('Artist', 'Other', 'Album X', '2026-01-01 10:00:00', 'unmatched');
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, 'berlin', null, 1, 10);
+        $this->assertSame(2, $r['total']);
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, 'album x', 1, 10);
+        $this->assertSame(2, $r['total']);
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, 'berlin', 'album x', 1, 10);
+        $this->assertSame(1, $r['total']);
+    }
+
+    public function testPagination(): void
+    {
+        // 5 distinct triplets, 1 scrobble each.
+        foreach (range(1, 5) as $i) {
+            $this->insert("Artist {$i}", 'Track', null, "2026-0{$i}-01 10:00:00", 'unmatched');
+        }
+
+        $page1 = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 1, 2);
+        $this->assertCount(2, $page1['items']);
+        $this->assertSame(5, $page1['total']);
+
+        $page2 = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 2, 2);
+        $this->assertCount(2, $page2['items']);
+
+        $page3 = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 3, 2);
+        $this->assertCount(1, $page3['items']);
+
+        // No overlap between pages.
+        $allTitles = array_merge(
+            array_column($page1['items'], 'artist'),
+            array_column($page2['items'], 'artist'),
+            array_column($page3['items'], 'artist'),
+        );
+        $this->assertCount(5, array_unique($allTitles));
+    }
+
+    public function testEmptyAlbumNormalizedToNull(): void
+    {
+        $this->insert('Artist', 'Track', '', '2026-01-01 10:00:00', 'unmatched');
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 1, 10);
+        $this->assertNull($r['items'][0]['album']);
+    }
+
+    public function testSortsByScrobblesDescThenLastPlayedDesc(): void
+    {
+        $this->insert('A', 'T', null, '2026-01-10 10:00:00', 'unmatched'); // 1 scrobble, played 2026-01-10
+        $this->insert('B', 'T', null, '2026-01-01 10:00:00', 'unmatched'); // 2 scrobbles
+        $this->insert('B', 'T', null, '2026-01-02 10:00:00', 'unmatched');
+        $this->insert('C', 'T', null, '2026-01-15 10:00:00', 'unmatched'); // 1 scrobble, played 2026-01-15 (more recent than A)
+
+        $r = LastFmImportTrackRepository::queryUnmatchedAggregated($this->conn, null, null, null, 1, 10);
+
+        $this->assertSame('B', $r['items'][0]['artist']); // 2 scrobbles wins
+        $this->assertSame('C', $r['items'][1]['artist']); // 1 scrobble, more recent
+        $this->assertSame('A', $r['items'][2]['artist']); // 1 scrobble, older
+    }
+
+    private function insert(string $artist, string $title, ?string $album, string $playedAt, string $status): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO lastfm_import_track (run_history_id, artist, title, album, played_at, status) VALUES (?, ?, ?, ?, ?, ?)',
+            [1, $artist, $title, $album, $playedAt, $status]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Audit cumulé de tous les scrobbles `unmatched` sur une seule page, plutôt qu'à devoir ouvrir chaque run un par un via `/history/{id}`. Sur le dataset local : **2 176 groupes (artist, title, album) distincts** en unmatched cumulés.

## Page

- `GET /lastfm/unmatched` (`app_lastfm_unmatched`)
- Filtres GET : `artist`, `title`, `album` (substring case-insensitive)
- Pagination 50 par page
- Tableau 8 colonnes : #, Artiste, Titre, Album, # scrobbles, Dernier joué, Statut Lidarr, Actions
- Statut Lidarr ✓/✗/— par ligne (même pattern que `HistoryController::buildUnmatchedArtists`)

## Actions par ligne

- **« ✏️ Mapper »** → `app_lastfm_alias_new` avec `source_artist=...&source_title=...` (pattern existant)
- **« + Lidarr »** → POST `app_lidarr_add_artist` avec nouveau hidden field `_redirect_unmatched=1` ; `LidarrController` est étendu pour revenir sur `/lastfm/unmatched` après ajout (au lieu du fallback `/lastfm/import`)

## Repository

- `findUnmatchedAggregated()` (méthode d'instance, branchée à l'EM)
- `queryUnmatchedAggregated()` (helper statique exposé pour la testabilité — prend un `Doctrine\DBAL\Connection` directement, teste la SQL sans booter Doctrine ORM)
- SQL DBAL native : `GROUP BY artist, title, album`, `COUNT(*)`, `MAX(played_at)`. Compteur séparé via subquery.
- Tri : `scrobbles DESC, last_played DESC` (les unmatched les plus fréquents et récents en haut)

## UI annexe

- Entrée « Unmatched » dans le menu déroulant Last.fm (`templates/base.html.twig`)
- Lien « Voir la liste détaillée → » dans la carte « Re-tenter le matching cumulé » sur `/lastfm/import`

## Test plan

- [x] 7 nouveaux tests sur `queryUnmatchedAggregated()` : agrégation, filtres case-insensitive, combinaison de filtres, pagination, tri (scrobbles DESC puis last_played DESC), exclusion des non-unmatched, album vide → null.
- [x] `composer ci` → 191 tests, 483 assertions, 0 failure.
- [x] Smoke test sur la lib locale : 2 176 groupes affichés, filtre `artist=gentleman` retourne 87 groupes, top liste cohérent (« La Ruda Salska / Marilyne » 43 scrobbles en tête).
- [x] Route `app_lastfm_unmatched` enregistrée (`bin/console debug:router`).

## Critical files

- **Nouveaux** :
  - `src/Controller/LastFmUnmatchedController.php`
  - `templates/lastfm/unmatched.html.twig`
  - `tests/Repository/LastFmImportTrackRepositoryTest.php`
- **Modifiés** :
  - `src/Repository/LastFmImportTrackRepository.php` — `findUnmatchedAggregated()` + `queryUnmatchedAggregated()`
  - `src/Controller/LidarrController.php` — gère `_redirect_unmatched`
  - `templates/base.html.twig` — entrée menu
  - `templates/lastfm/import.html.twig` — lien depuis la carte cumulative

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)