### PR TITLE
feat(matching): featuring asymétrique Last.fm titre vs Navidrome artiste (closes #67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **Matching Last.fm — featuring asymétrique** : nouveau palier
+  `lookupArtistPrefixFeaturingTitle()` dans la cascade
+  `findMediaFileByArtistTitle()`. Catche le cas où Last.fm met le
+  featuring dans le titre (ex. `Jurassic 5 / Join The Dots (Ft Roots
+  Manuva`) tandis que Navidrome le met dans l'artiste (ex. `Jurassic 5
+  feat. Roots Manuva / Join the Dots`). Active uniquement quand le
+  titre original contient un marker explicite `(feat./ft./featuring/
+  with X)` (helper `titleHasFeaturingMarker`) — gardé strict sur le
+  titre nettoyé pour limiter les faux-positifs. Marker LIKE côté
+  artiste : `:a feat %`, `:a ft %`, `:a featuring %`, `:a with %`.
+  Mesuré sur le dataset local : 23 unmatched distincts avec marker,
+  6 récupérables (Orelsan, Cypress Hill, Tiken Jah Fakoly, High Tone…).
+  Closes #67.
 - **Alias d'artistes (synonymes)** : nouvelle table
   `lastfm_artist_alias` (id, source_artist, source_artist_norm UNIQUE,
   target_artist, created_at) qui mappe un nom source Last.fm → nom

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,6 +200,13 @@ Décisions structurantes :
      Demo/Instrumental sont volontairement non strippés (différents
      enregistrements) ;
   4. les deux strips combinés.
+  5. **Featuring asymétrique** : si le titre original contenait un
+     marker `(feat./ft./featuring/with X)` (`titleHasFeaturingMarker`)
+     et que les paliers précédents ont échoué, retente avec
+     `lookupArtistPrefixFeaturingTitle()` — title strict sur le bare,
+     artiste LIKE `:a feat %` / `:a ft %` / etc. Catche le cas où
+     Last.fm met le featuring dans le titre et Navidrome dans
+     l'artiste.
 - **`scrobbles.submission_time` en INTEGER unix epoch** depuis
   Navidrome 0.55. Toutes les requêtes Navidrome bindent
   `getTimestamp()` (PARAM INTEGER) et passent le modifier

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -1207,6 +1207,7 @@ class NavidromeRepository
         $bareTitleN = self::normalize($bareTitle);
         $artistChanged = $leadArtistN !== '' && $leadArtistN !== $artistN;
         $titleChanged = $bareTitleN !== '' && $bareTitleN !== $titleN;
+        $titleHadFeaturing = self::titleHasFeaturingMarker($title);
 
         if ($artistChanged) {
             $id = $this->lookupExactArtistTitle($leadArtistN, $titleN);
@@ -1218,6 +1219,20 @@ class NavidromeRepository
             $id = $this->lookupExactArtistTitle($artistN, $bareTitleN);
             if ($id !== null) {
                 return $id;
+            }
+
+            // Asymmetric featuring : Last.fm packs "(feat. X)" in the title,
+            // Navidrome packs it in the artist column ("Jurassic 5 feat.
+            // Roots Manuva / Join the Dots"). Strict match on bareTitle
+            // failed because the artist column has a longer string. Try a
+            // prefix-based artist lookup, gated on the explicit featuring
+            // marker in the original title to keep the false-positive rate
+            // tight.
+            if ($titleHadFeaturing) {
+                $id = $this->lookupArtistPrefixFeaturingTitle($artistN, $bareTitleN);
+                if ($id !== null) {
+                    return $id;
+                }
             }
         }
         if ($artistChanged && $titleChanged) {
@@ -1249,6 +1264,74 @@ class NavidromeRepository
         $id = $this->connection()->fetchOne($sql, ['a' => $artistNormalized, 't' => $titleNormalized]);
 
         return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * Refined lookup for the asymmetric-featuring case: title strict on
+     * the bare (already feat-stripped) form, artist matched as a prefix
+     * followed by a recognised featuring marker. Catches the convention
+     * where Last.fm puts "(feat. X)" in the title while Navidrome puts
+     * it in the artist column. Gated by {@see titleHasFeaturingMarker()}
+     * in the cascade caller to avoid false-positives on plain titles.
+     *
+     * Marker list mirrors {@see stripFeaturingFromTitle()}: feat / ft /
+     * featuring / with — already lower-cased and dot-stripped by
+     * np_normalize() on the candidate side, hence the simple `LIKE
+     * ':a feat %'` form below.
+     */
+    private function lookupArtistPrefixFeaturingTitle(string $artistNormalized, string $titleNormalized): ?string
+    {
+        if ($artistNormalized === '' || $titleNormalized === '') {
+            return null;
+        }
+
+        $sql = 'SELECT id FROM media_file
+                WHERE np_normalize(title) = :t
+                  AND (
+                      np_normalize(artist) LIKE :feat
+                      OR np_normalize(artist) LIKE :ft
+                      OR np_normalize(artist) LIKE :featuring
+                      OR np_normalize(artist) LIKE :with
+                  )
+                ORDER BY id ASC
+                LIMIT 1';
+        $id = $this->connection()->fetchOne($sql, [
+            't' => $titleNormalized,
+            'feat' => $artistNormalized . ' feat %',
+            'ft' => $artistNormalized . ' ft %',
+            'featuring' => $artistNormalized . ' featuring %',
+            'with' => $artistNormalized . ' with %',
+        ]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * True when the (raw) title carries an explicit featuring marker —
+     * "(feat. X)" / "[ft. X]" / "(featuring X)" / "(with X)" — including
+     * truncated open-paren forms ("(Ft Roots Manuva" without trailing
+     * `)`) when the truncation comes from Last.fm's title length cap.
+     * Used as the signal to enable {@see lookupArtistPrefixFeaturingTitle()}.
+     */
+    private static function titleHasFeaturingMarker(string $title): bool
+    {
+        // Closed paren / bracket form.
+        if (preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+[^)]+\)/iu', $title)) {
+            return true;
+        }
+        if (preg_match('/\[(?:feat\.?|ft\.?|featuring|with)\s+[^\]]+\]/iu', $title)) {
+            return true;
+        }
+
+        // Truncated open paren (no closing paren in the whole title).
+        if (
+            !preg_match('/\([^)]*\)/u', $title)
+            && preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+/iu', $title)
+        ) {
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Navidrome/NavidromeRepositoryTest.php
+++ b/tests/Navidrome/NavidromeRepositoryTest.php
@@ -600,6 +600,70 @@ class NavidromeRepositoryTest extends TestCase
         $this->assertNull($repo->findMediaFileByArtistTitle('Some Artist', 'Foo (random truncated text'));
     }
 
+    public function testFindMediaFileByArtistTitleAsymmetricFeaturingTruncated(): void
+    {
+        // Last.fm packs "(Ft Roots Manuva" (truncated) in the title, while
+        // Navidrome stores the featuring info on the artist column.
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Join the Dots', 'Jurassic 5 feat. Roots Manuva');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame('mf-feat', $repo->findMediaFileByArtistTitle('Jurassic 5', 'Join The Dots (Ft Roots Manuva'));
+    }
+
+    public function testFindMediaFileByArtistTitleAsymmetricFeaturingClosedParen(): void
+    {
+        // Same convention but with the closing `)` present.
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Crazy in Love', 'Beyoncé feat. Jay-Z');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame('mf-feat', $repo->findMediaFileByArtistTitle('Beyoncé', 'Crazy in Love (feat. Jay-Z)'));
+    }
+
+    public function testFindMediaFileByArtistTitleAsymmetricFeaturingFtVariant(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Run This Town', 'Jay-Z ft. Rihanna');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame('mf-feat', $repo->findMediaFileByArtistTitle('Jay-Z', 'Run This Town (ft. Rihanna)'));
+    }
+
+    public function testFindMediaFileByArtistTitleAsymmetricFeaturingWithVariant(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Bad Guy', 'Billie Eilish with Justin Bieber');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame('mf-feat', $repo->findMediaFileByArtistTitle('Billie Eilish', 'Bad Guy (with Justin Bieber)'));
+    }
+
+    public function testFindMediaFileByArtistTitlePrefersStrictArtistOverFeaturingCandidate(): void
+    {
+        // Both artists exist : the bare artist as-is AND the prefixed feat.
+        // form. The strict palier should win — we only fall through to the
+        // prefix lookup when strict fails.
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-strict', 'Some Track', 'Beyoncé');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Some Track', 'Beyoncé feat. Jay-Z');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame('mf-strict', $repo->findMediaFileByArtistTitle('Beyoncé', 'Some Track (feat. Jay-Z)'));
+    }
+
+    public function testFindMediaFileByArtistTitleAsymmetricFeaturingAbstainsWithoutMarker(): void
+    {
+        // Title has no featuring marker → the prefix-based palier must NOT
+        // fire (false-positive guard). Returns null even though the lib has
+        // a "Beyoncé feat. Jay-Z / Some Track" candidate.
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-feat', 'Some Track', 'Beyoncé feat. Jay-Z');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertNull($repo->findMediaFileByArtistTitle('Beyoncé', 'Some Track'));
+    }
+
     /**
      * @return iterable<string, array{0: string, 1: string}>
      */


### PR DESCRIPTION
## Summary

Cas typique reporté : `Jurassic 5 / Join The Dots (Ft Roots Manuva` côté Last.fm reste unmatched alors que la lib contient `Jurassic 5 feat. Roots Manuva / Join the Dots / Pre-Historik Rarities`.

Last.fm met le featuring dans le **titre** (souvent tronqué), Navidrome dans l'**artiste**. Aucun palier précédent (`stripFeaturedArtists`, `stripTruncatedParen`, `stripFeaturingFromTitle`, fuzzy) ne résolvait ce mismatch asymétrique.

## Implémentation

Nouveau palier `lookupArtistPrefixFeaturingTitle()` dans `findMediaFileByArtistTitle()`, inséré dans la branche `titleChanged` après l'échec du strict-bare :

```sql
SELECT id FROM media_file
WHERE np_normalize(title) = :t
  AND (np_normalize(artist) LIKE :a || ' feat %'
       OR ...               LIKE :a || ' ft %'
       OR ...               LIKE :a || ' featuring %'
       OR ...               LIKE :a || ' with %')
ORDER BY id ASC LIMIT 1
```

**Garde-fous** :
- Titre **strict** (pas de LIKE sur le titre) — réduit drastiquement les FP.
- Markers explicites dans le LIKE (pas un wildcard ouvert).
- Activation conditionnelle via `titleHasFeaturingMarker(string)` : retourne `true` uniquement si le titre original contient `(feat./ft./featuring/with X)` (closed/bracket) ou la forme tronquée `(feat./ft./... X` sans `)` fermée.
- Strict prioritaire : si la lib a à la fois `Beyoncé` et `Beyoncé feat. Jay-Z` pour le même titre, le palier 0 (strict) gagne.

## Mesure d'impact

Sur le dataset local :
- **23** unmatched distincts avec featuring marker dans le titre.
- **6** récupérables avec ce nouveau palier (Orelsan, Cypress Hill, Tiken Jah Fakoly, High Tone, etc.).

Les 17 autres sont des unmatched légitimes (track absent de la lib).

## Test plan

- [x] 6 nouveaux tests dans `NavidromeRepositoryTest` :
  - Truncated paren `(Ft Roots Manuva` (le cas reporté en production).
  - Closed paren `(feat. Jay-Z)`.
  - Variants `ft.` et `with`.
  - **Preference for strict** over featuring candidate (sécurité).
  - **Abstain when no marker** in title (FP guard).
- [x] `composer ci` → 245 tests, 581 assertions, 0 failure.
- [x] Mesure live sur `var/data.db` × `var/navidrome.db` : 6 nouveaux matches confirmés.

## Critical files

- `src/Navidrome/NavidromeRepository.php` :
  - `findMediaFileByArtistTitle()` (nouveau call dans la branche `titleChanged`)
  - `lookupArtistPrefixFeaturingTitle()` (nouveau)
  - `titleHasFeaturingMarker()` (nouveau, static helper)
- `tests/Navidrome/NavidromeRepositoryTest.php` (+6 tests).
- `CLAUDE.md` §3 (cascade documentée à 5 paliers maintenant).
- `CHANGELOG.md`.

## Workflow utilisateur

Aucune action requise. Le palier s'applique automatiquement à tout nouveau scrobble + à tous les unmatched existants une fois la PR mergée et `app:lastfm:rematch` lancé. Pas de migration, pas de config.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)