### PR TITLE
docs(roadmap): ajoute la gestion des playlists Navidrome au backlog

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,6 +56,29 @@ l'ordre d'attaque recommandé.
 | [#8]  | Export M3U téléchargeable depuis la prévisualisation            | S      |
 | [#5]  | Diff entre deux runs d'une même playlist                        | M      |
 
+#### Gestion des playlists Navidrome (meta [#71])
+
+Vraie page de gestion des playlists côté navidrome-tools : voir/renommer/
+supprimer/starrer sans avoir à ouvrir Navidrome. Toutes les écritures
+restent côté Subsonic (DB Navidrome `:ro`). Voir le meta [#71] pour le
+contexte complet et l'ordre d'attaque (72 → 73 → 74-77 en parallèle).
+
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#72] | Liste sur `/playlists` (étend `getPlaylists` avec count/durée/dates) | S      |
+| [#73] | Page détail `/playlists/{id}` avec tracks et statut starred        | S      |
+| [#74] | Renommer une playlist via `updatePlaylist.view`                    | S      |
+| [#75] | Supprimer depuis l'UI + nettoyage `lastSubsonicPlaylistId`         | S      |
+| [#76] | Star / unstar individuel d'un morceau (réutilise `starTracks`)     | S      |
+| [#77] | Bulk star/unstar de tous les morceaux d'une playlist               | S      |
+| [#79] | Dupliquer une playlist                                             | S      |
+| [#82] | Bulk delete depuis la liste                                        | S      |
+| [#83] | Export M3U depuis la page détail (mutualisé avec [#8])             | M      |
+| [#84] | Auto-star CLI réutilisant `starTracks` (ferme [#6])                | M      |
+| [#78] | Ajouter / retirer / réordonner des morceaux                        | M      |
+| [#80] | Statistiques par playlist (durée, top artistes, distribution)      | M      |
+| [#81] | Détection des morceaux morts + purge                               | M      |
+
 ### Cron / observabilité
 
 | #   | Titre                                                              | Effort |
@@ -128,3 +151,17 @@ quand on tagge des releases) :
 [#31]: https://github.com/kgaut/navidrome-playlist-generator/issues/31
 [#47]: https://github.com/kgaut/navidrome-playlist-generator/issues/47
 [#58]: https://github.com/kgaut/navidrome-playlist-generator/issues/58
+[#71]: https://github.com/kgaut/navidrome-playlist-generator/issues/71
+[#72]: https://github.com/kgaut/navidrome-playlist-generator/issues/72
+[#73]: https://github.com/kgaut/navidrome-playlist-generator/issues/73
+[#74]: https://github.com/kgaut/navidrome-playlist-generator/issues/74
+[#75]: https://github.com/kgaut/navidrome-playlist-generator/issues/75
+[#76]: https://github.com/kgaut/navidrome-playlist-generator/issues/76
+[#77]: https://github.com/kgaut/navidrome-playlist-generator/issues/77
+[#78]: https://github.com/kgaut/navidrome-playlist-generator/issues/78
+[#79]: https://github.com/kgaut/navidrome-playlist-generator/issues/79
+[#80]: https://github.com/kgaut/navidrome-playlist-generator/issues/80
+[#81]: https://github.com/kgaut/navidrome-playlist-generator/issues/81
+[#82]: https://github.com/kgaut/navidrome-playlist-generator/issues/82
+[#83]: https://github.com/kgaut/navidrome-playlist-generator/issues/83
+[#84]: https://github.com/kgaut/navidrome-playlist-generator/issues/84

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -74,7 +74,6 @@ contexte complet et l'ordre d'attaque (72 → 73 → 74-77 en parallèle).
 | [#79] | Dupliquer une playlist                                             | S      |
 | [#82] | Bulk delete depuis la liste                                        | S      |
 | [#83] | Export M3U depuis la page détail (mutualisé avec [#8])             | M      |
-| [#84] | Auto-star CLI réutilisant `starTracks` (ferme [#6])                | M      |
 | [#78] | Ajouter / retirer / réordonner des morceaux                        | M      |
 | [#80] | Statistiques par playlist (durée, top artistes, distribution)      | M      |
 | [#81] | Détection des morceaux morts + purge                               | M      |
@@ -164,4 +163,3 @@ quand on tagge des releases) :
 [#81]: https://github.com/kgaut/navidrome-playlist-generator/issues/81
 [#82]: https://github.com/kgaut/navidrome-playlist-generator/issues/82
 [#83]: https://github.com/kgaut/navidrome-playlist-generator/issues/83
-[#84]: https://github.com/kgaut/navidrome-playlist-generator/issues/84

--- a/TODO.md
+++ b/TODO.md
@@ -11,3 +11,17 @@
 11. ~~Sur la preview d'une playlist, la colonne `Plays` ne semble pas indiquer le total de lecture de la période concernée.~~
 12. ~~Tu peux m'ajouter une favicon (note de musique par exemple, comme pour le logo)~~
 13. ~~Je voudrais héberger une copie de ce dépot sur mon instance gitlab, peux tu me générer un fichier .gitlab-ci.yml avec les même jobs que github actions.~~
+14. Gestion des playlists Navidrome — feature à découper en sous-tickets (epic #71) :
+    - Page `/playlists` : liste des playlists Navidrome avec aperçu (nombre de morceaux, durée, date de création, date de modification, owner, public/privé). Étendre `SubsonicClient::getPlaylists()` pour récupérer `songCount`, `created`, `changed`, `duration`, `public`, `comment`.
+    - Page `/playlists/{id}` : voir le contenu d'une playlist (tracks avec artiste/album/durée/play count/statut starred). Ajouter `SubsonicClient::getPlaylist(string $id)` (wrap `getPlaylist.view`).
+    - Renommer une playlist : action POST + nouveau `SubsonicClient::updatePlaylist(string $id, ?string $name = null, ?string $comment = null, ?bool $public = null)` (wrap `updatePlaylist.view`).
+    - Supprimer une playlist depuis l'UI : réutiliser `SubsonicClient::deletePlaylist()` ; si la playlist est rattachée à un `PlaylistDefinition`, nettoyer `lastSubsonicPlaylistId`.
+    - Star / unstar un morceau : réutiliser `SubsonicClient::starTracks(...$ids)` / `unstarTracks(...$ids)` (déjà livrés via la sync loved↔starred).
+    - Bulk star : bouton « tout starrer » sur la page détail (un seul appel `starTracks()` avec tous les `songId`).
+    - Idées complémentaires :
+        - Ajouter / retirer / réordonner des morceaux (`updatePlaylist.view` accepte `songIdToAdd` et `songIndexToRemove`).
+        - Dupliquer une playlist (createPlaylist + bulk add).
+        - Statistiques de playlist : durée totale, top artistes, distribution par année, % de morceaux jamais joués (réutiliser `NavidromeRepository`).
+        - Détection des morceaux « morts » (présents dans la playlist mais absents de `media_file`) avec proposition de purge.
+        - Bulk delete depuis la liste (cases à cocher + action groupée).
+        - Bouton « Export M3U » sur la page détail (mutualise l'idée déjà roadmap dans CLAUDE.md).


### PR DESCRIPTION
Feature à découper en sous-tickets : aperçu, détail, rename, delete,
star/bulk-star, plus idées complémentaires (réorganisation, duplication,
stats par playlist, morceaux morts, bulk delete, export M3U).

https://claude.ai/code/session_018hbtjBjsEHdAmzGVBjBxud