### PR TITLE
feat(lastfm): alias d'artiste (synonymes) pour gérer renommages et variantes (closes #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **Alias d'artistes (synonymes)** : nouvelle table
+  `lastfm_artist_alias` (id, source_artist, source_artist_norm UNIQUE,
+  target_artist, created_at) qui mappe un nom source Last.fm → nom
+  canonique côté Navidrome — utile pour les renommages
+  (« La Ruda Salska » → « La Ruda »), variantes de romanisation,
+  conventions « The X » / « X, The ». Consulté par
+  `App\LastFm\ScrobbleMatcher` **après** l'alias track-level
+  (`lastfm_alias`) mais **avant** la cascade : réécrit l'artiste du
+  `LastFmScrobble` puis laisse les heuristiques tourner. Un seul
+  alias couvre tous les morceaux d'un artiste renommé. CRUD complet
+  sur `/lastfm/artist-aliases` (menu Last.fm → Alias artistes) avec
+  recherche paginée. Bouton « 🎭 Aliaser artiste » sur
+  `/lastfm/unmatched`. Combo avec le rematch (#21) pour récupérer
+  rétrospectivement tous les scrobbles concernés. Comparaison via
+  `NavidromeRepository::normalize()` (case/accents/ponctuation
+  insensitive). Closes #65.
 - Page `/tagging/missing-mbid` : audit des morceaux Navidrome dont
   `mbz_track_id` ET `mbz_recording_id` sont vides. Filtres
   artiste/album, pagination, export CSV (id, path, artist,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,17 @@ Fonctionnalités livrées :
   (table `lastfm_import_track`, FK CASCADE) avec filtre par statut
   (inserted / duplicate / unmatched, défaut « non matchés »
   s'il y en a) et recherche full-text artiste/titre.
+- **Alias d'artiste** (`/lastfm/artist-aliases`) : table
+  `lastfm_artist_alias` qui mappe un nom source Last.fm → nom
+  canonique côté Navidrome (ex. « La Ruda Salska » → « La Ruda »).
+  Consulté par `App\LastFm\ScrobbleMatcher` **après** l'alias
+  track-level (`lastfm_alias`) mais **avant** la cascade — réécrit
+  l'artiste du `LastFmScrobble` puis laisse les heuristiques
+  habituelles tourner. Un seul alias couvre tous les morceaux
+  d'un artiste renommé. Bouton « 🎭 Aliaser artiste » sur
+  `/lastfm/unmatched`. CRUD complet (new/edit/delete + recherche
+  paginée). Comparaison via `NavidromeRepository::normalize()`
+  (case / accents / ponctuation insensitive). Sub-issue de #11.
 - **Page `/lastfm/unmatched`** : audit cumulé de **tous** les
   scrobbles `unmatched` (toutes runs confondues), agrégés par
   `(artist, title, album)` avec compteur de scrobbles + dernier

--- a/README.md
+++ b/README.md
@@ -402,6 +402,29 @@ lando symfony app:lastfm:import myuser --api-key=XXX \
 lando symfony app:lastfm:import myuser --api-key=XXX --show-unmatched=all
 ```
 
+## Alias d'artistes (synonymes)
+
+Quand un artiste a été **renommé** (« La Ruda Salska » → « La Ruda »),
+ou existe sous plusieurs **variantes** (romanisations, conventions
+« The X » / « X, The »), Last.fm peut envoyer le nom historique alors
+que Navidrome utilise le nom canonique. Plutôt que de créer un alias
+manuel par track, la page **`/lastfm/artist-aliases`** (menu Last.fm
+→ Alias artistes) gère ces synonymes au niveau artiste : un seul
+alias `source → cible` couvre tous les morceaux.
+
+Le matcher (`App\LastFm\ScrobbleMatcher`) consulte la table
+**après** l'alias track-level (qui garde la priorité absolue) mais
+**avant** la cascade MBID / triplet / couple : il réécrit le nom
+d'artiste dans le `LastFmScrobble` puis laisse les heuristiques
+habituelles tourner.
+
+Un bouton « 🎭 Aliaser artiste » apparaît sur `/lastfm/unmatched`
+pour créer rapidement un alias depuis un scrobble non matché.
+
+Une fois l'alias créé, lancez **« Re-tenter le matching cumulé »**
+(cf. ci-dessous) pour ré-essayer rétrospectivement tous les
+scrobbles concernés.
+
 ## Liste cumulée des unmatched
 
 La page **`/lastfm/unmatched`** (menu Last.fm → Unmatched) liste tous

--- a/migrations/Version20260502100000.php
+++ b/migrations/Version20260502100000.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260502100000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add lastfm_artist_alias table for artist-level renames / synonyms (e.g. "La Ruda Salska" → "La Ruda").';
+    }
+
+    public function isTransactional(): bool
+    {
+        // SQLite + DDL combined with `--all-or-nothing` triggers
+        // « There is no active transaction » on the migration runner.
+        // Each CREATE TABLE / CREATE INDEX is auto-committed by SQLite
+        // anyway, so wrapping is moot.
+        return false;
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE lastfm_artist_alias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                source_artist VARCHAR(255) NOT NULL,
+                source_artist_norm VARCHAR(255) NOT NULL,
+                target_artist VARCHAR(255) NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_lastfm_artist_alias_source_norm ON lastfm_artist_alias (source_artist_norm)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE lastfm_artist_alias');
+    }
+}

--- a/src/Controller/LastFmAliasController.php
+++ b/src/Controller/LastFmAliasController.php
@@ -38,21 +38,22 @@ class LastFmAliasController extends AbstractController
     #[Route('/lastfm/aliases/new', name: 'app_lastfm_alias_new', methods: ['GET', 'POST'])]
     public function new(Request $request, LastFmAliasRepository $repo, EntityManagerInterface $em): Response
     {
+        // Pre-fill from query string (« Mapper » button on /history/{id}
+        // and /lastfm/unmatched). Passed as FormType options because the
+        // field's `data` option in the builder takes precedence over
+        // post-creation `setData()` calls.
+        $prefillArtist = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_artist', ''))
+            : '';
+        $prefillTitle = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_title', ''))
+            : '';
+
         $form = $this->createForm(LastFmAliasType::class, null, [
             'alias' => null,
+            'prefill_source_artist' => $prefillArtist,
+            'prefill_source_title' => $prefillTitle,
         ]);
-
-        // Pre-fill from query string when coming from a "Mapper" button.
-        if ($request->isMethod('GET')) {
-            $prefillArtist = (string) $request->query->get('source_artist', '');
-            $prefillTitle = (string) $request->query->get('source_title', '');
-            if ($prefillArtist !== '') {
-                $form->get('source_artist')->setData($prefillArtist);
-            }
-            if ($prefillTitle !== '') {
-                $form->get('source_title')->setData($prefillTitle);
-            }
-        }
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/LastFmArtistAliasController.php
+++ b/src/Controller/LastFmArtistAliasController.php
@@ -38,17 +38,18 @@ class LastFmArtistAliasController extends AbstractController
     #[Route('/lastfm/artist-aliases/new', name: 'app_lastfm_artist_alias_new', methods: ['GET', 'POST'])]
     public function new(Request $request, LastFmArtistAliasRepository $repo, EntityManagerInterface $em): Response
     {
+        // Pre-fill from query string when coming from the « Aliaser l'artiste »
+        // button — passed as a FormType option so it wires into the field's
+        // initial `data`. Setting `data` via the form builder takes precedence
+        // over post-creation `setData()` calls, hence this route.
+        $prefillSource = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_artist', ''))
+            : '';
+
         $form = $this->createForm(LastFmArtistAliasType::class, null, [
             'alias' => null,
+            'prefill_source_artist' => $prefillSource,
         ]);
-
-        // Pre-fill from query string when coming from the « Aliaser l'artiste » button.
-        if ($request->isMethod('GET')) {
-            $prefill = (string) $request->query->get('source_artist', '');
-            if ($prefill !== '') {
-                $form->get('source_artist')->setData($prefill);
-            }
-        }
 
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Controller/LastFmArtistAliasController.php
+++ b/src/Controller/LastFmArtistAliasController.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\LastFmArtistAlias;
+use App\Form\LastFmArtistAliasType;
+use App\Repository\LastFmArtistAliasRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmArtistAliasController extends AbstractController
+{
+    private const PER_PAGE = 25;
+
+    #[Route('/lastfm/artist-aliases', name: 'app_lastfm_artist_alias_index', methods: ['GET'])]
+    public function index(Request $request, LastFmArtistAliasRepository $repo): Response
+    {
+        $query = trim((string) $request->query->get('q', ''));
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $aliases = $repo->search($query, $page, self::PER_PAGE);
+        $total = $repo->countSearch($query);
+        $totalPages = (int) max(1, ceil($total / self::PER_PAGE));
+
+        return $this->render('lastfm/artist_aliases/index.html.twig', [
+            'aliases' => $aliases,
+            'total' => $total,
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => ['q' => $query],
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/new', name: 'app_lastfm_artist_alias_new', methods: ['GET', 'POST'])]
+    public function new(Request $request, LastFmArtistAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $form = $this->createForm(LastFmArtistAliasType::class, null, [
+            'alias' => null,
+        ]);
+
+        // Pre-fill from query string when coming from the « Aliaser l'artiste » button.
+        if ($request->isMethod('GET')) {
+            $prefill = (string) $request->query->get('source_artist', '');
+            if ($prefill !== '') {
+                $form->get('source_artist')->setData($prefill);
+            }
+        }
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $targetArtist = (string) $form->get('target_artist')->getData();
+
+            $existing = $repo->findBySourceArtist($sourceArtist);
+            if ($existing !== null) {
+                $this->addFlash('error', sprintf(
+                    'Un alias existe déjà pour « %s » → « %s ». Modifiez-le au lieu d\'en créer un nouveau.',
+                    $existing->getSourceArtist(),
+                    $existing->getTargetArtist(),
+                ));
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_edit', ['id' => $existing->getId()]);
+            }
+
+            $alias = new LastFmArtistAlias($sourceArtist, $targetArtist);
+            try {
+                $em->persist($alias);
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un alias normalisé identique existe déjà — modifiez-le.');
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_index', ['q' => $sourceArtist]);
+            }
+
+            $this->addFlash('success', sprintf(
+                'Alias artiste créé : « %s » → « %s ». Lancez « Re-tenter le matching » pour ré-essayer les unmatched.',
+                $sourceArtist,
+                $targetArtist,
+            ));
+
+            return $this->redirectToRoute('app_lastfm_artist_alias_index');
+        }
+
+        return $this->render('lastfm/artist_aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => null,
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/{id}/edit', name: 'app_lastfm_artist_alias_edit', methods: ['GET', 'POST'])]
+    public function edit(int $id, Request $request, LastFmArtistAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        $form = $this->createForm(LastFmArtistAliasType::class, null, [
+            'alias' => $alias,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $targetArtist = (string) $form->get('target_artist')->getData();
+
+            $alias->setSource($sourceArtist);
+            $alias->setTargetArtist($targetArtist);
+
+            try {
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un autre alias couvre déjà cet artiste source normalisé.');
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_index');
+            }
+
+            $this->addFlash('success', sprintf('Alias artiste « %s » → « %s » mis à jour.', $sourceArtist, $targetArtist));
+
+            return $this->redirectToRoute('app_lastfm_artist_alias_index');
+        }
+
+        return $this->render('lastfm/artist_aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/{id}/delete', name: 'app_lastfm_artist_alias_delete', methods: ['POST'])]
+    public function delete(int $id, Request $request, LastFmArtistAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        if (!$this->isCsrfTokenValid('delete-artist-alias-' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $label = sprintf('%s → %s', $alias->getSourceArtist(), $alias->getTargetArtist());
+        $em->remove($alias);
+        $em->flush();
+        $this->addFlash('success', sprintf('Alias artiste « %s » supprimé.', $label));
+
+        return $this->redirectToRoute('app_lastfm_artist_alias_index');
+    }
+}

--- a/src/Entity/LastFmArtistAlias.php
+++ b/src/Entity/LastFmArtistAlias.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Entity;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmArtistAliasRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Artist-level alias (a.k.a. synonym): rewrite the source artist name
+ * coming from Last.fm to a canonical one before the matching cascade
+ * runs. Useful for renames ("La Ruda Salska" → "La Ruda"), alternate
+ * romanizations ("Tchaïkovski" → "Tchaikovsky"), or "The X" / "X, The"
+ * conventions. One alias covers ALL tracks of the artist — unlike the
+ * track-level {@see LastFmAlias} which targets a single media_file id.
+ *
+ * Lookup is normalized (`source_artist_norm` UNIQUE) so a typo in the
+ * raw `source_artist` doesn't break matching for other variants.
+ */
+#[ORM\Entity(repositoryClass: LastFmArtistAliasRepository::class)]
+#[ORM\Table(name: 'lastfm_artist_alias')]
+#[ORM\UniqueConstraint(name: 'uniq_lastfm_artist_alias_source_norm', columns: ['source_artist_norm'])]
+class LastFmArtistAlias
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtist;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtistNorm;
+
+    /**
+     * Canonical artist name as it appears in Navidrome. Stored raw so the
+     * cascade re-normalizes it the same way as any other input — keeps
+     * matching consistent regardless of how the user typed it.
+     */
+    #[ORM\Column(length: 255)]
+    private string $targetArtist;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(string $sourceArtist, string $targetArtist)
+    {
+        $this->setSource($sourceArtist);
+        $this->setTargetArtist($targetArtist);
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function setSource(string $sourceArtist): void
+    {
+        $this->sourceArtist = trim($sourceArtist);
+        $this->sourceArtistNorm = NavidromeRepository::normalize($sourceArtist);
+    }
+
+    public function setTargetArtist(string $targetArtist): void
+    {
+        $this->targetArtist = trim($targetArtist);
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSourceArtist(): string
+    {
+        return $this->sourceArtist;
+    }
+
+    public function getSourceArtistNorm(): string
+    {
+        return $this->sourceArtistNorm;
+    }
+
+    public function getTargetArtist(): string
+    {
+        return $this->targetArtist;
+    }
+
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Form/LastFmAliasType.php
+++ b/src/Form/LastFmAliasType.php
@@ -23,17 +23,23 @@ class LastFmAliasType extends AbstractType
         /** @var LastFmAlias|null $alias */
         $alias = $options['alias'];
         $isSkip = $alias !== null && $alias->isSkip();
+        $prefillArtist = $options['prefill_source_artist'] !== ''
+            ? $options['prefill_source_artist']
+            : ($alias?->getSourceArtist() ?? '');
+        $prefillTitle = $options['prefill_source_title'] !== ''
+            ? $options['prefill_source_title']
+            : ($alias?->getSourceTitle() ?? '');
 
         $builder
             ->add('source_artist', TextType::class, [
                 'label' => 'Artiste (Last.fm)',
                 'help' => 'Tel qu\'écrit par Last.fm. Comparé sans accents / casse / ponctuation.',
-                'data' => $alias?->getSourceArtist() ?? '',
+                'data' => $prefillArtist,
                 'constraints' => [new NotBlank()],
             ])
             ->add('source_title', TextType::class, [
                 'label' => 'Titre (Last.fm)',
-                'data' => $alias?->getSourceTitle() ?? '',
+                'data' => $prefillTitle,
                 'constraints' => [new NotBlank()],
             ])
             ->add('skip', CheckboxType::class, [
@@ -70,7 +76,11 @@ class LastFmAliasType extends AbstractType
     {
         $resolver->setDefaults([
             'alias' => null,
+            'prefill_source_artist' => '',
+            'prefill_source_title' => '',
         ]);
         $resolver->setAllowedTypes('alias', [LastFmAlias::class, 'null']);
+        $resolver->setAllowedTypes('prefill_source_artist', 'string');
+        $resolver->setAllowedTypes('prefill_source_title', 'string');
     }
 }

--- a/src/Form/LastFmArtistAliasType.php
+++ b/src/Form/LastFmArtistAliasType.php
@@ -18,12 +18,15 @@ class LastFmArtistAliasType extends AbstractType
     {
         /** @var LastFmArtistAlias|null $alias */
         $alias = $options['alias'];
+        $prefillSource = $options['prefill_source_artist'] !== ''
+            ? $options['prefill_source_artist']
+            : ($alias?->getSourceArtist() ?? '');
 
         $builder
             ->add('source_artist', TextType::class, [
                 'label' => 'Artiste source (Last.fm)',
                 'help' => 'Le nom tel qu\'envoyé par Last.fm (ex. « La Ruda Salska »). Comparé sans accents / casse / ponctuation.',
-                'data' => $alias?->getSourceArtist() ?? '',
+                'data' => $prefillSource,
                 'constraints' => [new NotBlank()],
             ])
             ->add('target_artist', TextType::class, [
@@ -38,7 +41,9 @@ class LastFmArtistAliasType extends AbstractType
     {
         $resolver->setDefaults([
             'alias' => null,
+            'prefill_source_artist' => '',
         ]);
         $resolver->setAllowedTypes('alias', [LastFmArtistAlias::class, 'null']);
+        $resolver->setAllowedTypes('prefill_source_artist', 'string');
     }
 }

--- a/src/Form/LastFmArtistAliasType.php
+++ b/src/Form/LastFmArtistAliasType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\LastFmArtistAlias;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @extends AbstractType<LastFmArtistAlias|null>
+ */
+class LastFmArtistAliasType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var LastFmArtistAlias|null $alias */
+        $alias = $options['alias'];
+
+        $builder
+            ->add('source_artist', TextType::class, [
+                'label' => 'Artiste source (Last.fm)',
+                'help' => 'Le nom tel qu\'envoyé par Last.fm (ex. « La Ruda Salska »). Comparé sans accents / casse / ponctuation.',
+                'data' => $alias?->getSourceArtist() ?? '',
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('target_artist', TextType::class, [
+                'label' => 'Artiste cible (canonique côté Navidrome)',
+                'help' => 'Le nom tel qu\'il apparaît dans votre lib Navidrome (ex. « La Ruda »). Une fois la cascade relancée, tous les scrobbles de l\'artiste source seront ré-essayés avec ce nom.',
+                'data' => $alias?->getTargetArtist() ?? '',
+                'constraints' => [new NotBlank()],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'alias' => null,
+        ]);
+        $resolver->setAllowedTypes('alias', [LastFmArtistAlias::class, 'null']);
+    }
+}

--- a/src/LastFm/LastFmImporter.php
+++ b/src/LastFm/LastFmImporter.php
@@ -4,6 +4,7 @@ namespace App\LastFm;
 
 use App\Navidrome\NavidromeRepository;
 use App\Repository\LastFmAliasRepository;
+use App\Repository\LastFmArtistAliasRepository;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -18,9 +19,15 @@ class LastFmImporter
         ?LoggerInterface $logger = null,
         int $fuzzyMaxDistance = 0,
         ?LastFmAliasRepository $aliasRepository = null,
+        ?LastFmArtistAliasRepository $artistAliasRepository = null,
     ) {
         $this->logger = $logger ?? new NullLogger();
-        $this->matcher = new ScrobbleMatcher($this->navidrome, $aliasRepository, $fuzzyMaxDistance);
+        $this->matcher = new ScrobbleMatcher(
+            $this->navidrome,
+            $aliasRepository,
+            $fuzzyMaxDistance,
+            $artistAliasRepository,
+        );
     }
 
     /**

--- a/src/LastFm/ScrobbleMatcher.php
+++ b/src/LastFm/ScrobbleMatcher.php
@@ -4,6 +4,7 @@ namespace App\LastFm;
 
 use App\Navidrome\NavidromeRepository;
 use App\Repository\LastFmAliasRepository;
+use App\Repository\LastFmArtistAliasRepository;
 
 /**
  * Encapsulates the matching cascade Last.fm scrobble → Navidrome media_file.
@@ -12,11 +13,12 @@ use App\Repository\LastFmAliasRepository;
  * one place.
  *
  * Cascade order (each step short-circuits on success) :
- *   1. Manual alias    → STATUS_MATCHED or STATUS_SKIPPED if alias targets null
- *   2. MBID            → STATUS_MATCHED
- *   3. Triplet (artist, title, album) when album is non-empty → STATUS_MATCHED
- *   4. Couple (artist, title) with strip-feat / strip-version-markers
- *   5. Fuzzy Levenshtein (opt-in via fuzzyMaxDistance > 0)
+ *   1. Track-level manual alias → STATUS_MATCHED or STATUS_SKIPPED
+ *   2. Artist-level alias       → rewrite artist name, fall through to next step
+ *   3. MBID                     → STATUS_MATCHED
+ *   4. Triplet (artist, title, album) when album is non-empty → STATUS_MATCHED
+ *   5. Couple (artist, title) with strip-feat / strip-version-markers / etc.
+ *   6. Fuzzy Levenshtein (opt-in via fuzzyMaxDistance > 0)
  *   → STATUS_UNMATCHED if everything fails.
  */
 class ScrobbleMatcher
@@ -25,13 +27,14 @@ class ScrobbleMatcher
         private readonly NavidromeRepository $navidrome,
         private readonly ?LastFmAliasRepository $aliasRepository = null,
         private readonly int $fuzzyMaxDistance = 0,
+        private readonly ?LastFmArtistAliasRepository $artistAliasRepository = null,
     ) {
     }
 
     public function match(LastFmScrobble $scrobble): MatchResult
     {
-        // Manual alias overrides every heuristic. A `null` target means
-        // « ignore this scrobble silently » (skipped status).
+        // Track-level manual alias overrides every heuristic. A `null`
+        // target means « ignore this scrobble silently » (skipped).
         $alias = $this->aliasRepository?->findByScrobble($scrobble->artist, $scrobble->title);
         if ($alias !== null) {
             if ($alias->isSkip()) {
@@ -41,6 +44,21 @@ class ScrobbleMatcher
             if ($mfid !== null) {
                 return MatchResult::matched($mfid);
             }
+        }
+
+        // Artist-level alias: rewrite the source artist before any
+        // heuristic. Lets a single mapping cover ALL tracks of a renamed
+        // artist (e.g. "La Ruda Salska" → "La Ruda" matches every La Ruda
+        // track in the library without needing a per-track alias).
+        $resolvedArtist = $this->artistAliasRepository?->resolve($scrobble->artist);
+        if ($resolvedArtist !== null && $resolvedArtist !== '' && $resolvedArtist !== $scrobble->artist) {
+            $scrobble = new LastFmScrobble(
+                artist: $resolvedArtist,
+                title: $scrobble->title,
+                album: $scrobble->album,
+                mbid: $scrobble->mbid,
+                playedAt: $scrobble->playedAt,
+            );
         }
 
         if ($scrobble->mbid !== null) {

--- a/src/Repository/LastFmArtistAliasRepository.php
+++ b/src/Repository/LastFmArtistAliasRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LastFmArtistAlias;
+use App\Navidrome\NavidromeRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LastFmArtistAlias>
+ */
+class LastFmArtistAliasRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LastFmArtistAlias::class);
+    }
+
+    /**
+     * Look up an artist alias by its source name. Lookup is normalized
+     * via {@see NavidromeRepository::normalize()} (case / accents /
+     * punctuation insensitive).
+     */
+    public function findBySourceArtist(string $artist): ?LastFmArtistAlias
+    {
+        $norm = NavidromeRepository::normalize($artist);
+        if ($norm === '') {
+            return null;
+        }
+
+        return $this->findOneBy(['sourceArtistNorm' => $norm]);
+    }
+
+    /**
+     * Resolve `$artist` to its canonical form via the alias table, or
+     * return null when no alias is registered. Used by the matching
+     * cascade ({@see \App\LastFm\ScrobbleMatcher}) to rewrite the source
+     * artist before any heuristic.
+     */
+    public function resolve(string $artist): ?string
+    {
+        $alias = $this->findBySourceArtist($artist);
+
+        return $alias?->getTargetArtist();
+    }
+
+    /**
+     * Paginated search by substring on source / target artist.
+     *
+     * @return list<LastFmArtistAlias>
+     */
+    public function search(string $query, int $page, int $perPage): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->orderBy('a.createdAt', 'DESC')
+            ->setFirstResult(max(0, ($page - 1) * $perPage))
+            ->setMaxResults($perPage);
+
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.targetArtist) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        /** @var list<LastFmArtistAlias> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    public function countSearch(string $query): int
+    {
+        $qb = $this->createQueryBuilder('a')->select('COUNT(a.id)');
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.targetArtist) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -67,7 +67,8 @@
                             <a href="{{ path('app_lastfm_import') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Import</a>
                             <a href="{{ path('app_lastfm_unmatched') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Unmatched</a>
                             <a href="{{ path('app_lastfm_love_sync') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Sync loved/star</a>
-                            <a href="{{ path('app_lastfm_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias</a>
+                            <a href="{{ path('app_lastfm_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias tracks</a>
+                            <a href="{{ path('app_lastfm_artist_alias_index') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Alias artistes</a>
                         </div>
                     </div>
                     <a href="{{ path('app_tagging_missing_mbid') }}" class="hover:underline">Tagging</a>

--- a/templates/lastfm/artist_aliases/form.html.twig
+++ b/templates/lastfm/artist_aliases/form.html.twig
@@ -1,0 +1,49 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ alias ? 'Modifier alias artiste' : 'Nouvel alias artiste' }} Last.fm{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-sky-700 hover:underline">
+            ← Retour à la liste des alias artistes
+        </a>
+    </div>
+
+    <h1 class="text-2xl font-semibold mb-2">
+        {{ alias ? 'Modifier l\'alias artiste' : 'Nouvel alias artiste' }}
+    </h1>
+    <p class="text-sm text-slate-500 mb-6">
+        Réécrit le nom d'artiste source en nom canonique avant la cascade de matching.
+        Un seul alias couvre tous les morceaux de l'artiste — utile pour les renommages
+        (« La Ruda Salska » → « La Ruda »), les variantes de romanisation, ou les conventions
+        « The X » / « X, The ».
+    </p>
+
+    <div class="bg-white shadow rounded p-6 max-w-2xl">
+        {{ form_start(form) }}
+            <div class="space-y-4">
+                <div>
+                    {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
+                    {{ form_errors(form.source_artist) }}
+                </div>
+                <div>
+                    {{ form_label(form.target_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.target_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_artist) }}</p>
+                    {{ form_errors(form.target_artist) }}
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3 mt-6">
+                <button type="submit" class="px-4 py-2 rounded bg-slate-900 text-white text-sm">
+                    {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias artiste' }}
+                </button>
+                <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-slate-500 hover:underline">
+                    Annuler
+                </a>
+            </div>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/lastfm/artist_aliases/index.html.twig
+++ b/templates/lastfm/artist_aliases/index.html.twig
@@ -1,0 +1,86 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Alias artistes Last.fm{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Alias artistes Last.fm → Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ total|number_format(0, '.', ' ') }} alias définis. Réécrit le nom d'artiste avant la cascade
+                (utile pour les renommages : « La Ruda Salska » → « La Ruda »). Un seul alias couvre tous les
+                morceaux. Pour mapper un track précis vers un media_file, utilisez les
+                <a href="{{ path('app_lastfm_alias_index') }}" class="underline">alias track-level</a>.
+            </p>
+        </div>
+        <a href="{{ path('app_lastfm_artist_alias_new') }}"
+           class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">+ Nouvel alias artiste</a>
+    </div>
+
+    <form method="get" class="bg-white shadow rounded p-4 mb-4 flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[200px]">
+            <label class="block text-xs uppercase text-slate-500">Recherche</label>
+            <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste source ou cible…"
+                   class="w-full border rounded px-2 py-1 text-sm">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
+    </form>
+
+    {% if aliases is empty %}
+        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+            {% if filters.q %}
+                Aucun alias artiste ne correspond à « {{ filters.q }} ».
+            {% else %}
+                Aucun alias artiste défini pour l'instant. Cliquez « + Nouvel alias artiste » ou utilisez le bouton
+                « 🎭 Aliaser l'artiste » sur la page <a href="{{ path('app_lastfm_unmatched') }}" class="underline">Unmatched</a>.
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2">Artiste source (Last.fm)</th>
+                    <th class="px-3 py-2">Artiste cible (Navidrome)</th>
+                    <th class="px-3 py-2">Créé le</th>
+                    <th class="px-3 py-2"></th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for alias in aliases %}
+                    <tr>
+                        <td class="px-3 py-1.5">{{ alias.sourceArtist }}</td>
+                        <td class="px-3 py-1.5">{{ alias.targetArtist }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">{{ alias.createdAt|date('Y-m-d H:i') }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            <a href="{{ path('app_lastfm_artist_alias_edit', {id: alias.id}) }}"
+                               class="text-xs text-sky-700 hover:underline">Modifier</a>
+                            <form method="post" action="{{ path('app_lastfm_artist_alias_delete', {id: alias.id}) }}"
+                                  class="inline-block ml-2"
+                                  onsubmit="return confirm('Supprimer cet alias artiste ?');">
+                                <input type="hidden" name="_token" value="{{ csrf_token('delete-artist-alias-' ~ alias.id) }}">
+                                <button type="submit" class="text-xs text-rose-700 hover:underline">Supprimer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/lastfm/unmatched.html.twig
+++ b/templates/lastfm/unmatched.html.twig
@@ -101,6 +101,9 @@
                             <a href="{{ path('app_lastfm_alias_new', {source_artist: row.artist, source_title: row.title}) }}"
                                class="text-xs px-2 py-0.5 rounded bg-slate-700 text-white hover:bg-slate-800 mr-1"
                                title="Créer un alias manuel pour ce scrobble">✏️ Mapper</a>
+                            <a href="{{ path('app_lastfm_artist_alias_new', {source_artist: row.artist}) }}"
+                               class="text-xs px-2 py-0.5 rounded bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
+                               title="Aliaser ce nom d'artiste vers son nom canonique côté Navidrome">🎭 Aliaser artiste</a>
                             {% if lidarr_configured and lidarr_reachable and not row.lidarr_url %}
                                 <form method="post" action="{{ path('app_lidarr_add_artist') }}"
                                       class="inline"

--- a/tests/LastFm/InMemoryArtistAliasRepository.php
+++ b/tests/LastFm/InMemoryArtistAliasRepository.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Tests\LastFm;
+
+use App\Entity\LastFmArtistAlias;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmArtistAliasRepository;
+
+/**
+ * Stub LastFmArtistAliasRepository that skips parent::__construct (no
+ * Doctrine registry needed) and looks up aliases against an in-memory
+ * list.
+ */
+final class InMemoryArtistAliasRepository extends LastFmArtistAliasRepository
+{
+    /** @param LastFmArtistAlias[] $aliases */
+    public function __construct(private readonly array $aliases)
+    {
+        // Skip parent::__construct — we don't need the Doctrine registry.
+    }
+
+    public function findBySourceArtist(string $artist): ?LastFmArtistAlias
+    {
+        $norm = NavidromeRepository::normalize($artist);
+        foreach ($this->aliases as $a) {
+            if ($a->getSourceArtistNorm() === $norm) {
+                return $a;
+            }
+        }
+
+        return null;
+    }
+
+    public function resolve(string $artist): ?string
+    {
+        return $this->findBySourceArtist($artist)?->getTargetArtist();
+    }
+}

--- a/tests/LastFm/ScrobbleMatcherTest.php
+++ b/tests/LastFm/ScrobbleMatcherTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\LastFm;
 
 use App\Entity\LastFmAlias;
+use App\Entity\LastFmArtistAlias;
 use App\LastFm\LastFmScrobble;
 use App\LastFm\MatchResult;
 use App\LastFm\ScrobbleMatcher;
@@ -105,5 +106,81 @@ class ScrobbleMatcherTest extends TestCase
         $r = $matcher->match(new LastFmScrobble('Some Podcast', 'Episode 42', '', null, new \DateTimeImmutable()));
         $this->assertSame(MatchResult::STATUS_SKIPPED, $r->status);
         $this->assertNull($r->mediaFileId);
+    }
+
+    public function testArtistAliasRewritesNameAndCascadeMatches(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        // Lib only has tracks under the canonical name "La Ruda".
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'L\'instinct du meilleur', 'La Ruda');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Le prix du silence', 'La Ruda');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $artistAliasRepo = new InMemoryArtistAliasRepository([
+            new LastFmArtistAlias('La Ruda Salska', 'La Ruda'),
+        ]);
+        $matcher = new ScrobbleMatcher($repo, null, 0, $artistAliasRepo);
+
+        // Last.fm scrobble uses the old name → strict match would fail, alias rewrites it.
+        $r = $matcher->match(new LastFmScrobble('La Ruda Salska', 'L\'instinct du meilleur', '', null, new \DateTimeImmutable()));
+        $this->assertSame(MatchResult::STATUS_MATCHED, $r->status);
+        $this->assertSame('mf-1', $r->mediaFileId);
+
+        // Same alias covers ANOTHER track of the same artist.
+        $r = $matcher->match(new LastFmScrobble('La Ruda Salska', 'Le prix du silence', '', null, new \DateTimeImmutable()));
+        $this->assertSame('mf-2', $r->mediaFileId);
+    }
+
+    public function testArtistAliasSkippedWhenNotConfigured(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track', 'La Ruda');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // No artist alias repo → "La Ruda Salska" stays as-is, strict match fails.
+        $matcher = new ScrobbleMatcher($repo);
+
+        $r = $matcher->match(new LastFmScrobble('La Ruda Salska', 'Track', '', null, new \DateTimeImmutable()));
+        $this->assertSame(MatchResult::STATUS_UNMATCHED, $r->status);
+    }
+
+    public function testTrackAliasTakesPriorityOverArtistAlias(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-canonical', 'Track', 'La Ruda');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-track-override', 'Track', 'Other Artist');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // Track-level alias forces this scrobble to mf-track-override.
+        $trackAliasRepo = new InMemoryAliasRepository([
+            new LastFmAlias('La Ruda Salska', 'Track', 'mf-track-override'),
+        ]);
+        // Artist-level alias would rewrite to "La Ruda" → mf-canonical.
+        $artistAliasRepo = new InMemoryArtistAliasRepository([
+            new LastFmArtistAlias('La Ruda Salska', 'La Ruda'),
+        ]);
+
+        $matcher = new ScrobbleMatcher($repo, $trackAliasRepo, 0, $artistAliasRepo);
+        $r = $matcher->match(new LastFmScrobble('La Ruda Salska', 'Track', '', null, new \DateTimeImmutable()));
+
+        // Track-level wins.
+        $this->assertSame('mf-track-override', $r->mediaFileId);
+    }
+
+    public function testArtistAliasIsCaseAndAccentInsensitive(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track', 'Tchaikovsky');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $artistAliasRepo = new InMemoryArtistAliasRepository([
+            // Stored with accent + capitalization.
+            new LastFmArtistAlias('Tchaïkovski', 'Tchaikovsky'),
+        ]);
+        $matcher = new ScrobbleMatcher($repo, null, 0, $artistAliasRepo);
+
+        // Lookup with different casing AND missing accent (matches via np_normalize).
+        $r = $matcher->match(new LastFmScrobble('TCHAIKOVSKI', 'Track', '', null, new \DateTimeImmutable()));
+        $this->assertSame('mf-1', $r->mediaFileId);
     }
 }


### PR DESCRIPTION
## Summary

Quand Last.fm envoie un nom qui ne match pas la lib Navidrome (renommage : « La Ruda Salska » → « La Ruda » ; romanisation : « Tchaïkovski » / « Tchaikovsky » ; convention : « The Beatles » / « Beatles, The »), créer un alias track-level par morceau n'est pas tenable. Cette PR ajoute un alias **niveau artiste** qui réécrit le nom dans le `LastFmScrobble` avant la cascade — un seul alias couvre tous les morceaux.

## Architecture

- **Migration** `Version20260502100000` : nouvelle table `lastfm_artist_alias` (id, source_artist, source_artist_norm UNIQUE, target_artist, created_at). `isTransactional() = false` pour éviter le « no active transaction » SQLite + DDL avec `--all-or-nothing`.
- **Entité** `App\Entity\LastFmArtistAlias` avec `setSource()` qui re-normalise via `NavidromeRepository::normalize()`.
- **Repository** `LastFmArtistAliasRepository` : `findBySourceArtist()`, `resolve()` (wrapper pour le matcher), `search()` / `countSearch()` paginés.
- **Pipeline** dans `App\LastFm\ScrobbleMatcher` :
  1. Alias track-level (`lastfm_alias`) — inchangé, **priorité 1**.
  2. **NEW** Alias artiste : si match, réécrit l'artiste du `LastFmScrobble` puis fall-through vers la cascade.
  3. MBID, triplet, couple, fuzzy — inchangés.
- **Controller** CRUD `LastFmArtistAliasController` (pattern copié de `LastFmAliasController`) avec form `LastFmArtistAliasType` (2 champs : source, target).
- **Templates** `templates/lastfm/artist_aliases/{index,form}.html.twig`.

## UI

- Entrée « Alias artistes » dans le menu Last.fm (renommé « Alias » → « Alias tracks » pour différencier).
- Bouton « 🎭 Aliaser artiste » par ligne sur `/lastfm/unmatched`, pré-remplit le form via query string.

## Workflow utilisateur

1. `/lastfm/unmatched` → repérer un artiste mal nommé (ex. en haut de liste : « La Ruda Salska / Marilyne » 43 scrobbles).
2. Bouton « 🎭 Aliaser artiste » → form pré-rempli, saisir « La Ruda » comme cible.
3. `/lastfm/import` → « 🔁 Re-tenter le matching cumulé » (#21).
4. Tous les scrobbles de l'artiste basculent en `inserted` d'un coup.

## Test plan

- [x] 4 nouveaux tests dans `ScrobbleMatcherTest` :
  - Réécriture artiste + cascade matche correctement.
  - Alias inactif si repo absent (backwards compat).
  - **Track-level prioritaire** sur artist-level (sécurité).
  - Lookup case/accents insensitive (ex. `Tchaïkovski` ↔ `TCHAIKOVSKI`).
- [x] `tests/LastFm/InMemoryArtistAliasRepository` : nouveau stub parallèle à `InMemoryAliasRepository`.
- [x] `composer ci` → 239 tests, 575 assertions, 0 failure.
- [x] Migration testée en local : `bin/console doctrine:migrations:migrate -n --all-or-nothing=false` → table créée.
- [x] Routes enregistrées : `app_lastfm_artist_alias_{index,new,edit,delete}`.

## Hors-scope

- **Alias d'album** : pas demandé. Si besoin plus tard, table similaire `lastfm_album_alias`.
- **Alias bidirectionnel** : un alias n'est pas symétrique — source → cible uniquement. Les sync nd→lf utilisent le nom Navidrome canonique qui est la bonne valeur par construction.
- **Wildcard / regex** : `source_artist` est un nom littéral. Pour les patterns plus complexes, ouvrir une issue dédiée.
- **Détection automatique** des artistes à aliaser : sujet de #19.

Closes #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)