### PR TITLE
feat(dashboard): tableau des 10 derniers runs (closes #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   helper statique testable `queryUnmatchedAggregated()`. Lien depuis
   la carte « Re-tenter le matching cumulé » sur `/lastfm/import`.
   Closes #56.
+- Bloc **« Derniers runs »** sur le dashboard (`/`) : tableau des 10
+  derniers `RunHistory` (tous types confondus), affiché juste après les
+  cards de santé. Reprend les colonnes et badges de `/history`
+  (type, label, statut emerald/rose/amber, démarré, durée, métriques)
+  + lien « Détails » par ligne et lien « Voir tout l'historique → »
+  vers `/history`. Donne un coup d'œil immédiat sur l'activité récente
+  du tool (imports Last.fm, rematches, recalculs de stats, runs de
+  playlists, sync love) sans avoir à quitter l'accueil. Closes #58.
 - Commande **`app:lastfm:rematch`** (+ UI sur `/history/{id}` et
   `/lastfm/import`, + cron via `LASTFM_REMATCH_SCHEDULE`) qui ré-applique
   la cascade de matching courante sur les rows `lastfm_import_track`

--- a/README.md
+++ b/README.md
@@ -557,6 +557,11 @@ La page `/history` (lien dans la nav) liste les exécutions avec :
 
 Filtres par type/statut + recherche libre + pagination (50/page).
 
+Le dashboard (`/`) affiche en plus un bloc « Derniers runs » avec les
+10 dernières entrées (tous types confondus) pour repérer en un coup
+d'œil les erreurs récentes, avec un lien direct vers la page
+complète.
+
 Une commande `app:history:purge` supprime les entrées plus vieilles que
 `RUN_HISTORY_RETENTION_DAYS` (défaut 90). Elle est ajoutée
 automatiquement au crontab par `app:cron:dump` (1×/jour à 4h30).

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -5,6 +5,7 @@ namespace App\Controller;
 use App\Generator\GeneratorRegistry;
 use App\Navidrome\NavidromeRepository;
 use App\Repository\PlaylistDefinitionRepository;
+use App\Repository\RunHistoryRepository;
 use App\Service\SettingsService;
 use App\Subsonic\SubsonicClient;
 use Cron\CronExpression;
@@ -25,6 +26,7 @@ class DashboardController extends AbstractController
         NavidromeRepository $navidrome,
         SubsonicClient $subsonic,
         SettingsService $settings,
+        RunHistoryRepository $runHistory,
     ): Response {
         $q = trim((string) $request->query->get('q', ''));
         $enabledRaw = $request->query->get('enabled');
@@ -64,9 +66,12 @@ class DashboardController extends AbstractController
             'subsonic' => $subsonic->ping(),
         ];
 
+        $recentRuns = $runHistory->findFilteredPaginated([], 1, 10)['items'];
+
         return $this->render('dashboard/index.html.twig', [
             'rows' => $rows,
             'health' => $health,
+            'recent_runs' => $recentRuns,
             'default_limit' => $settings->getDefaultLimit(),
             'default_template' => $settings->getDefaultNameTemplate(),
             'filters' => [

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -38,6 +38,58 @@
         </div>
     </div>
 
+    {# ---------- Recent runs ---------- #}
+    <div class="bg-white shadow rounded overflow-hidden mb-6">
+        <div class="flex items-center justify-between px-3 py-2 bg-slate-100 border-b">
+            <h2 class="text-sm font-semibold text-slate-700">Derniers runs</h2>
+            <a href="{{ path('app_history') }}" class="text-xs text-sky-700 hover:underline">Voir tout l'historique →</a>
+        </div>
+        {% if recent_runs is empty %}
+            <div class="px-3 py-4 text-sm text-slate-500 text-center">Aucun run pour l'instant.</div>
+        {% else %}
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50 text-slate-600 text-left text-xs uppercase">
+                <tr>
+                    <th class="px-3 py-1.5">Type</th>
+                    <th class="px-3 py-1.5">Label</th>
+                    <th class="px-3 py-1.5">Statut</th>
+                    <th class="px-3 py-1.5">Démarré</th>
+                    <th class="px-3 py-1.5 text-right">Durée</th>
+                    <th class="px-3 py-1.5">Métriques</th>
+                    <th class="px-3 py-1.5 text-right"></th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for entry in recent_runs %}
+                    <tr>
+                        <td class="px-3 py-1.5 font-mono text-xs">{{ entry.type }}</td>
+                        <td class="px-3 py-1.5">{{ entry.label }}</td>
+                        <td class="px-3 py-1.5">
+                            {% set badge = entry.status == 'success' ? 'bg-emerald-100 text-emerald-800'
+                                : entry.status == 'error' ? 'bg-rose-100 text-rose-800'
+                                : 'bg-amber-100 text-amber-800' %}
+                            <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ entry.status }}</span>
+                        </td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">{{ entry.startedAt|date('Y-m-d H:i:s') }}</td>
+                        <td class="px-3 py-1.5 text-right text-xs text-slate-500">
+                            {% if entry.durationMs is not null %}{{ (entry.durationMs / 1000)|number_format(2) }}s{% else %}—{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">
+                            {% if entry.metrics %}
+                                {% for k, v in entry.metrics|filter(v => v is not null and v is not iterable and v != '') %}{{ k }}={{ v }} {% endfor %}
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-right">
+                            <a href="{{ path('app_history_detail', {id: entry.id}) }}"
+                               class="text-xs text-sky-700 hover:underline">Détails</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+
     {# ---------- Filters bar ---------- #}
     <form method="get" class="bg-white shadow rounded p-3 mb-4 flex flex-wrap items-end gap-3 text-sm">
         <div class="flex-1 min-w-[200px]">


### PR DESCRIPTION
## Summary

- Nouveau bloc **« Derniers runs »** sur le dashboard (`/`) : tableau des 10 derniers `RunHistory` (tous types confondus), affiché entre les cards de santé et la barre de filtres playlists.
- Réutilise `RunHistoryRepository::findFilteredPaginated([], 1, 10)['items']` (tri DESC déjà fait, aucun nouveau SQL) et le markup de `templates/history/index.html.twig:60-83` (badges emerald/rose/amber, durée en secondes, métriques filtrées).
- Lien « Détails » par ligne + lien global « Voir tout l'historique → » vers `/history`. Placeholder discret si la table est vide.

Closes #58.

## Test plan

- [x] `composer ci` vert (phpcs 131/131, phpstan 0 erreur, phpunit 184 tests / 457 assertions)
- [x] `bin/console lint:twig templates/dashboard/index.html.twig` OK
- [ ] Rendu manuel sur instance Lando : tableau ≤ 10 lignes, tri DESC, badges colorés cohérents avec `/history`, lien « Voir tout l'historique » mène à `/history`, placeholder visible si base vide.
- [ ] Vérifier le rendu avec au moins un run de chaque type (`app:playlist:run`, `app:stats:compute`, `app:lastfm:rematch`, etc.).

https://claude.ai/code/session_01WvavJRudaTC4uMqREnF8gA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvavJRudaTC4uMqREnF8gA)_