### PR TITLE
feat(plugins): support custom playlist generators via /app/plugins volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **Plugins custom en déploiement Docker** : nouveau namespace
+  `App\Plugin\` mappé sur `plugins/`, bind-mountable sur `/app/plugins`
+  pour ajouter ses propres générateurs de playlists sans rebuilder
+  l'image. L'autoload Composer et le cache Symfony sont régénérés à
+  chaque démarrage du conteneur (`docker/entrypoint.sh`). Le flag
+  `--classmap-authoritative` est retiré du `Dockerfile` pour autoriser
+  le fallback PSR-4 actif au runtime ; le classmap optimisé reste en
+  place pour les vendors. Documentation complète dans
+  `docs/PLUGINS.md` (section « Plugins custom en déploiement Docker »)
+  avec exemple de classe et bind-mount à dupliquer sur les services
+  web ET cron. Closes #69.
 - **Matching Last.fm — featuring asymétrique** : nouveau palier
   `lookupArtistPrefixFeaturingTitle()` dans la cascade
   `findMediaFileByArtistTitle()`. Catche le cas où Last.fm met le

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,9 @@ RUN composer install --no-dev --no-scripts --prefer-dist --no-interaction --no-p
 
 COPY . .
 
-RUN composer dump-autoload --optimize --no-dev --classmap-authoritative \
- && mkdir -p var \
- && chown -R www-data:www-data var \
+RUN composer dump-autoload --optimize --no-dev \
+ && mkdir -p var plugins \
+ && chown -R www-data:www-data var plugins \
  && APP_ENV=prod APP_DEBUG=0 php bin/console cache:warmup --env=prod || true
 
 COPY docker/entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -706,6 +706,12 @@ qui implémente `App\Generator\PlaylistGeneratorInterface` dans
 `src/Generator/`, elle est auto-détectée et apparaît immédiatement dans
 le dropdown de l'UI.
 
+**En déploiement Docker**, il n'est pas nécessaire de rebuilder
+l'image : il suffit de bind-mounter un dossier hôte sur `/app/plugins`
+(namespace `App\Plugin\`) et d'y déposer ses classes. L'autoload et le
+cache Symfony sont régénérés à chaque démarrage du conteneur. Détails et
+exemple complet dans [`docs/PLUGINS.md`](docs/PLUGINS.md#plugins-custom-en-déploiement-docker).
+
 ## Schéma Navidrome utilisé (lecture seule)
 
 | Table          | Colonnes lues                                                |

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
     },
     "autoload": {
         "psr-4": {
-            "App\\": "src/"
+            "App\\": "src/",
+            "App\\Plugin\\": "plugins/"
         }
     },
     "autoload-dev": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -41,6 +41,9 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
+    App\Plugin\:
+        resource: '../plugins/'
+
     App\Generator\GeneratorRegistry:
         arguments:
             $generators: !tagged_iterator app.playlist_generator

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -44,6 +44,9 @@ services:
       - navidrome-tools-data:/app/var
       # Dedicated volume for the cover-art cache (can grow to ~MBs).
       - navidrome-tools-covers:/app/var/covers
+      # Optional: bind-mount custom playlist generators (App\Plugin\ namespace).
+      # See docs/PLUGINS.md. Mount the SAME path on the cron service below.
+      # - ./plugins:/app/plugins:ro
 
   navidrome-tools-cron:
     image: ghcr.io/kgaut/navidrome-tools:latest
@@ -85,6 +88,9 @@ services:
       - ${NAVIDROME_DATA_DIR:-/srv/navidrome/data}/navidrome.db:/data/navidrome.db:ro
       - navidrome-tools-data:/app/var
       - navidrome-tools-covers:/app/var/covers
+      # Optional: bind-mount custom playlist generators (App\Plugin\ namespace).
+      # MUST match the mount on the web service above so cron runs see the same plugins.
+      # - ./plugins:/app/plugins:ro
 
 volumes:
   navidrome-tools-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,13 @@ set -eu
 
 cd /app
 
-mkdir -p var
+mkdir -p var plugins
+
+# Refresh autoload + DI cache so plugins dropped in /app/plugins are picked up.
+composer dump-autoload --no-dev --optimize --working-dir=/app --no-interaction --quiet
+rm -rf /app/var/cache/prod
+php bin/console cache:warmup --env="${APP_ENV:-prod}"
+
 # Apply Doctrine migrations on every boot (idempotent).
 php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration --env="${APP_ENV:-prod}" || {
     echo "Migration failed" >&2

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -3,8 +3,8 @@
 Chaque type de playlist proposé par le tool est une classe PHP qui
 implémente `App\Generator\PlaylistGeneratorInterface`. L'autoconfigure
 de Symfony tague automatiquement toute classe dans `src/Generator/`
-qui implémente cette interface, et `GeneratorRegistry` la rend disponible
-dans :
+(côté projet) ou `plugins/` (extension utilisateur) qui implémente cette
+interface, et `GeneratorRegistry` la rend disponible dans :
 
 - la liste déroulante du formulaire de définition (`/playlist/new`),
 - la commande `bin/console app:playlist:run`,
@@ -13,6 +13,16 @@ dans :
 **Aucun changement de configuration n'est nécessaire** : les paramètres
 sont stockés en JSON dans la colonne `parameters` de
 `playlist_definition`.
+
+Deux emplacements possibles :
+
+| Emplacement      | Namespace      | Cas d'usage                                            |
+|------------------|----------------|--------------------------------------------------------|
+| `src/Generator/` | `App\Generator\` | Générateurs livrés avec le projet (PR upstream).     |
+| `plugins/`       | `App\Plugin\`    | Générateurs custom de l'utilisateur, conservés hors du repo, montés via volume Docker. |
+
+Les deux fonctionnent strictement de la même manière — seul l'endroit où
+poser le fichier change.
 
 ## L'interface
 
@@ -136,3 +146,130 @@ class TopByGenreGeneratorTest extends \PHPUnit\Framework\TestCase
 
 Voir `tests/Generator/TopLastDaysGeneratorTest.php` pour un exemple
 complet utilisant une fixture SQLite minimaliste.
+
+## Plugins custom en déploiement Docker
+
+Quand on déploie via l'image GHCR (`ghcr.io/kgaut/navidrome-tools`), on
+ne peut évidemment pas éditer `src/Generator/` à l'intérieur du
+conteneur. À la place, on bind-mount un dossier hôte sur `/app/plugins`
+et on y dépose une ou plusieurs classes dans le namespace `App\Plugin\`.
+
+### 1. Préparer un dossier `plugins/` sur l'hôte
+
+```
+mkdir -p /srv/navidrome-tools/plugins
+```
+
+### 2. Y déposer un générateur
+
+Fichier `/srv/navidrome-tools/plugins/HelloPluginGenerator.php` :
+
+```php
+<?php
+
+namespace App\Plugin;
+
+use App\Generator\ParameterDefinition;
+use App\Generator\PlaylistGeneratorInterface;
+use App\Navidrome\NavidromeRepository;
+
+class HelloPluginGenerator implements PlaylistGeneratorInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+    ) {}
+
+    public function getKey(): string
+    {
+        return 'hello-plugin';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Plugin de démo';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Renvoie le top all-time, mais c\'est mon plugin à moi.';
+    }
+
+    public function getParameterSchema(): array
+    {
+        return [];
+    }
+
+    public function generate(array $parameters, int $limit): array
+    {
+        return $this->navidrome->topAllTime($limit);
+    }
+}
+```
+
+Règles :
+
+- Le fichier **doit** s'appeler `HelloPluginGenerator.php` (PSR-4 strict :
+  nom de fichier = nom de classe).
+- Le namespace **doit** être `App\Plugin` (ou un sous-namespace, ex.
+  `App\Plugin\Pop`, auquel cas le fichier va dans `plugins/Pop/`).
+- `getKey()` doit être unique dans tout le système (collision avec un
+  des 8 générateurs livrés ou avec un autre plugin = exception au boot).
+- L'autowire fonctionne : on peut injecter `NavidromeRepository`,
+  `Doctrine\DBAL\Connection`, etc., comme pour n'importe quel service.
+
+### 3. Monter le dossier dans `docker-compose.yml`
+
+Sur **les deux services** (web ET cron) :
+
+```yaml
+services:
+  navidrome-tools-web:
+    # ...
+    volumes:
+      - ./plugins:/app/plugins:ro
+      # autres volumes...
+
+  navidrome-tools-cron:
+    # ...
+    volumes:
+      - ./plugins:/app/plugins:ro
+      # autres volumes...
+```
+
+Si le mount est posé uniquement côté web, les définitions custom
+apparaissent dans l'UI mais leurs runs cron échoueront avec
+`Unknown generator key`.
+
+### 4. Redémarrer le conteneur
+
+```
+docker compose restart navidrome-tools-web navidrome-tools-cron
+```
+
+Au démarrage, l'entrypoint régénère l'autoload Composer puis warme le
+cache Symfony — les nouveaux générateurs sont alors visibles dans le
+dropdown du formulaire de définition. Ajouter ou modifier un plugin
+nécessite un `docker compose restart` (le cache DI n'est rebuildé qu'au
+boot).
+
+### 5. Vérifier
+
+```
+docker compose exec navidrome-tools-web php bin/console debug:container --tag=app.playlist_generator
+```
+
+doit lister votre classe (`App\Plugin\HelloPluginGenerator` par
+exemple) à côté des 8 générateurs livrés.
+
+### Limitations
+
+- **Pas de dépendances Composer additionnelles**. Les plugins ne peuvent
+  utiliser que les classes déjà présentes dans l'image (services du
+  projet + dépendances de `composer.json`). Si vous avez besoin d'une
+  lib externe, dérivez votre propre image (`FROM
+  ghcr.io/kgaut/navidrome-tools:latest`) et faites votre `composer
+  require` dedans.
+- **Erreurs de syntaxe = boot cassé**. Si le fichier déposé contient
+  une erreur fatale, le `cache:warmup` de l'entrypoint échoue et le
+  conteneur crash. Lire les logs (`docker compose logs
+  navidrome-tools-web`) pour le message d'erreur exact.


### PR DESCRIPTION
L'image Docker fige le classmap au build (composer dump-autoload
--classmap-authoritative + cache:warmup), ce qui empêche tout
chargement de classes ajoutées au runtime. Or les utilisateurs en
self-host veulent fournir leurs propres générateurs sans rebuilder
l'image, et un mount sur src/Generator/ est impossible (le dossier
contient déjà les 8 générateurs livrés).

On introduit un namespace dédié App\Plugin\ mappé vers plugins/. Le
dossier est destiné à être bind-mounté sur /app/plugins dans le
conteneur. L'entrypoint régénère l'autoload Composer et warme le cache
Symfony à chaque démarrage, donc les nouvelles classes sont découvertes
par le _instanceof + tagged_iterator déjà en place — aucun changement
dans GeneratorRegistry ni dans l'interface plugin.

Le flag --classmap-authoritative est retiré du Dockerfile pour laisser
le fallback PSR-4 actif. Le coût : ~5s ajoutées au boot du conteneur,
acceptable pour ce type d'app.

https://claude.ai/code/session_01WxgBaZTRFg4aWhFyofB9av