### PR TITLE
feat(tagging): page d'audit des tracks Navidrome sans MBID + rescan

### DIFF
--- a/.env
+++ b/.env
@@ -52,6 +52,16 @@ LIDARR_MONITOR=all
 RUN_HISTORY_RETENTION_DAYS=90
 ###< Run history retention ###
 
+###> Beets queue (file de chemins pour un tagger externe) ###
+# Chemin (côté container navidrome-tools) d'un fichier dans lequel l'app
+# appendit les chemins absolus des tracks à tagger via la page
+# /tagging/missing-mbid. Vide = bouton « pousser dans la queue » masqué.
+# Côté container beets, monter le même volume et lancer un cron type :
+#   beet import -A --quiet $(cat /shared/queue.txt) && : > /shared/queue.txt
+# (ou variantes avec flock + truncate atomique).
+BEETS_QUEUE_PATH=
+###< Beets queue ###
+
 ###> Album/artist covers ###
 # Local on-disk cache for cover art proxied from Navidrome's Subsonic API.
 # Mount a dedicated Docker volume here in prod (default `var/covers`).

--- a/.env.dist
+++ b/.env.dist
@@ -53,6 +53,17 @@ LIDARR_MONITOR=all
 RUN_HISTORY_RETENTION_DAYS=90
 ###< Run history retention ###
 
+###> Beets queue (optional — file de chemins pour tagger externe) ###
+# Path (inside the navidrome-tools container) of a file the app
+# appends absolute track paths to, via the /tagging/missing-mbid page.
+# Empty = the "push to beets queue" button is hidden. On the beets
+# host, mount the same volume and run a cron that consumes the file:
+#   beet import -A --quiet $(cat /shared/queue.txt) && : > /shared/queue.txt
+# (or atomic flock + truncate variants). Architecture is read-only on
+# /music for navidrome-tools — only this queue file needs RW.
+BEETS_QUEUE_PATH=
+###< Beets queue ###
+
 ###> Album/artist covers (proxy + local disk cache) ###
 # Local cache directory for cover art binaries fetched from Navidrome.
 # In production, mount a dedicated Docker volume on this path.

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -39,6 +39,10 @@ services:
         LIDARR_METADATA_PROFILE_ID: 1
         LIDARR_MONITOR: all
         RUN_HISTORY_RETENTION_DAYS: '90'
+        # File de chemins consommée par un beets externe (cron côté hôte
+        # qui partage le même volume). Vide = bouton « pousser dans la
+        # queue beets » masqué sur /tagging/missing-mbid.
+        BEETS_QUEUE_PATH: ''
         # Last.fm API key — optional. Fallback for the /lastfm/import form
         # and the app:lastfm:import CLI when --api-key is not passed.
         # Get one at https://www.last.fm/api/account/create

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+- Page `/tagging/missing-mbid` : audit des morceaux Navidrome dont
+  `mbz_track_id` ET `mbz_recording_id` sont vides. Filtres
+  artiste/album, pagination, export CSV (id, path, artist,
+  album_artist, album, title, year) à piper dans un tagger externe
+  type `beet import -A` ou MusicBrainz Picard. Bouton
+  « Rescan Navidrome » qui appelle `startScan` via Subsonic
+  (`POST /tagging/missing-mbid/rescan`) pour propager les nouveaux
+  MBIDs sans attendre le scan planifié. Architecture délibérément
+  read-only : navidrome-tools ne touche jamais aux fichiers audio.
+  Card santé sur le dashboard + entrée « Tagging » dans la nav. Run
+  history type `navidrome-rescan`.
+- `NavidromeRepository::findMediaFilesWithoutMbid()` /
+  `countMediaFilesWithoutMbid()` : version-agnostiques, probe
+  `mbz_track_id` et `mbz_recording_id` selon les colonnes présentes.
+- `SubsonicClient::startScan(bool $fullScan = false)` qui hit
+  `/rest/startScan.view` (full-scan optionnel via `?fullScan=true`).
+
 ### Changed
 - Doc : recommandation explicite d'activer
   `LASTFM_FUZZY_MAX_DISTANCE=2` pour les imports one-shot Last.fm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   read-only : navidrome-tools ne touche jamais aux fichiers audio.
   Card santé sur le dashboard + entrée « Tagging » dans la nav. Run
   history type `navidrome-rescan`.
+- Queue beets : nouvelle env var `BEETS_QUEUE_PATH` (vide par
+  défaut). Quand configurée, un bouton « 📋 Pousser dans la queue
+  beets » apparaît sur `/tagging/missing-mbid` et appendit les
+  chemins filtrés (jusqu'à 5 000) dans un fichier protégé par
+  `flock` que tu fais consommer par un cron beets côté hôte
+  (`beet import -A`). Bandeau d'info indique la taille courante
+  de la queue. Run history type `beets-queue-push`. Le dossier de
+  musique reste read-only pour navidrome-tools — seul le fichier
+  de queue est en RW. Doc README + cron type fourni.
 - `NavidromeRepository::findMediaFilesWithoutMbid()` /
   `countMediaFilesWithoutMbid()` : version-agnostiques, probe
   `mbz_track_id` et `mbz_recording_id` selon les colonnes présentes.

--- a/README.md
+++ b/README.md
@@ -582,6 +582,30 @@ rester monté `:ro`). Le workflow est :
 Une card « Tracks sans MBID » sur le dashboard affiche le compteur
 courant et un raccourci vers la page.
 
+### Queue beets (intégration semi-automatique)
+
+Si tu préfères ne pas copier-coller le CSV à chaque fois, configure
+`BEETS_QUEUE_PATH` (ex. `/shared/beets-queue.txt`). La page expose
+alors un bouton **« 📋 Pousser dans la queue beets »** qui appendit
+les chemins filtrés dans ce fichier sous `flock` (sûr en
+concurrence). Côté hôte beets, monter le même volume et lancer un
+cron qui consomme la queue, par exemple :
+
+```bash
+# /etc/cron.d/beets-queue : toutes les 15 min
+*/15 * * * * beets   ( flock -x 9 ; \
+   [ -s /shared/beets-queue.txt ] || exit 0 ; \
+   mv /shared/beets-queue.txt /shared/beets-queue.processing ; \
+ ) 9>/shared/beets-queue.lock && \
+ beet import -A --quiet $(cat /shared/beets-queue.processing) && \
+ rm /shared/beets-queue.processing
+```
+
+Avec ce pattern, navidrome-tools ne touche **que** le fichier de
+queue (RW), `/music` reste `:ro`. Le push est tracé dans
+`/history` (type `beets-queue-push`) et le bandeau de la page
+affiche la taille courante de la queue.
+
 ## Historique des runs cron
 
 Tous les jobs longs sont audités dans la table locale `run_history`.

--- a/README.md
+++ b/README.md
@@ -546,6 +546,42 @@ Le service :
 3. Si Lidarr répond que l'artiste existe déjà, l'UI affiche un flash
    info (« déjà présent ») au lieu d'une erreur.
 
+## Tracks sans MBID
+
+La page **`/tagging/missing-mbid`** (menu **Tagging**) liste les
+morceaux Navidrome dont les colonnes `mbz_track_id` ET
+`mbz_recording_id` sont vides. Sans MBID, le palier le plus fiable de
+la cascade de matching Last.fm est inutilisable, et l'outil retombe
+sur les paliers (artiste, titre, album) + fuzzy, plus fragiles.
+
+L'architecture est volontairement read-only : navidrome-tools
+**n'écrit jamais** dans tes fichiers audio (le volume `/music` peut
+rester monté `:ro`). Le workflow est :
+
+1. **Audit** sur la page : filtres artiste/album, pagination, voir
+   les chemins absolus.
+2. **Export CSV** (bouton « ⬇ Export CSV ») : télécharge la liste
+   des chemins (id, path, artist, album, title…) que tu pipes dans
+   un tagger sur la machine où ton dossier de musique est en
+   lecture/écriture. Exemples :
+   - **beets** :
+     ```bash
+     # extrait la colonne path et nourris beet
+     tail -n +2 missing-mbid-2026-05-02.csv \
+       | awk -F'"' '{print $4}' \
+       | xargs -d '\n' beet import -A --quiet
+     ```
+   - **MusicBrainz Picard** : ouvre Picard, drag-and-drop le dossier
+     de musique, lance « Scan » puis « Save ».
+3. **Rescan Navidrome** (bouton « ↻ Rescan Navidrome ») : déclenche
+   `startScan` via Subsonic une fois le tagging fini. Les nouveaux
+   MBIDs apparaissent dans `media_file.mbz_track_id` sans attendre
+   le scan planifié. Logué dans `/history` sous le type
+   `navidrome-rescan`.
+
+Une card « Tracks sans MBID » sur le dashboard affiche le compteur
+courant et un raccourci vers la page.
+
 ## Historique des runs cron
 
 Tous les jobs longs sont audités dans la table locale `run_history`.

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
     lastfm.fuzzy_max_distance: '%env(int:LASTFM_FUZZY_MAX_DISTANCE)%'
     lastfm.love_sync_schedule: '%env(LASTFM_LOVE_SYNC_SCHEDULE)%'
     lastfm.rematch_schedule: '%env(LASTFM_REMATCH_SCHEDULE)%'
+    beets.queue_path: '%env(resolve:BEETS_QUEUE_PATH)%'
     lidarr.url: '%env(LIDARR_URL)%'
     lidarr.api_key: '%env(LIDARR_API_KEY)%'
     lidarr.root_folder_path: '%env(LIDARR_ROOT_FOLDER_PATH)%'
@@ -112,3 +113,7 @@ services:
     App\Service\CoverArtCache:
         arguments:
             $cacheRoot: '%app.covers_cache_path%'
+
+    App\Service\BeetsQueueService:
+        arguments:
+            $queuePath: '%beets.queue_path%'

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -25,6 +25,10 @@ services:
       LIDARR_METADATA_PROFILE_ID: ${LIDARR_METADATA_PROFILE_ID:-1}
       LIDARR_MONITOR: ${LIDARR_MONITOR:-all}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
+      # File de chemins consommée par un beets externe (cron côté hôte
+      # qui partage le même volume). Vide = bouton masqué sur
+      # /tagging/missing-mbid.
+      BEETS_QUEUE_PATH: ${BEETS_QUEUE_PATH:-}
       LASTFM_API_KEY: ${LASTFM_API_KEY:-}
       LASTFM_API_SECRET: ${LASTFM_API_SECRET:-}
       LASTFM_USER: ${LASTFM_USER:-}
@@ -65,6 +69,10 @@ services:
       LIDARR_METADATA_PROFILE_ID: ${LIDARR_METADATA_PROFILE_ID:-1}
       LIDARR_MONITOR: ${LIDARR_MONITOR:-all}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
+      # File de chemins consommée par un beets externe (cron côté hôte
+      # qui partage le même volume). Vide = bouton masqué sur
+      # /tagging/missing-mbid.
+      BEETS_QUEUE_PATH: ${BEETS_QUEUE_PATH:-}
       LASTFM_API_KEY: ${LASTFM_API_KEY:-}
       LASTFM_API_SECRET: ${LASTFM_API_SECRET:-}
       LASTFM_USER: ${LASTFM_USER:-}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,7 @@
         <env name="LIDARR_METADATA_PROFILE_ID" value="1"/>
         <env name="LIDARR_MONITOR" value="all"/>
         <env name="RUN_HISTORY_RETENTION_DAYS" value="90"/>
+        <env name="BEETS_QUEUE_PATH" value=""/>
         <env name="LASTFM_API_KEY" value=""/>
         <env name="LASTFM_API_SECRET" value=""/>
         <env name="LASTFM_USER" value=""/>

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -64,6 +64,7 @@ class DashboardController extends AbstractController
             'has_scrobbles' => $hasScrobbles,
             'scrobbles_count' => $hasScrobbles ? $navidrome->getScrobblesCount() : null,
             'subsonic' => $subsonic->ping(),
+            'missing_mbid_count' => $navidrome->isAvailable() ? $navidrome->countMediaFilesWithoutMbid() : null,
         ];
 
         $recentRuns = $runHistory->findFilteredPaginated([], 1, 10)['items'];

--- a/src/Controller/MissingMbidController.php
+++ b/src/Controller/MissingMbidController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Navidrome\NavidromeRepository;
+use App\Service\BeetsQueueService;
 use App\Service\NavidromeRescanService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -29,6 +30,7 @@ class MissingMbidController extends AbstractController
     public function __construct(
         private readonly NavidromeRepository $navidrome,
         private readonly NavidromeRescanService $rescan,
+        private readonly BeetsQueueService $beetsQueue,
     ) {
     }
 
@@ -61,6 +63,8 @@ class MissingMbidController extends AbstractController
             'page' => $page,
             'total_pages' => $totalPages,
             'filters' => array_filter($filters, static fn ($v) => $v !== null),
+            'beets_queue_configured' => $this->beetsQueue->isConfigured(),
+            'beets_queue_pending' => $this->beetsQueue->pendingCount(),
         ]);
     }
 
@@ -110,6 +114,55 @@ class MissingMbidController extends AbstractController
         ));
 
         return $response;
+    }
+
+    #[Route('/tagging/missing-mbid/queue', name: 'app_tagging_missing_mbid_queue', methods: ['POST'])]
+    public function queue(Request $request): Response
+    {
+        $token = (string) $request->request->get('_token', '');
+        if (!$this->isCsrfTokenValid('missing_mbid_queue', $token)) {
+            $this->addFlash('error', 'Jeton CSRF invalide.');
+
+            return $this->redirectToRoute('app_tagging_missing_mbid');
+        }
+
+        if (!$this->beetsQueue->isConfigured()) {
+            $this->addFlash('error', 'BEETS_QUEUE_PATH n\'est pas configuré.');
+
+            return $this->redirectToRoute('app_tagging_missing_mbid');
+        }
+
+        $artistFilter = trim((string) $request->request->get('artist', '')) ?: null;
+        $albumFilter = trim((string) $request->request->get('album', '')) ?: null;
+        $limit = max(1, min(5000, (int) $request->request->get('limit', 1000)));
+
+        $rows = $this->navidrome->findMediaFilesWithoutMbid(
+            artistFilter: $artistFilter,
+            albumFilter: $albumFilter,
+            limit: $limit,
+            offset: 0,
+        );
+
+        $paths = array_values(array_filter(
+            array_map(static fn (array $r) => (string) $r['path'], $rows),
+            static fn (string $p) => $p !== '',
+        ));
+
+        try {
+            $run = $this->beetsQueue->push($paths, reason: 'missing-mbid-page');
+            $submitted = (int) ($run->getMetrics()['submitted'] ?? 0);
+            $this->addFlash(
+                $submitted > 0 ? 'success' : 'info',
+                sprintf('%d chemin%s ajouté%s à la queue beets.', $submitted, $submitted > 1 ? 's' : '', $submitted > 1 ? 's' : ''),
+            );
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur push beets queue : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_tagging_missing_mbid', array_filter([
+            'artist' => $artistFilter,
+            'album' => $albumFilter,
+        ]));
     }
 
     #[Route('/tagging/missing-mbid/rescan', name: 'app_tagging_missing_mbid_rescan', methods: ['POST'])]

--- a/src/Controller/MissingMbidController.php
+++ b/src/Controller/MissingMbidController.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Controller;
+
+use App\Navidrome\NavidromeRepository;
+use App\Service\NavidromeRescanService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Audit page for Navidrome tracks whose MBID columns are empty —
+ * the canonical input for an external tagger like beets / Picard.
+ *
+ * Architecture is deliberately decoupled: navidrome-tools never writes to
+ * the music files (the volume can stay :ro). The page lists the tracks,
+ * exports the absolute paths as CSV (which the user pipes into
+ * `beet import -A …` on their tagger host), and exposes a "rescan"
+ * button that triggers Navidrome via the Subsonic API once tagging is done
+ * — so the new MBIDs propagate to media_file.mbz_track_id without waiting
+ * for Navidrome's scheduled scan.
+ */
+class MissingMbidController extends AbstractController
+{
+    private const PER_PAGE = 50;
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly NavidromeRescanService $rescan,
+    ) {
+    }
+
+    #[Route('/tagging/missing-mbid', name: 'app_tagging_missing_mbid', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $filters = [
+            'artist' => trim((string) $request->query->get('artist', '')) ?: null,
+            'album' => trim((string) $request->query->get('album', '')) ?: null,
+        ];
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $total = $this->navidrome->countMediaFilesWithoutMbid(
+            artistFilter: $filters['artist'],
+            albumFilter: $filters['album'],
+        );
+        $totalPages = (int) max(1, ceil(max(1, $total) / self::PER_PAGE));
+        $page = min($page, $totalPages);
+
+        $rows = $this->navidrome->findMediaFilesWithoutMbid(
+            artistFilter: $filters['artist'],
+            albumFilter: $filters['album'],
+            limit: self::PER_PAGE,
+            offset: ($page - 1) * self::PER_PAGE,
+        );
+
+        return $this->render('tagging/missing_mbid.html.twig', [
+            'rows' => $rows,
+            'total' => $total,
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => array_filter($filters, static fn ($v) => $v !== null),
+        ]);
+    }
+
+    /**
+     * Streams the full unfiltered (or filtered, if query string is present)
+     * list of paths as CSV so the user can pipe it into beets/Picard on
+     * their tagger host. Format: one row per track with id, path, artist,
+     * album, title, year. Limit clamped to 5000 to keep memory bounded.
+     */
+    #[Route('/tagging/missing-mbid/export.csv', name: 'app_tagging_missing_mbid_export', methods: ['GET'])]
+    public function export(Request $request): StreamedResponse
+    {
+        $artistFilter = trim((string) $request->query->get('artist', '')) ?: null;
+        $albumFilter = trim((string) $request->query->get('album', '')) ?: null;
+        $limit = max(1, min(5000, (int) $request->query->get('limit', 1000)));
+
+        $rows = $this->navidrome->findMediaFilesWithoutMbid(
+            artistFilter: $artistFilter,
+            albumFilter: $albumFilter,
+            limit: $limit,
+            offset: 0,
+        );
+
+        $response = new StreamedResponse(function () use ($rows): void {
+            $out = fopen('php://output', 'wb');
+            if ($out === false) {
+                return;
+            }
+            fputcsv($out, ['id', 'path', 'artist', 'album_artist', 'album', 'title', 'year'], ',', '"', '');
+            foreach ($rows as $row) {
+                fputcsv($out, [
+                    $row['id'],
+                    $row['path'],
+                    $row['artist'],
+                    $row['album_artist'],
+                    $row['album'],
+                    $row['title'],
+                    $row['year'],
+                ], ',', '"', '');
+            }
+            fclose($out);
+        });
+        $response->headers->set('Content-Type', 'text/csv; charset=utf-8');
+        $response->headers->set('Content-Disposition', sprintf(
+            'attachment; filename="missing-mbid-%s.csv"',
+            (new \DateTimeImmutable())->format('Y-m-d'),
+        ));
+
+        return $response;
+    }
+
+    #[Route('/tagging/missing-mbid/rescan', name: 'app_tagging_missing_mbid_rescan', methods: ['POST'])]
+    public function rescan(Request $request): Response
+    {
+        $token = (string) $request->request->get('_token', '');
+        if (!$this->isCsrfTokenValid('missing_mbid_rescan', $token)) {
+            $this->addFlash('error', 'Jeton CSRF invalide.');
+
+            return $this->redirectToRoute('app_tagging_missing_mbid');
+        }
+
+        try {
+            $this->rescan->rescan(reason: 'missing-mbid-page');
+            $this->addFlash('success', 'Rescan Navidrome déclenché.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur déclenchement rescan : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_tagging_missing_mbid');
+    }
+}

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -19,6 +19,7 @@ class RunHistory
     public const TYPE_LASTFM_LOVE_SYNC = 'lastfm-love-sync';
     public const TYPE_LASTFM_REMATCH = 'lastfm-rematch';
     public const TYPE_NAVIDROME_RESCAN = 'navidrome-rescan';
+    public const TYPE_BEETS_QUEUE_PUSH = 'beets-queue-push';
 
     public const STATUS_SUCCESS = 'success';
     public const STATUS_ERROR = 'error';

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -18,6 +18,7 @@ class RunHistory
     public const TYPE_LASTFM_IMPORT = 'lastfm-import';
     public const TYPE_LASTFM_LOVE_SYNC = 'lastfm-love-sync';
     public const TYPE_LASTFM_REMATCH = 'lastfm-rematch';
+    public const TYPE_NAVIDROME_RESCAN = 'navidrome-rescan';
 
     public const STATUS_SUCCESS = 'success';
     public const STATUS_ERROR = 'error';

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -937,6 +937,142 @@ class NavidromeRepository
     }
 
     /**
+     * List media_files where every MBID column known to this Navidrome version
+     * is either NULL or empty — i.e. tracks that the Last.fm matcher cannot
+     * resolve via the most reliable path. Used by the /tagging/missing-mbid
+     * audit page and by `app:beets:tag-missing` to feed beets a worklist.
+     *
+     * Filters and pagination:
+     *   - $artistFilter / $albumFilter: case-insensitive substring (LIKE
+     *     %term%) on artist / album. Empty / null = no filter.
+     *   - $limit: max rows returned. Bound to [1, 1000].
+     *   - $offset: SQL offset for pagination.
+     *
+     * Returned shape exposes the optional `path` column when Navidrome stores
+     * it (every modern version does), so callers can hand the absolute file
+     * paths to an external tagger like beets.
+     *
+     * @return list<array{
+     *     id: string,
+     *     path: string,
+     *     artist: string,
+     *     album_artist: string,
+     *     album: string,
+     *     title: string,
+     *     year: int
+     * }>
+     */
+    public function findMediaFilesWithoutMbid(
+        ?string $artistFilter = null,
+        ?string $albumFilter = null,
+        int $limit = 100,
+        int $offset = 0,
+    ): array {
+        $where = $this->missingMbidWhereClause();
+        if ($where === null) {
+            return [];
+        }
+
+        $columns = $this->mediaFileColumns();
+        $hasPath = in_array('path', $columns, true);
+        $select = sprintf(
+            'id, %s AS path, artist, album_artist, album, title, year',
+            $hasPath ? 'path' : "''",
+        );
+
+        $params = [];
+        $types = [];
+        $clauses = [$where];
+        if ($artistFilter !== null && trim($artistFilter) !== '') {
+            $clauses[] = 'LOWER(artist) LIKE :artist';
+            $params['artist'] = '%' . strtolower(trim($artistFilter)) . '%';
+        }
+        if ($albumFilter !== null && trim($albumFilter) !== '') {
+            $clauses[] = 'LOWER(album) LIKE :album';
+            $params['album'] = '%' . strtolower(trim($albumFilter)) . '%';
+        }
+
+        $limit = max(1, min(1000, $limit));
+        $offset = max(0, $offset);
+        $params['lim'] = $limit;
+        $params['off'] = $offset;
+        $types['lim'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        $types['off'] = \Doctrine\DBAL\ParameterType::INTEGER;
+
+        $sql = sprintf(
+            'SELECT %s FROM media_file WHERE %s ORDER BY artist, album, title LIMIT :lim OFFSET :off',
+            $select,
+            implode(' AND ', $clauses),
+        );
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r): array => [
+            'id' => (string) $r['id'],
+            'path' => (string) ($r['path'] ?? ''),
+            'artist' => (string) ($r['artist'] ?? ''),
+            'album_artist' => (string) ($r['album_artist'] ?? ''),
+            'album' => (string) ($r['album'] ?? ''),
+            'title' => (string) ($r['title'] ?? ''),
+            'year' => (int) ($r['year'] ?? 0),
+        ], $rows);
+    }
+
+    /**
+     * Counts every media_file row whose MBID columns are all NULL or empty.
+     * Same filter semantics as {@see findMediaFilesWithoutMbid()}; used by
+     * the dashboard card and by paginated UIs.
+     */
+    public function countMediaFilesWithoutMbid(
+        ?string $artistFilter = null,
+        ?string $albumFilter = null,
+    ): int {
+        $where = $this->missingMbidWhereClause();
+        if ($where === null) {
+            return 0;
+        }
+
+        $params = [];
+        $clauses = [$where];
+        if ($artistFilter !== null && trim($artistFilter) !== '') {
+            $clauses[] = 'LOWER(artist) LIKE :artist';
+            $params['artist'] = '%' . strtolower(trim($artistFilter)) . '%';
+        }
+        if ($albumFilter !== null && trim($albumFilter) !== '') {
+            $clauses[] = 'LOWER(album) LIKE :album';
+            $params['album'] = '%' . strtolower(trim($albumFilter)) . '%';
+        }
+
+        $sql = sprintf('SELECT COUNT(*) FROM media_file WHERE %s', implode(' AND ', $clauses));
+
+        return (int) $this->connection()->fetchOne($sql, $params);
+    }
+
+    /**
+     * Build a WHERE fragment matching rows where every MBID column known to
+     * this Navidrome version is NULL or ''. Returns null when none of the
+     * MBID columns exist (e.g. a stub fixture without MBID columns) — caller
+     * should treat that as « nothing to do ».
+     */
+    private function missingMbidWhereClause(): ?string
+    {
+        $columns = $this->mediaFileColumns();
+        $candidates = array_values(array_filter(
+            ['mbz_track_id', 'mbz_recording_id'],
+            static fn (string $c) => in_array($c, $columns, true),
+        ));
+        if ($candidates === []) {
+            return null;
+        }
+
+        return implode(' AND ', array_map(
+            static fn (string $c) => sprintf("(%s IS NULL OR %s = '')", $c, $c),
+            $candidates,
+        ));
+    }
+
+    /**
      * Find a media_file by normalised (artist, title) pair. Case- and whitespace-
      * insensitive. Returns null when there is no match. When several rows share
      * the same (artist, title) — e.g. the same song shipped on a studio album

--- a/src/Service/BeetsQueueService.php
+++ b/src/Service/BeetsQueueService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\RunHistory;
+
+/**
+ * Appends absolute file paths to a queue file consumed by an external beets
+ * cron — the file is the only RW resource navidrome-tools needs ; /music
+ * stays read-only on this side. Concurrent writers and the beets-side
+ * consumer coexist safely thanks to advisory file locks (`flock`).
+ *
+ * Format : one absolute path per line, UTF-8, no escaping (paths with
+ * embedded newlines aren't supported — neither beets nor most filesystems
+ * support them anyway). Duplicate suppression is delegated to the beets
+ * `import.incremental` flag — pushing a path twice is harmless.
+ *
+ * Recommended cron on the beets side (atomic mv + flock) :
+ *
+ *     ( flock -x 9
+ *       [ -s /shared/queue.txt ] || exit 0
+ *       mv /shared/queue.txt /shared/queue.processing
+ *     ) 9>/shared/queue.lock
+ *     beet import -A --quiet $(cat /shared/queue.processing)
+ *     rm /shared/queue.processing
+ *
+ * The shell only holds the flock for the rename ; navidrome-tools then
+ * starts appending to a fresh file while beets is still running.
+ */
+class BeetsQueueService
+{
+    public function __construct(
+        private readonly string $queuePath,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->queuePath !== '';
+    }
+
+    /**
+     * Current size of the queue file, in lines. Returns null when the
+     * service isn't configured or the file doesn't exist yet (— the page
+     * shows that as "queue empty"). Counts lines without loading the whole
+     * file in memory.
+     */
+    public function pendingCount(): ?int
+    {
+        if (!$this->isConfigured() || !is_file($this->queuePath)) {
+            return null;
+        }
+
+        $count = 0;
+        $fh = @fopen($this->queuePath, 'rb');
+        if ($fh === false) {
+            return null;
+        }
+        try {
+            while (!feof($fh)) {
+                $line = fgets($fh);
+                if ($line === false) {
+                    break;
+                }
+                if (trim($line) !== '') {
+                    ++$count;
+                }
+            }
+        } finally {
+            fclose($fh);
+        }
+
+        return $count;
+    }
+
+    /**
+     * Append the given paths to the queue file under an exclusive flock,
+     * recording the push as a {@see RunHistory} row (type beets-queue-push).
+     *
+     * Empty paths and paths that contain a newline are silently skipped —
+     * the beets cron consumes one-line-one-path so embedded newlines would
+     * corrupt the queue.
+     *
+     * @param string[] $paths absolute filesystem paths
+     */
+    public function push(array $paths, string $reason = 'manual'): RunHistory
+    {
+        if (!$this->isConfigured()) {
+            throw new \RuntimeException('Beets queue is not configured (BEETS_QUEUE_PATH).');
+        }
+
+        return $this->recorder->record(
+            type: RunHistory::TYPE_BEETS_QUEUE_PUSH,
+            reference: $reason,
+            label: sprintf('Push to beets queue (%d candidate%s)', count($paths), count($paths) > 1 ? 's' : ''),
+            action: function (RunHistory $entry) use ($paths, $reason): RunHistory {
+                $clean = [];
+                $skipped = 0;
+                foreach ($paths as $p) {
+                    $p = (string) $p;
+                    if ($p === '' || str_contains($p, "\n") || str_contains($p, "\r")) {
+                        ++$skipped;
+                        continue;
+                    }
+                    $clean[] = $p;
+                }
+
+                $entry->setMetrics([
+                    'reason' => $reason,
+                    'queue_path' => $this->queuePath,
+                    'submitted' => 0,
+                    'skipped_invalid' => $skipped,
+                ]);
+
+                if ($clean === []) {
+                    return $entry;
+                }
+
+                self::ensureDirectory($this->queuePath);
+
+                $fh = @fopen($this->queuePath, 'ab');
+                if ($fh === false) {
+                    throw new \RuntimeException(sprintf('Cannot open beets queue %s for append.', $this->queuePath));
+                }
+
+                try {
+                    if (!flock($fh, LOCK_EX)) {
+                        throw new \RuntimeException(sprintf('Cannot lock beets queue %s.', $this->queuePath));
+                    }
+                    $payload = implode("\n", $clean) . "\n";
+                    $written = fwrite($fh, $payload);
+                    fflush($fh);
+                    flock($fh, LOCK_UN);
+
+                    if ($written === false || $written < strlen($payload)) {
+                        throw new \RuntimeException(sprintf('Short write on beets queue %s.', $this->queuePath));
+                    }
+                } finally {
+                    fclose($fh);
+                }
+
+                $entry->setMetrics([
+                    'reason' => $reason,
+                    'queue_path' => $this->queuePath,
+                    'submitted' => count($clean),
+                    'skipped_invalid' => $skipped,
+                ]);
+
+                return $entry;
+            },
+        );
+    }
+
+    private static function ensureDirectory(string $filePath): void
+    {
+        $dir = dirname($filePath);
+        if ($dir !== '' && !is_dir($dir) && !@mkdir($dir, 0o755, true) && !is_dir($dir)) {
+            throw new \RuntimeException(sprintf('Cannot create beets queue directory %s.', $dir));
+        }
+    }
+}

--- a/src/Service/NavidromeRescanService.php
+++ b/src/Service/NavidromeRescanService.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\RunHistory;
+use App\Subsonic\SubsonicClient;
+
+/**
+ * Triggers a Navidrome library scan via Subsonic (`startScan`) and records
+ * the trigger in run_history for audit. Useful from the « tracks missing
+ * MBID » page after the user has externally tagged files with beets — a
+ * scan picks up the new MBIDs without waiting for Navidrome's scheduled run.
+ *
+ * The scan itself is asynchronous on Navidrome's side; we only log that the
+ * trigger was sent. An empty success means the API accepted the call.
+ */
+class NavidromeRescanService
+{
+    public function __construct(
+        private readonly SubsonicClient $subsonic,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    /**
+     * @throws \RuntimeException if Navidrome refuses or the Subsonic call fails;
+     *                           the run is recorded as STATUS_ERROR before re-throw
+     */
+    public function rescan(string $reason = 'manual', bool $fullScan = false): RunHistory
+    {
+        $reference = $reason;
+        $label = $fullScan ? 'Navidrome full rescan' : 'Navidrome rescan';
+
+        return $this->recorder->record(
+            type: RunHistory::TYPE_NAVIDROME_RESCAN,
+            reference: $reference,
+            label: $label,
+            action: function (RunHistory $entry) use ($fullScan, $reason): RunHistory {
+                // Set metrics BEFORE the call so they're preserved if the action
+                // throws (RunHistoryRecorder doesn't clear metrics on exception).
+                $entry->setMetrics([
+                    'reason' => $reason,
+                    'full_scan' => $fullScan,
+                    'accepted' => false,
+                ]);
+                $ok = $this->subsonic->startScan($fullScan);
+                if (!$ok) {
+                    throw new \RuntimeException('Navidrome refused or did not answer the scan trigger.');
+                }
+                $entry->setMetrics([
+                    'reason' => $reason,
+                    'full_scan' => $fullScan,
+                    'accepted' => true,
+                ]);
+
+                return $entry;
+            },
+        );
+    }
+}

--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -137,6 +137,27 @@ class SubsonicClient
         }
     }
 
+    /**
+     * Trigger a Navidrome library scan via the Subsonic `startScan` endpoint.
+     * Returns true when Navidrome accepts the request (regardless of whether
+     * the scan was already running). Useful after writing tags via beets so
+     * Navidrome picks up the new MBIDs without waiting for its own scheduled
+     * scan.
+     */
+    public function startScan(bool $fullScan = false): bool
+    {
+        try {
+            $params = [];
+            if ($fullScan) {
+                $params['fullScan'] = 'true';
+            }
+            $this->call('startScan', $params);
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
     public function ping(): bool
     {
         try {

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -70,6 +70,7 @@
                             <a href="{{ path('app_lastfm_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias</a>
                         </div>
                     </div>
+                    <a href="{{ path('app_tagging_missing_mbid') }}" class="hover:underline">Tagging</a>
                     <a href="{{ path('app_history') }}" class="hover:underline">Historique</a>
                     <a href="{{ path('app_settings') }}" class="hover:underline">Réglages</a>
                     <span class="text-slate-400">{{ app.user.userIdentifier }}</span>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -16,7 +16,7 @@
         </a>
     </div>
 
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 mb-6 text-sm">
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-6 text-sm">
         <div class="rounded border p-3 {{ health.navidrome_db ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
             <div class="font-medium">DB Navidrome</div>
             <div>{{ health.navidrome_db ? '✓ accessible' : '✗ inaccessible (vérifier NAVIDROME_DB_PATH)' }}</div>
@@ -35,6 +35,19 @@
         <div class="rounded border p-3 {{ health.subsonic ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
             <div class="font-medium">API Subsonic</div>
             <div>{{ health.subsonic ? '✓ ping OK' : '✗ injoignable (vérifier NAVIDROME_URL/USER/PASSWORD)' }}</div>
+        </div>
+        <div class="rounded border p-3 {% if health.missing_mbid_count is null %}bg-slate-50 border-slate-300{% elseif health.missing_mbid_count == 0 %}bg-emerald-50 border-emerald-300{% else %}bg-amber-50 border-amber-300{% endif %}">
+            <div class="font-medium">Tracks sans MBID</div>
+            <div>
+                {% if health.missing_mbid_count is null %}
+                    —
+                {% elseif health.missing_mbid_count == 0 %}
+                    ✓ tout est taggué
+                {% else %}
+                    {{ health.missing_mbid_count|number_format(0, '.', ' ') }} track{{ health.missing_mbid_count > 1 ? 's' : '' }} à tagger —
+                    <a href="{{ path('app_tagging_missing_mbid') }}" class="underline">voir</a>
+                {% endif %}
+            </div>
         </div>
     </div>
 

--- a/templates/tagging/missing_mbid.html.twig
+++ b/templates/tagging/missing_mbid.html.twig
@@ -25,6 +25,21 @@
         </form>
     </div>
 
+    {% if beets_queue_configured %}
+        <div class="mb-4 p-3 rounded bg-sky-50 border border-sky-200 text-sm flex items-center justify-between gap-3 flex-wrap">
+            <div class="text-sky-900">
+                Queue beets active —
+                {% if beets_queue_pending is null or beets_queue_pending == 0 %}
+                    file vide
+                {% else %}
+                    <strong>{{ beets_queue_pending|number_format(0, '.', ' ') }}</strong>
+                    chemin{{ beets_queue_pending > 1 ? 's' : '' }} en attente de traitement par le cron beets
+                {% endif %}
+                .
+            </div>
+        </div>
+    {% endif %}
+
     <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
         <div>
             <label class="block text-xs uppercase text-slate-500">Artiste</label>
@@ -40,7 +55,7 @@
             <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
             <a href="{{ path('app_tagging_missing_mbid') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         </div>
-        <div class="text-right">
+        <div class="text-right flex flex-col gap-1">
             <a href="{{ path('app_tagging_missing_mbid_export', filters|merge({limit: 5000})) }}"
                class="inline-block px-3 py-1.5 rounded bg-slate-700 text-white text-sm hover:bg-slate-800"
                title="Télécharge les 5 000 premiers chemins (filtres appliqués) au format CSV">
@@ -48,6 +63,23 @@
             </a>
         </div>
     </form>
+
+    {% if beets_queue_configured %}
+        <form method="post" action="{{ path('app_tagging_missing_mbid_queue') }}" class="mb-4 flex flex-wrap items-center gap-3"
+              onsubmit="return confirm('Pousser les chemins filtrés (jusqu\'à 5 000) dans la queue beets ?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('missing_mbid_queue') }}">
+            <input type="hidden" name="artist" value="{{ filters.artist|default('') }}">
+            <input type="hidden" name="album" value="{{ filters.album|default('') }}">
+            <input type="hidden" name="limit" value="5000">
+            <button type="submit" class="px-3 py-1.5 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700">
+                📋 Pousser dans la queue beets
+            </button>
+            <span class="text-xs text-slate-500">
+                Append les chemins filtrés (max 5 000) dans <code>BEETS_QUEUE_PATH</code>.
+                Ton cron beets côté hôte les consomme.
+            </span>
+        </form>
+    {% endif %}
 
     {% if rows is empty %}
         <div class="bg-white shadow rounded p-6 text-center text-slate-500">

--- a/templates/tagging/missing_mbid.html.twig
+++ b/templates/tagging/missing_mbid.html.twig
@@ -1,0 +1,100 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Tracks sans MBID{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Tracks sans MBID</h1>
+            <p class="text-sm text-slate-500 max-w-3xl">
+                {{ total|number_format(0, '.', ' ') }}
+                track{{ total > 1 ? 's' : '' }} dans Navidrome dont les colonnes
+                <code>mbz_track_id</code> et <code>mbz_recording_id</code> sont vides.
+                Ces fichiers ne peuvent pas être matchés via le palier MBID lors d'un import Last.fm.
+                Exporte la liste des chemins, lance un tagger externe (par ex. <code>beet import -A</code>
+                sur la machine où le dossier de musique est en RW), puis déclenche un rescan Navidrome
+                pour propager les nouveaux MBIDs.
+            </p>
+        </div>
+        <form method="post" action="{{ path('app_tagging_missing_mbid_rescan') }}"
+              onsubmit="return confirm('Déclencher un rescan Navidrome maintenant ?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('missing_mbid_rescan') }}">
+            <button type="submit" class="px-3 py-1.5 rounded bg-emerald-600 text-white text-sm hover:bg-emerald-700">
+                ↻ Rescan Navidrome
+            </button>
+        </form>
+    </div>
+
+    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500">Artiste</label>
+            <input type="search" name="artist" value="{{ filters.artist|default('') }}" placeholder="ex. Daft Punk"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500">Album</label>
+            <input type="search" name="album" value="{{ filters.album|default('') }}" placeholder="ex. Discovery"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <div class="flex gap-2">
+            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <a href="{{ path('app_tagging_missing_mbid') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+        </div>
+        <div class="text-right">
+            <a href="{{ path('app_tagging_missing_mbid_export', filters|merge({limit: 5000})) }}"
+               class="inline-block px-3 py-1.5 rounded bg-slate-700 text-white text-sm hover:bg-slate-800"
+               title="Télécharge les 5 000 premiers chemins (filtres appliqués) au format CSV">
+                ⬇ Export CSV
+            </a>
+        </div>
+    </form>
+
+    {% if rows is empty %}
+        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+            Aucun track sans MBID pour ce filtre 🎉
+        </div>
+    {% else %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2 w-10">#</th>
+                    <th class="px-3 py-2">Artiste</th>
+                    <th class="px-3 py-2">Album</th>
+                    <th class="px-3 py-2">Titre</th>
+                    <th class="px-3 py-2 text-right">Année</th>
+                    <th class="px-3 py-2">Chemin</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for row in rows %}
+                    <tr>
+                        <td class="px-3 py-1.5 text-slate-400">{{ (page - 1) * 50 + loop.index }}</td>
+                        <td class="px-3 py-1.5">{{ row.artist }}</td>
+                        <td class="px-3 py-1.5 text-slate-500">{{ row.album ?: '—' }}</td>
+                        <td class="px-3 py-1.5">{{ row.title }}</td>
+                        <td class="px-3 py-1.5 text-right text-slate-500">{{ row.year > 0 ? row.year : '—' }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 font-mono break-all" title="{{ row.path }}">
+                            {{ row.path ?: '—' }}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_tagging_missing_mbid', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_tagging_missing_mbid', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/Navidrome/NavidromeFixtureFactory.php
+++ b/tests/Navidrome/NavidromeFixtureFactory.php
@@ -37,6 +37,7 @@ final class NavidromeFixtureFactory
         $conn->executeStatement(<<<'SQL'
             CREATE TABLE media_file (
                 id VARCHAR(255) PRIMARY KEY NOT NULL,
+                path VARCHAR(1024) DEFAULT '' NOT NULL,
                 title VARCHAR(255) DEFAULT '' NOT NULL,
                 album VARCHAR(255) DEFAULT '' NOT NULL,
                 artist VARCHAR(255) DEFAULT '' NOT NULL,
@@ -45,7 +46,9 @@ final class NavidromeFixtureFactory
                 album_id VARCHAR(255) DEFAULT '' NOT NULL,
                 duration INTEGER DEFAULT 0 NOT NULL,
                 year INTEGER DEFAULT 0 NOT NULL,
-                genre VARCHAR(255) DEFAULT '' NOT NULL
+                genre VARCHAR(255) DEFAULT '' NOT NULL,
+                mbz_track_id VARCHAR(255) DEFAULT '',
+                mbz_recording_id VARCHAR(255) DEFAULT ''
             )
         SQL);
         $conn->executeStatement(<<<'SQL'
@@ -93,11 +96,26 @@ final class NavidromeFixtureFactory
         int $duration = 180,
         string $album = 'Album',
         ?string $albumArtist = null,
+        string $path = '',
+        ?string $mbzTrackId = null,
+        ?string $mbzRecordingId = null,
     ): void {
         $artistId = 'artist-' . md5($artist);
         $conn->executeStatement(
-            'INSERT INTO media_file (id, title, artist, album, artist_id, album_artist, duration) VALUES (?, ?, ?, ?, ?, ?, ?)',
-            [$id, $title, $artist, $album, $artistId, $albumArtist ?? $artist, $duration],
+            'INSERT INTO media_file (id, path, title, artist, album, artist_id, album_artist, duration, mbz_track_id, mbz_recording_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $id,
+                $path,
+                $title,
+                $artist,
+                $album,
+                $artistId,
+                $albumArtist ?? $artist,
+                $duration,
+                $mbzTrackId,
+                $mbzRecordingId,
+            ],
         );
     }
 

--- a/tests/Navidrome/NavidromeRepositoryTest.php
+++ b/tests/Navidrome/NavidromeRepositoryTest.php
@@ -660,4 +660,54 @@ class NavidromeRepositoryTest extends TestCase
         $this->assertSame('mf-1', $repo->findMediaFileByArtistTitle('Sigur Ros', 'Hoppipolla'));
         $this->assertNull($repo->findMediaFileByArtistTitle('Sigur Ros', 'Unknown Title'));
     }
+
+    public function testFindMediaFilesWithoutMbidReturnsOnlyEmptyOnes(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-tagged', 'Tagged', 'Daft Punk', 200, 'Discovery', null, '/music/discovery/tagged.flac', 'mbz-1');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-recording', 'Recording', 'Daft Punk', 200, 'Discovery', null, '/music/discovery/rec.flac', null, 'mbz-2');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-empty-1', 'Untagged 1', 'Air', 200, 'Moon Safari', null, '/music/moon-safari/untagged-1.flac');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-empty-2', 'Untagged 2', 'Aphex Twin', 200, 'Drukqs', null, '/music/drukqs/untagged-2.flac');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+
+        $rows = $repo->findMediaFilesWithoutMbid();
+        $ids = array_column($rows, 'id');
+        sort($ids);
+        $this->assertSame(['mf-empty-1', 'mf-empty-2'], $ids);
+        $this->assertSame(2, $repo->countMediaFilesWithoutMbid());
+
+        // Path is exposed for the export pipeline.
+        $byId = [];
+        foreach ($rows as $r) {
+            $byId[$r['id']] = $r;
+        }
+        $this->assertSame('/music/moon-safari/untagged-1.flac', $byId['mf-empty-1']['path']);
+        $this->assertSame('Air', $byId['mf-empty-1']['artist']);
+        $this->assertSame('Moon Safari', $byId['mf-empty-1']['album']);
+    }
+
+    public function testFindMediaFilesWithoutMbidAppliesFiltersAndPagination(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'A', 'Daft Punk', 200, 'Discovery');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'B', 'Daft Punk', 200, 'Random Access Memories');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'C', 'Air', 200, 'Moon Safari');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+
+        $this->assertSame(2, $repo->countMediaFilesWithoutMbid(artistFilter: 'daft'));
+        $this->assertSame(1, $repo->countMediaFilesWithoutMbid(artistFilter: 'daft', albumFilter: 'memories'));
+        $this->assertSame(0, $repo->countMediaFilesWithoutMbid(artistFilter: 'unknown'));
+
+        $page1 = $repo->findMediaFilesWithoutMbid(limit: 2, offset: 0);
+        $page2 = $repo->findMediaFilesWithoutMbid(limit: 2, offset: 2);
+        $this->assertCount(2, $page1);
+        $this->assertCount(1, $page2);
+        $this->assertNotEquals(
+            array_column($page1, 'id'),
+            array_column($page2, 'id'),
+            'Pagination must yield disjoint slices.',
+        );
+    }
 }

--- a/tests/Service/BeetsQueueServiceTest.php
+++ b/tests/Service/BeetsQueueServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\RunHistory;
+use App\Service\BeetsQueueService;
+use App\Service\RunHistoryRecorder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class BeetsQueueServiceTest extends TestCase
+{
+    private string $queuePath;
+
+    protected function setUp(): void
+    {
+        $this->queuePath = sys_get_temp_dir() . '/beets-queue-test-' . uniqid() . '.txt';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->queuePath)) {
+            unlink($this->queuePath);
+        }
+        $dir = dirname($this->queuePath);
+        if (is_dir($dir) && str_contains($dir, 'beets-queue-test-')) {
+            @rmdir($dir);
+        }
+    }
+
+    public function testNotConfiguredWhenPathEmpty(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService('', new RunHistoryRecorder($em['em']));
+        $this->assertFalse($service->isConfigured());
+        $this->assertNull($service->pendingCount());
+    }
+
+    public function testPushAppendsPathsAndRecordsRun(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $recorder = new RunHistoryRecorder($em['em']);
+        $service = new BeetsQueueService($this->queuePath, $recorder);
+
+        $run = $service->push(['/music/a.flac', '/music/b.flac']);
+
+        $this->assertSame(RunHistory::STATUS_SUCCESS, $run->getStatus());
+        $this->assertSame(RunHistory::TYPE_BEETS_QUEUE_PUSH, $run->getType());
+        $metrics = $run->getMetrics();
+        $this->assertSame(2, $metrics['submitted']);
+        $this->assertSame(0, $metrics['skipped_invalid']);
+
+        $contents = file_get_contents($this->queuePath);
+        $this->assertSame("/music/a.flac\n/music/b.flac\n", $contents);
+
+        // Subsequent push appends rather than truncating.
+        $service->push(['/music/c.flac']);
+        $this->assertStringEndsWith("/music/c.flac\n", (string) file_get_contents($this->queuePath));
+
+        $this->assertSame(3, $service->pendingCount());
+    }
+
+    public function testPushThrowsWhenNotConfigured(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService('', new RunHistoryRecorder($em['em']));
+
+        $this->expectException(\RuntimeException::class);
+        $service->push(['/music/a.flac']);
+    }
+
+    public function testPushFiltersInvalidPaths(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService($this->queuePath, new RunHistoryRecorder($em['em']));
+
+        $run = $service->push([
+            '/music/ok.flac',
+            '',                         // empty
+            "/music/with\nnewline.flac", // newline → would corrupt one-per-line format
+            "/music/with\rcr.flac",      // carriage return — same
+            '/music/also-ok.flac',
+        ]);
+
+        $metrics = $run->getMetrics();
+        $this->assertSame(2, $metrics['submitted']);
+        $this->assertSame(3, $metrics['skipped_invalid']);
+        $this->assertSame("/music/ok.flac\n/music/also-ok.flac\n", file_get_contents($this->queuePath));
+    }
+
+    public function testPushNoOpWhenAllPathsInvalid(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService($this->queuePath, new RunHistoryRecorder($em['em']));
+
+        $run = $service->push(['', '']);
+        $this->assertSame(0, $run->getMetrics()['submitted']);
+        $this->assertFileDoesNotExist($this->queuePath);
+    }
+
+    public function testPushCreatesParentDirectoryIfMissing(): void
+    {
+        $this->queuePath = sys_get_temp_dir() . '/beets-queue-test-' . uniqid() . '/queue.txt';
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService($this->queuePath, new RunHistoryRecorder($em['em']));
+
+        $service->push(['/music/a.flac']);
+
+        $this->assertFileExists($this->queuePath);
+    }
+
+    public function testPendingCountReadsLineCount(): void
+    {
+        file_put_contents($this->queuePath, "/a\n/b\n\n/c\n");
+        $em = $this->makeFakeEntityManager();
+        $service = new BeetsQueueService($this->queuePath, new RunHistoryRecorder($em['em']));
+
+        // Empty lines are not counted.
+        $this->assertSame(3, $service->pendingCount());
+    }
+
+    /**
+     * @return array{em: EntityManagerInterface, persisted: list<RunHistory>}
+     */
+    private function makeFakeEntityManager(): array
+    {
+        $persisted = [];
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist')->willReturnCallback(function (object $entity) use (&$persisted): void {
+            $persisted[] = $entity;
+        });
+        $em->method('flush');
+
+        return ['em' => $em, 'persisted' => &$persisted];
+    }
+}

--- a/tests/Service/NavidromeRescanServiceTest.php
+++ b/tests/Service/NavidromeRescanServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\RunHistory;
+use App\Service\NavidromeRescanService;
+use App\Service\RunHistoryRecorder;
+use App\Subsonic\SubsonicClient;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class NavidromeRescanServiceTest extends TestCase
+{
+    public function testSuccessfulRescanRecordsRunWithMetrics(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $recorder = new RunHistoryRecorder($em['em']);
+        $http = new MockHttpClient([
+            new MockResponse(
+                json_encode(['subsonic-response' => ['status' => 'ok']], JSON_THROW_ON_ERROR),
+                ['response_headers' => ['content-type: application/json']],
+            ),
+        ]);
+        $subsonic = new SubsonicClient($http, 'http://navi.test', 'admin', 'changeme');
+
+        $service = new NavidromeRescanService($subsonic, $recorder);
+        $run = $service->rescan(reason: 'unit-test');
+
+        $this->assertSame(RunHistory::STATUS_SUCCESS, $run->getStatus());
+        $this->assertSame(RunHistory::TYPE_NAVIDROME_RESCAN, $run->getType());
+        $this->assertSame('unit-test', $run->getReference());
+        $this->assertSame(['reason' => 'unit-test', 'full_scan' => false, 'accepted' => true], $run->getMetrics());
+        $this->assertCount(1, $em['persisted']);
+    }
+
+    public function testFailedRescanMarksRunErrorAndRethrows(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $recorder = new RunHistoryRecorder($em['em']);
+        $http = new MockHttpClient([
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+        $subsonic = new SubsonicClient($http, 'http://navi.test', 'admin', 'changeme');
+
+        $service = new NavidromeRescanService($subsonic, $recorder);
+
+        try {
+            $service->rescan();
+            $this->fail('Expected the failed rescan to throw.');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        $this->assertCount(1, $em['persisted']);
+        /** @var RunHistory $entry */
+        $entry = $em['persisted'][0];
+        $this->assertSame(RunHistory::STATUS_ERROR, $entry->getStatus());
+        $this->assertNotNull($entry->getMessage());
+        // Metrics set inside the action survive the exception path because
+        // RunHistoryRecorder mutates entry status/message but keeps metrics.
+        $this->assertSame(['reason' => 'manual', 'full_scan' => false, 'accepted' => false], $entry->getMetrics());
+    }
+
+    public function testFullScanFlagPropagates(): void
+    {
+        $em = $this->makeFakeEntityManager();
+        $recorder = new RunHistoryRecorder($em['em']);
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return new MockResponse(
+                json_encode(['subsonic-response' => ['status' => 'ok']], JSON_THROW_ON_ERROR),
+                ['response_headers' => ['content-type: application/json']],
+            );
+        });
+        $subsonic = new SubsonicClient($http, 'http://navi.test', 'admin', 'changeme');
+
+        $service = new NavidromeRescanService($subsonic, $recorder);
+        $run = $service->rescan(reason: 'manual', fullScan: true);
+
+        $this->assertTrue($run->getMetrics()['full_scan'] ?? false);
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('fullScan=true', (string) $captured);
+    }
+
+    /**
+     * @return array{em: EntityManagerInterface, persisted: list<RunHistory>}
+     */
+    private function makeFakeEntityManager(): array
+    {
+        $persisted = [];
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist')->willReturnCallback(function (object $entity) use (&$persisted): void {
+            $persisted[] = $entity;
+        });
+        $em->method('flush');
+
+        return ['em' => $em, 'persisted' => &$persisted];
+    }
+}

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -174,6 +174,49 @@ class SubsonicClientTest extends TestCase
         $sub->fetchCoverArt('', 128);
     }
 
+    public function testStartScanHitsStartScanEndpoint(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok([]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $this->assertTrue($sub->startScan(false));
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/rest/startScan.view?', $captured);
+        $this->assertStringNotContainsString('fullScan=true', $captured);
+    }
+
+    public function testStartScanFullScanFlag(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok([]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $this->assertTrue($sub->startScan(true));
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('fullScan=true', $captured);
+    }
+
+    public function testStartScanReturnsFalseOnError(): void
+    {
+        $client = new MockHttpClient([
+            new MockResponse('', ['http_code' => 500]),
+        ]);
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $this->assertFalse($sub->startScan());
+    }
+
     /**
      * @param array<string, mixed> $payload
      */


### PR DESCRIPTION
Sans MBID, le palier le plus fiable de la cascade de matching Last.fm
(`findMediaFileByMbid`) ne fait rien et l'outil retombe sur les paliers
artiste/titre/album + fuzzy, plus fragiles. Cette page expose le workflow
manuel pour boucher les trous : auditer → exporter la liste des chemins
→ tagger côté hôte (beets / Picard) → rescanner Navidrome.

Architecture délibérément read-only : navidrome-tools n'écrit jamais
dans les fichiers audio (le volume `/music` peut rester `:ro`). C'est
un changement vs. l'idée initiale d'embarquer beets dans le container
— un pattern bien plus simple et qui découple les responsabilités.

- `NavidromeRepository::findMediaFilesWithoutMbid()` /
  `countMediaFilesWithoutMbid()` : version-agnostiques, probe les
  colonnes MBID disponibles via `mediaFileColumns()`.
- `SubsonicClient::startScan(bool $fullScan)` qui hit
  `/rest/startScan.view` (full-scan optionnel).
- `NavidromeRescanService` : wrap la rescan dans `RunHistoryRecorder`
  pour audit (type `navidrome-rescan`). Throw si Navidrome refuse,
  metrics conservés sur l'exception path.
- Page `/tagging/missing-mbid` : audit avec filtres artiste/album,
  pagination, export CSV (limité à 5 000 lignes), bouton « ↻ Rescan
  Navidrome » (CSRF-protégé).
- Card santé « Tracks sans MBID » sur le dashboard + lien
  « Tagging » dans la nav.
- Fixture étendue : `media_file.path`, `mbz_track_id`,
  `mbz_recording_id` ; `insertTrack()` accepte les 3 en optionnel
  (rétrocompatible).

228 tests / 552 assertions, phpcs + phpstan verts.

https://claude.ai/code/session_017ADwjG41kPFbVQMUG1qNm4