### PR TITLE
feat(playlists): page de gestion des playlists Navidrome (epic #71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   Last.fm renvoie le terme corrigé même quand l'input était déjà
   canonique. Réutilise `LASTFM_API_KEY` existant (pas de nouvelle
   variable). Closes #17.
+- **Gestion des playlists Navidrome** (epic #71) : nouvelle section
+  `/playlists` qui liste les playlists existantes côté Navidrome avec
+  leurs métadonnées (nombre de morceaux, durée, dates création/
+  modification, owner, public/privé) — `SubsonicClient::getPlaylists()`
+  enrichi avec ces champs. Page détail `/playlists/{id}` affiche le
+  contenu (artist/album/durée/play count/statut starred), avec : bouton
+  rename, suppression (cleanup automatique du `lastSubsonicPlaylistId`
+  des `PlaylistDefinition` rattachées), duplication, star/unstar par
+  morceau et bulk star/unstar (réutilise `SubsonicClient::starTracks`/
+  `unstarTracks` existants), retrait d'un morceau, détection des
+  morceaux « morts » (présents dans la playlist mais absents de
+  `media_file`) avec bouton purge, statistiques (durée totale, top 10
+  artistes, top 10 albums, distribution par année, % jamais joués),
+  bulk delete depuis la liste, export M3U téléchargeable. Le
+  `M3uExporter` est aussi branché sur la prévisualisation des
+  `PlaylistDefinition` (closes #8). Toutes les écritures passent par
+  l'API Subsonic (`updatePlaylist.view`, `deletePlaylist.view`) — la
+  DB Navidrome reste mountée `:ro` en prod. Nouvelles méthodes
+  `SubsonicClient::getPlaylist()` et `updatePlaylist()`. Closes #72,
+  #73, #74, #75, #76, #77, #78, #79, #80, #81, #82, #83.
 - **Plugins custom en déploiement Docker** : nouveau namespace
   `App\Plugin\` mappé sur `plugins/`, bind-mountable sur `/app/plugins`
   pour ajouter ses propres générateurs de playlists sans rebuilder

--- a/README.md
+++ b/README.md
@@ -754,6 +754,40 @@ L'option « remplacer la playlist existante » utilise
 `getPlaylists.view` + `deletePlaylist.view` pour retirer l'ancienne du
 même nom appartenant au même utilisateur, puis recrée la nouvelle.
 
+## Gestion des playlists existantes
+
+Page `/playlists` (lien « Playlists » dans la barre de nav) : liste
+toutes les playlists Navidrome avec leur métadonnées (nombre de
+morceaux, durée, dates de création/modification, owner, public/privé).
+Cases à cocher + bouton « Supprimer la sélection » pour la suppression
+en masse. Bouton « M3U » par ligne pour télécharger la playlist au
+format M3U Extended (lisible par VLC / mpv / foobar2000).
+
+Page détail `/playlists/{id}` : affiche le contenu de la playlist
+(titre, artiste, album, durée, play count, statut starred ★) et permet :
+
+- **Renommer** la playlist (`updatePlaylist.view`)
+- **Dupliquer** la playlist sous le nom « X (copie) »
+- **Supprimer** la playlist (avec nettoyage automatique du
+  `lastSubsonicPlaylistId` des `PlaylistDefinition` rattachées)
+- **Star/unstar individuel** d'un morceau (icône ★/☆)
+- **Bulk star/unstar** : « ★ Tout starrer » / « ☆ Tout dé-starrer »,
+  un seul appel API
+- **Retirer un morceau** de la playlist (`updatePlaylist.view` avec
+  `songIndexToRemove`)
+- **Détecter les morceaux morts** (présents dans la playlist mais
+  absents de `media_file`) et les purger en un clic
+- **Statistiques** : durée totale, nombre starré, % jamais joués, top
+  10 artistes, top 10 albums, distribution par année (mini bar chart)
+- **Exporter en M3U**
+
+Toutes les écritures passent par l'API Subsonic — aucune écriture
+directe dans la DB Navidrome (qui peut donc rester montée `:ro`).
+
+L'export M3U est aussi disponible sur la prévisualisation des
+définitions de playlist (`/playlist/{id}/preview` → bouton « Exporter
+M3U »), pour récupérer la liste avant même de la créer côté Navidrome.
+
 ## Changelog
 
 L'historique des évolutions est tenu dans [`CHANGELOG.md`](CHANGELOG.md)

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -1,0 +1,353 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\PlaylistDefinition;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\PlaylistDefinitionRepository;
+use App\Service\M3uExporter;
+use App\Service\PlaylistStatsService;
+use App\Subsonic\SubsonicClient;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * UI for managing Subsonic playlists themselves (as opposed to
+ * PlaylistDefinition entities). All mutations go through SubsonicClient
+ * because the Navidrome DB is mounted read-only in production.
+ */
+class PlaylistController extends AbstractController
+{
+    #[Route('/playlists', name: 'app_playlists_index', methods: ['GET'])]
+    public function index(SubsonicClient $subsonic): Response
+    {
+        try {
+            $playlists = $subsonic->getPlaylists();
+        } catch (\Throwable $e) {
+            $this->addFlash('error', sprintf('Impossible de récupérer les playlists Navidrome : %s', $e->getMessage()));
+            $playlists = [];
+        }
+
+        usort($playlists, static fn (array $a, array $b) => strcasecmp($a['name'], $b['name']));
+
+        return $this->render('playlist_management/index.html.twig', [
+            'playlists' => $playlists,
+        ]);
+    }
+
+    #[Route('/playlists/{id}', name: 'app_playlists_show', methods: ['GET'], requirements: ['id' => '[^/]+'])]
+    public function show(
+        string $id,
+        SubsonicClient $subsonic,
+        NavidromeRepository $navidrome,
+        PlaylistStatsService $stats,
+    ): Response {
+        try {
+            $playlist = $subsonic->getPlaylist($id);
+        } catch (\Throwable $e) {
+            $this->addFlash('error', sprintf('Playlist introuvable : %s', $e->getMessage()));
+            return $this->redirectToRoute('app_playlists_index');
+        }
+
+        $trackIds = array_values(array_filter(
+            array_map(static fn (array $t) => $t['id'], $playlist['tracks']),
+            static fn (string $tid) => $tid !== '',
+        ));
+
+        $missingIds = $navidrome->isAvailable()
+            ? $navidrome->filterMissingMediaFileIds($trackIds)
+            : [];
+
+        return $this->render('playlist_management/show.html.twig', [
+            'playlist' => $playlist,
+            'stats' => $stats->compute($playlist['tracks']),
+            'missingIds' => array_fill_keys($missingIds, true),
+        ]);
+    }
+
+    #[Route('/playlists/{id}/rename', name: 'app_playlists_rename', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function rename(string $id, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('rename' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        $name = trim((string) $request->request->get('name', ''));
+        if ($name === '') {
+            $this->addFlash('error', 'Le nom de playlist ne peut pas être vide.');
+            return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+        }
+
+        try {
+            $subsonic->updatePlaylist($id, name: $name);
+            $this->addFlash('success', sprintf('Playlist renommée en « %s ».', $name));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+    }
+
+    #[Route('/playlists/{id}/delete', name: 'app_playlists_delete', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function delete(
+        string $id,
+        Request $request,
+        SubsonicClient $subsonic,
+        PlaylistDefinitionRepository $defs,
+        EntityManagerInterface $em,
+    ): Response {
+        if (!$this->isCsrfTokenValid('delete' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $subsonic->deletePlaylist($id);
+            $this->detachFromDefinitions($id, $defs, $em);
+            $this->addFlash('success', 'Playlist supprimée côté Navidrome.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_index');
+    }
+
+    #[Route('/playlists/bulk-delete', name: 'app_playlists_bulk_delete', methods: ['POST'])]
+    public function bulkDelete(
+        Request $request,
+        SubsonicClient $subsonic,
+        PlaylistDefinitionRepository $defs,
+        EntityManagerInterface $em,
+    ): Response {
+        if (!$this->isCsrfTokenValid('bulk-delete', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $ids = array_values(array_filter(
+            array_map('strval', (array) $request->request->all('ids')),
+            static fn (string $i) => $i !== '',
+        ));
+        if ($ids === []) {
+            $this->addFlash('error', 'Aucune playlist sélectionnée.');
+            return $this->redirectToRoute('app_playlists_index');
+        }
+
+        $ok = 0;
+        $errors = [];
+        foreach ($ids as $id) {
+            try {
+                $subsonic->deletePlaylist($id);
+                $this->detachFromDefinitions($id, $defs, $em);
+                $ok++;
+            } catch (\Throwable $e) {
+                $errors[] = $id . ': ' . $e->getMessage();
+            }
+        }
+
+        if ($ok > 0) {
+            $this->addFlash('success', sprintf('%d playlist(s) supprimée(s).', $ok));
+        }
+        if ($errors !== []) {
+            $this->addFlash('error', sprintf('%d échec(s) : %s', count($errors), implode(' / ', $errors)));
+        }
+
+        return $this->redirectToRoute('app_playlists_index');
+    }
+
+    #[Route('/playlists/{id}/duplicate', name: 'app_playlists_duplicate', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function duplicate(string $id, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('duplicate' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $src = $subsonic->getPlaylist($id);
+            $songIds = array_values(array_filter(
+                array_map(static fn (array $t) => $t['id'], $src['tracks']),
+                static fn (string $tid) => $tid !== '',
+            ));
+            $name = $this->buildCopyName($subsonic, $src['name']);
+            $newId = $subsonic->createPlaylist($name, $songIds);
+            $this->addFlash('success', sprintf('Playlist dupliquée : « %s ».', $name));
+
+            return $this->redirectToRoute('app_playlists_show', ['id' => $newId]);
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+
+            return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+        }
+    }
+
+    #[Route('/playlists/{id}/tracks/{songId}/toggle-star', name: 'app_playlists_toggle_star', methods: ['POST'], requirements: ['id' => '[^/]+', 'songId' => '[^/]+'])]
+    public function toggleStar(string $id, string $songId, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('toggle-star' . $songId, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        $unstar = (bool) $request->request->get('unstar', false);
+
+        try {
+            if ($unstar) {
+                $subsonic->unstarTracks($songId);
+            } else {
+                $subsonic->starTracks($songId);
+            }
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+    }
+
+    #[Route('/playlists/{id}/star-all', name: 'app_playlists_star_all', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function starAll(string $id, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('star-all' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        $unstar = (bool) $request->request->get('unstar', false);
+
+        try {
+            $playlist = $subsonic->getPlaylist($id);
+            $ids = [];
+            foreach ($playlist['tracks'] as $t) {
+                if ($t['id'] === '') {
+                    continue;
+                }
+                $isStarred = $t['starred'] !== null && $t['starred'] !== '';
+                if ($unstar ? $isStarred : !$isStarred) {
+                    $ids[] = $t['id'];
+                }
+            }
+
+            if ($ids === []) {
+                $this->addFlash('info', $unstar ? 'Aucun morceau starré à retirer.' : 'Tous les morceaux sont déjà starrés.');
+            } else {
+                if ($unstar) {
+                    $subsonic->unstarTracks(...$ids);
+                    $this->addFlash('success', sprintf('%d morceau(x) dé-starré(s).', count($ids)));
+                } else {
+                    $subsonic->starTracks(...$ids);
+                    $this->addFlash('success', sprintf('%d morceau(x) starré(s).', count($ids)));
+                }
+            }
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+    }
+
+    #[Route('/playlists/{id}/remove-track/{position}', name: 'app_playlists_remove_track', methods: ['POST'], requirements: ['id' => '[^/]+', 'position' => '\d+'])]
+    public function removeTrack(string $id, int $position, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('remove-track' . $id . ':' . $position, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $subsonic->updatePlaylist($id, songIndexToRemove: [$position]);
+            $this->addFlash('success', 'Morceau retiré de la playlist.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+    }
+
+    #[Route('/playlists/{id}/purge-dead', name: 'app_playlists_purge_dead', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function purgeDead(
+        string $id,
+        Request $request,
+        SubsonicClient $subsonic,
+        NavidromeRepository $navidrome,
+    ): Response {
+        if (!$this->isCsrfTokenValid('purge-dead' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        if (!$navidrome->isAvailable()) {
+            $this->addFlash('error', 'DB Navidrome inaccessible — purge impossible.');
+            return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+        }
+
+        try {
+            $playlist = $subsonic->getPlaylist($id);
+            $missing = $navidrome->filterMissingMediaFileIds(array_map(
+                static fn (array $t) => $t['id'],
+                $playlist['tracks'],
+            ));
+            if ($missing === []) {
+                $this->addFlash('info', 'Aucun morceau mort à purger.');
+                return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+            }
+
+            // Compute zero-based positions to remove. We iterate from the
+            // last position to the first so Subsonic's index shifts don't
+            // throw the next removal off.
+            $missingSet = array_fill_keys($missing, true);
+            $positions = [];
+            foreach ($playlist['tracks'] as $i => $t) {
+                if (isset($missingSet[$t['id']])) {
+                    $positions[] = $i;
+                }
+            }
+            rsort($positions);
+
+            $subsonic->updatePlaylist($id, songIndexToRemove: $positions);
+            $this->addFlash('success', sprintf('%d morceau(x) mort(s) retiré(s).', count($positions)));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+    }
+
+    #[Route('/playlists/{id}/export.m3u', name: 'app_playlists_export_m3u', methods: ['GET'], requirements: ['id' => '[^/]+'])]
+    public function exportM3u(string $id, SubsonicClient $subsonic, M3uExporter $exporter): Response
+    {
+        $playlist = $subsonic->getPlaylist($id);
+        $body = $exporter->export($playlist['tracks']);
+
+        $response = new Response($body, Response::HTTP_OK, [
+            'Content-Type' => 'audio/x-mpegurl; charset=utf-8',
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $exporter->filenameFor($playlist['name'])),
+        ]);
+
+        return $response;
+    }
+
+    private function detachFromDefinitions(
+        string $playlistId,
+        PlaylistDefinitionRepository $defs,
+        EntityManagerInterface $em,
+    ): void {
+        foreach ($defs->findBy(['lastSubsonicPlaylistId' => $playlistId]) as $def) {
+            /** @var PlaylistDefinition $def */
+            $def->setLastSubsonicPlaylistId(null);
+        }
+        $em->flush();
+    }
+
+    private function buildCopyName(SubsonicClient $subsonic, string $base): string
+    {
+        $existing = [];
+        foreach ($subsonic->getPlaylists() as $p) {
+            $existing[$p['name']] = true;
+        }
+
+        $candidate = $base . ' (copie)';
+        if (!isset($existing[$candidate])) {
+            return $candidate;
+        }
+        for ($i = 2; $i < 100; $i++) {
+            $candidate = sprintf('%s (copie %d)', $base, $i);
+            if (!isset($existing[$candidate])) {
+                return $candidate;
+            }
+        }
+
+        return $base . ' (copie ' . uniqid() . ')';
+    }
+}

--- a/src/Controller/PlaylistDefinitionController.php
+++ b/src/Controller/PlaylistDefinitionController.php
@@ -7,6 +7,7 @@ use App\Form\PlaylistDefinitionType;
 use App\Generator\GeneratorRegistry;
 use App\Navidrome\NavidromeRepository;
 use App\Repository\PlaylistDefinitionRepository;
+use App\Service\M3uExporter;
 use App\Service\PlaylistRunner;
 use App\Service\SettingsService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -144,6 +145,37 @@ class PlaylistDefinitionController extends AbstractController
             'limit' => $limit,
             'error' => $error,
             'window' => $window,
+        ]);
+    }
+
+    #[Route('/playlist/{id}/preview.m3u', name: 'app_playlist_preview_export_m3u', methods: ['GET'])]
+    public function previewExportM3u(
+        PlaylistDefinition $def,
+        GeneratorRegistry $registry,
+        NavidromeRepository $navidrome,
+        SettingsService $settings,
+        M3uExporter $exporter,
+    ): Response {
+        if (!$registry->has($def->getGeneratorKey())) {
+            $this->addFlash('error', sprintf('Générateur inconnu : "%s"', $def->getGeneratorKey()));
+            return $this->redirectToRoute('app_dashboard');
+        }
+        $generator = $registry->get($def->getGeneratorKey());
+        $limit = $def->getLimitOverride() ?? $settings->getDefaultLimit();
+        $window = $generator->getActiveWindow($def->getParameters());
+
+        $ids = $generator->generate($def->getParameters(), $limit);
+        $tracks = $navidrome->summarize(
+            $ids,
+            $window['from'] ?? null,
+            $window['to'] ?? null,
+        );
+
+        $body = $exporter->export($tracks);
+
+        return new Response($body, Response::HTTP_OK, [
+            'Content-Type' => 'audio/x-mpegurl; charset=utf-8',
+            'Content-Disposition' => sprintf('attachment; filename="%s"', $exporter->filenameFor($def->getName())),
         ]);
     }
 

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -866,6 +866,87 @@ class NavidromeRepository
     }
 
     /**
+     * Given a list of media_file ids, return those that no longer exist
+     * in the Navidrome library (file was removed/moved/renamed). Useful
+     * for detecting « dead » entries inside a Subsonic playlist.
+     *
+     * @param string[] $ids
+     *
+     * @return string[] subset of $ids, preserving original order
+     */
+    public function filterMissingMediaFileIds(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $rows = $this->connection()->fetchAllAssociative(
+            sprintf('SELECT id FROM media_file WHERE id IN (%s)', $placeholders),
+            $ids,
+        );
+
+        $existing = [];
+        foreach ($rows as $r) {
+            $existing[(string) $r['id']] = true;
+        }
+
+        $missing = [];
+        foreach ($ids as $id) {
+            if (!isset($existing[$id])) {
+                $missing[] = $id;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Per-id metadata needed for playlist stats (year + album + artist).
+     * Returned in the same order as input ids; missing rows are silently
+     * dropped (use {@see filterMissingMediaFileIds()} to surface them).
+     *
+     * @param string[] $ids
+     *
+     * @return array<int, array{id: string, artist: string, album: string, year: ?int, duration: int}>
+     */
+    public function getMediaFileMetadata(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $rows = $this->connection()->fetchAllAssociative(
+            sprintf(
+                'SELECT id, artist, album, year, duration FROM media_file WHERE id IN (%s)',
+                $placeholders,
+            ),
+            $ids,
+        );
+
+        $byId = [];
+        foreach ($rows as $r) {
+            $byId[(string) $r['id']] = [
+                'id' => (string) $r['id'],
+                'artist' => (string) ($r['artist'] ?? ''),
+                'album' => (string) ($r['album'] ?? ''),
+                'year' => isset($r['year']) ? (int) $r['year'] : null,
+                'duration' => (int) ($r['duration'] ?? 0),
+            ];
+        }
+
+        $out = [];
+        foreach ($ids as $id) {
+            if (isset($byId[$id])) {
+                $out[] = $byId[$id];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
      * Find an artist id by name. Prefers the dedicated `artist` table when
      * present (Navidrome >= 0.50), falls back on a DISTINCT lookup over
      * media_file. Case- and whitespace-insensitive. Returns null when no

--- a/src/Service/M3uExporter.php
+++ b/src/Service/M3uExporter.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Build an M3U Extended playlist body from track data. Used both by the
+ * Navidrome playlist detail page (export real Subsonic playlists) and by
+ * the PlaylistDefinition preview (export the dry-run track list before
+ * creating the playlist on Navidrome).
+ *
+ * The exporter intentionally takes plain arrays so any source — Subsonic
+ * `getPlaylist.view`, NavidromeRepository::summarize(), or generator
+ * preview — can feed it without coupling to a specific class.
+ */
+final class M3uExporter
+{
+    /**
+     * @param iterable<array{title?: string, artist?: string, duration?: int, path?: string}|object> $tracks
+     *   Each item may be an array (Subsonic shape) or an object with the
+     *   same field names readable as public properties (TrackSummary etc.).
+     */
+    public function export(iterable $tracks): string
+    {
+        $lines = ['#EXTM3U'];
+        foreach ($tracks as $t) {
+            $title = self::field($t, 'title');
+            $artist = self::field($t, 'artist');
+            $duration = (int) (self::field($t, 'duration') ?: 0);
+            $path = (string) (self::field($t, 'path') ?: '');
+
+            $label = trim($artist . ' - ' . $title, ' -');
+            // EXTINF: comma is the field separator, so drop literal commas
+            // from the label to keep the line parseable by VLC/mpv.
+            $label = str_replace(',', '', $label);
+            $lines[] = '#EXTINF:' . $duration . ',' . $label;
+            $lines[] = $path !== '' ? $path : ($title !== '' ? $title : 'unknown');
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Build a filename-safe slug for the playlist filename.
+     */
+    public function filenameFor(string $playlistName): string
+    {
+        $slug = preg_replace('/[^A-Za-z0-9._-]+/', '-', $playlistName) ?? 'playlist';
+        $slug = trim($slug, '-');
+        if ($slug === '') {
+            $slug = 'playlist';
+        }
+
+        return $slug . '.m3u';
+    }
+
+    private static function field(mixed $row, string $name): mixed
+    {
+        if (is_array($row)) {
+            return $row[$name] ?? null;
+        }
+        if (is_object($row) && isset($row->{$name})) {
+            return $row->{$name};
+        }
+
+        return null;
+    }
+}

--- a/src/Service/PlaylistStatsService.php
+++ b/src/Service/PlaylistStatsService.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Service;
+
+use App\Navidrome\NavidromeRepository;
+
+/**
+ * Compute aggregate stats for a Subsonic playlist (top artists, year
+ * distribution, never-played percentage, total duration). Data is pulled
+ * from the Subsonic getPlaylist payload (already loaded by the caller)
+ * for play counts and starred status, and enriched with `media_file.year`
+ * via NavidromeRepository when the local DB is reachable.
+ */
+final class PlaylistStatsService
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+    ) {
+    }
+
+    /**
+     * @param list<array{
+     *     id: string, title: string, artist: string, album: string,
+     *     duration: int, playCount: int, year: ?int, starred: ?string, path: string
+     * }> $tracks Tracks as returned by SubsonicClient::getPlaylist().
+     *
+     * @return array{
+     *     trackCount: int,
+     *     totalDuration: int,
+     *     starredCount: int,
+     *     neverPlayedCount: int,
+     *     neverPlayedRatio: float,
+     *     topArtists: list<array{artist: string, count: int}>,
+     *     topAlbums: list<array{album: string, artist: string, count: int}>,
+     *     yearDistribution: array<int, int>,
+     *     missingYearCount: int
+     * }
+     */
+    public function compute(array $tracks): array
+    {
+        $count = count($tracks);
+        $totalDuration = 0;
+        $starredCount = 0;
+        $neverPlayedCount = 0;
+        $artistCounts = [];
+        $albumCounts = [];
+
+        // Year may be missing from Subsonic — refetch from media_file in
+        // one batched query so we can build a meaningful distribution.
+        $missingYearIds = [];
+        $yearByTrackId = [];
+        foreach ($tracks as $t) {
+            if ($t['year'] !== null) {
+                $yearByTrackId[$t['id']] = $t['year'];
+            } else {
+                $missingYearIds[] = $t['id'];
+            }
+        }
+        if ($missingYearIds !== [] && $this->navidrome->isAvailable()) {
+            foreach ($this->navidrome->getMediaFileMetadata($missingYearIds) as $meta) {
+                if ($meta['year'] !== null) {
+                    $yearByTrackId[$meta['id']] = $meta['year'];
+                }
+            }
+        }
+
+        foreach ($tracks as $t) {
+            $totalDuration += max(0, $t['duration']);
+            if ($t['starred'] !== null && $t['starred'] !== '') {
+                $starredCount++;
+            }
+            if ($t['playCount'] === 0) {
+                $neverPlayedCount++;
+            }
+            $artist = trim($t['artist']);
+            if ($artist !== '') {
+                $artistCounts[$artist] = ($artistCounts[$artist] ?? 0) + 1;
+            }
+            $album = trim($t['album']);
+            if ($album !== '') {
+                $key = $album . '|' . $artist;
+                $albumCounts[$key] = $albumCounts[$key] ?? ['album' => $album, 'artist' => $artist, 'count' => 0];
+                $albumCounts[$key]['count']++;
+            }
+        }
+
+        arsort($artistCounts);
+        $topArtists = [];
+        foreach (array_slice($artistCounts, 0, 10, true) as $name => $n) {
+            $topArtists[] = ['artist' => $name, 'count' => $n];
+        }
+
+        $albumCounts = array_values($albumCounts);
+        usort($albumCounts, static fn (array $a, array $b) => $b['count'] <=> $a['count']);
+        $topAlbums = array_slice($albumCounts, 0, 10);
+
+        $yearDistribution = [];
+        $missingYearCount = 0;
+        foreach ($tracks as $t) {
+            $year = $yearByTrackId[$t['id']] ?? null;
+            if ($year === null) {
+                $missingYearCount++;
+                continue;
+            }
+            $yearDistribution[$year] = ($yearDistribution[$year] ?? 0) + 1;
+        }
+        ksort($yearDistribution);
+
+        $ratio = $count > 0 ? $neverPlayedCount / $count : 0.0;
+
+        return [
+            'trackCount' => $count,
+            'totalDuration' => $totalDuration,
+            'starredCount' => $starredCount,
+            'neverPlayedCount' => $neverPlayedCount,
+            'neverPlayedRatio' => $ratio,
+            'topArtists' => $topArtists,
+            'topAlbums' => $topAlbums,
+            'yearDistribution' => $yearDistribution,
+            'missingYearCount' => $missingYearCount,
+        ];
+    }
+}

--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -47,7 +47,11 @@ class SubsonicClient
     }
 
     /**
-     * @return array<int, array{id: string, name: string, owner: string}>
+     * @return array<int, array{
+     *     id: string, name: string, owner: string,
+     *     songCount: int, duration: int, public: bool,
+     *     created: ?string, changed: ?string, comment: string
+     * }>
      */
     public function getPlaylists(): array
     {
@@ -60,6 +64,12 @@ class SubsonicClient
                 'id' => (string) ($p['id'] ?? ''),
                 'name' => (string) ($p['name'] ?? ''),
                 'owner' => (string) ($p['owner'] ?? ''),
+                'songCount' => (int) ($p['songCount'] ?? 0),
+                'duration' => (int) ($p['duration'] ?? 0),
+                'public' => (bool) ($p['public'] ?? false),
+                'created' => isset($p['created']) ? (string) $p['created'] : null,
+                'changed' => isset($p['changed']) ? (string) $p['changed'] : null,
+                'comment' => (string) ($p['comment'] ?? ''),
             ];
         }
 
@@ -75,6 +85,106 @@ class SubsonicClient
         }
 
         return null;
+    }
+
+    /**
+     * Fetch a single playlist with its tracks. Throws if the id is unknown.
+     *
+     * @return array{
+     *     id: string, name: string, owner: string,
+     *     songCount: int, duration: int, public: bool,
+     *     created: ?string, changed: ?string, comment: string,
+     *     tracks: array<int, array{
+     *         id: string, title: string, artist: string, album: string,
+     *         duration: int, playCount: int, year: ?int, starred: ?string,
+     *         path: string
+     *     }>
+     * }
+     */
+    public function getPlaylist(string $id): array
+    {
+        if ($id === '') {
+            throw new \RuntimeException('getPlaylist requires a non-empty id.');
+        }
+
+        $data = $this->call('getPlaylist', ['id' => $id]);
+        $p = $data['playlist'] ?? null;
+        if (!is_array($p)) {
+            throw new \RuntimeException('getPlaylist did not return a playlist node. Raw response: ' . json_encode($data));
+        }
+
+        $tracks = [];
+        foreach (($p['entry'] ?? []) as $e) {
+            $tracks[] = [
+                'id' => (string) ($e['id'] ?? ''),
+                'title' => (string) ($e['title'] ?? ''),
+                'artist' => (string) ($e['artist'] ?? ''),
+                'album' => (string) ($e['album'] ?? ''),
+                'duration' => (int) ($e['duration'] ?? 0),
+                'playCount' => (int) ($e['playCount'] ?? 0),
+                'year' => isset($e['year']) ? (int) $e['year'] : null,
+                'starred' => isset($e['starred']) ? (string) $e['starred'] : null,
+                'path' => (string) ($e['path'] ?? ''),
+            ];
+        }
+
+        return [
+            'id' => (string) ($p['id'] ?? $id),
+            'name' => (string) ($p['name'] ?? ''),
+            'owner' => (string) ($p['owner'] ?? ''),
+            'songCount' => (int) ($p['songCount'] ?? count($tracks)),
+            'duration' => (int) ($p['duration'] ?? 0),
+            'public' => (bool) ($p['public'] ?? false),
+            'created' => isset($p['created']) ? (string) $p['created'] : null,
+            'changed' => isset($p['changed']) ? (string) $p['changed'] : null,
+            'comment' => (string) ($p['comment'] ?? ''),
+            'tracks' => $tracks,
+        ];
+    }
+
+    /**
+     * Mutate a playlist via Subsonic's `updatePlaylist.view`. Pass only the
+     * fields you want to change; null arguments are not transmitted, so the
+     * server keeps the existing value.
+     *
+     * @param string[] $songIdToAdd      Track ids to append at the end.
+     * @param int[]    $songIndexToRemove Zero-based track positions to drop.
+     */
+    public function updatePlaylist(
+        string $id,
+        ?string $name = null,
+        ?string $comment = null,
+        ?bool $public = null,
+        array $songIdToAdd = [],
+        array $songIndexToRemove = [],
+    ): void {
+        if ($id === '') {
+            throw new \RuntimeException('updatePlaylist requires a non-empty id.');
+        }
+
+        $params = ['playlistId' => $id];
+        if ($name !== null) {
+            $params['name'] = $name;
+        }
+        if ($comment !== null) {
+            $params['comment'] = $comment;
+        }
+        if ($public !== null) {
+            $params['public'] = $public ? 'true' : 'false';
+        }
+
+        $extra = [];
+        foreach ($songIdToAdd as $songId) {
+            $songId = (string) $songId;
+            if ($songId !== '') {
+                $extra[] = 'songIdToAdd=' . rawurlencode($songId);
+            }
+        }
+        foreach ($songIndexToRemove as $idx) {
+            $extra[] = 'songIndexToRemove=' . (int) $idx;
+        }
+
+        $this->call('updatePlaylist', $params, implode('&', $extra));
     }
 
     /**

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -36,6 +36,7 @@
             <nav class="flex items-center gap-4 text-sm">
                 {% if app.user %}
                     <a href="{{ path('app_dashboard') }}" class="hover:underline">Dashboard</a>
+                    <a href="{{ path('app_playlists_index') }}" class="hover:underline">Playlists</a>
                     <a href="{{ path('app_playlist_new') }}" class="hover:underline">Nouvelle playlist</a>
 
                     {# Stats dropdown — pure CSS hover/focus, no JS #}

--- a/templates/playlist/preview.html.twig
+++ b/templates/playlist/preview.html.twig
@@ -20,12 +20,16 @@
             {% endif %}
             <p class="text-sm mt-2">Limite : <strong>{{ limit }}</strong></p>
         </div>
-        <form method="post" action="{{ path('app_playlist_run', {id: def.id}) }}">
-            <input type="hidden" name="_token" value="{{ csrf_token('run' ~ def.id) }}">
-            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded text-sm">
-                Créer dans Navidrome
-            </button>
-        </form>
+        <div class="flex items-center gap-2">
+            <a href="{{ path('app_playlist_preview_export_m3u', {id: def.id}) }}"
+               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-2 rounded">Exporter M3U</a>
+            <form method="post" action="{{ path('app_playlist_run', {id: def.id}) }}">
+                <input type="hidden" name="_token" value="{{ csrf_token('run' ~ def.id) }}">
+                <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded text-sm">
+                    Créer dans Navidrome
+                </button>
+            </form>
+        </div>
     </div>
 
     {% if error %}

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -1,0 +1,89 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Playlists Navidrome{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-6">
+        <div>
+            <h1 class="text-2xl font-semibold">Playlists Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ playlists|length }} playlist{{ playlists|length > 1 ? 's' : '' }}
+                récupérée{{ playlists|length > 1 ? 's' : '' }} via l'API Subsonic.
+            </p>
+        </div>
+    </div>
+
+    {% if playlists is empty %}
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded p-6 text-center text-sm">
+            Aucune playlist n'a été trouvée. Créez-en une via les
+            <a href="{{ path('app_dashboard') }}" class="text-sky-700 hover:underline">définitions</a>
+            ou directement dans Navidrome.
+        </div>
+    {% else %}
+        <form method="post" action="{{ path('app_playlists_bulk_delete') }}"
+              onsubmit="return confirm('Supprimer les playlists sélectionnées ?');"
+              class="bg-white border border-slate-200 rounded">
+            <input type="hidden" name="_token" value="{{ csrf_token('bulk-delete') }}">
+
+            <div class="flex items-center justify-between px-4 py-2 border-b bg-slate-50 text-sm">
+                <div class="text-slate-600">
+                    Cochez les playlists pour les supprimer en lot (action irréversible).
+                </div>
+                <button type="submit" class="bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded text-xs">
+                    Supprimer la sélection
+                </button>
+            </div>
+
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600">
+                    <tr>
+                        <th class="px-3 py-2 w-8 text-left">
+                            <input type="checkbox" onchange="document.querySelectorAll('input[name=&quot;ids[]&quot;]').forEach(c => c.checked = this.checked)">
+                        </th>
+                        <th class="px-3 py-2 text-left">Nom</th>
+                        <th class="px-3 py-2 text-left">Owner</th>
+                        <th class="px-3 py-2 text-right">Morceaux</th>
+                        <th class="px-3 py-2 text-right">Durée</th>
+                        <th class="px-3 py-2 text-left">Créée</th>
+                        <th class="px-3 py-2 text-left">Modifiée</th>
+                        <th class="px-3 py-2 text-left">Visibilité</th>
+                        <th class="px-3 py-2 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for p in playlists %}
+                        <tr class="border-t hover:bg-slate-50">
+                            <td class="px-3 py-2">
+                                <input type="checkbox" name="ids[]" value="{{ p.id }}">
+                            </td>
+                            <td class="px-3 py-2 font-medium">
+                                <a href="{{ path('app_playlists_show', {id: p.id}) }}" class="text-sky-700 hover:underline">
+                                    {{ p.name }}
+                                </a>
+                                {% if p.comment %}<div class="text-xs text-slate-400">{{ p.comment }}</div>{% endif %}
+                            </td>
+                            <td class="px-3 py-2 text-slate-600">{{ p.owner }}</td>
+                            <td class="px-3 py-2 text-right">{{ p.songCount }}</td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-500">
+                                {{ (p.duration // 60) }} min
+                            </td>
+                            <td class="px-3 py-2 text-xs text-slate-500">{{ p.created ? p.created|slice(0, 10) : '—' }}</td>
+                            <td class="px-3 py-2 text-xs text-slate-500">{{ p.changed ? p.changed|slice(0, 10) : '—' }}</td>
+                            <td class="px-3 py-2 text-xs">
+                                <span class="px-1.5 py-0.5 rounded {{ p.public ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-600' }}">
+                                    {{ p.public ? 'Publique' : 'Privée' }}
+                                </span>
+                            </td>
+                            <td class="px-3 py-2 text-right whitespace-nowrap">
+                                <a href="{{ path('app_playlists_show', {id: p.id}) }}"
+                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded">Voir</a>
+                                <a href="{{ path('app_playlists_export_m3u', {id: p.id}) }}"
+                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded">M3U</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </form>
+    {% endif %}
+{% endblock %}

--- a/templates/playlist_management/show.html.twig
+++ b/templates/playlist_management/show.html.twig
@@ -1,0 +1,213 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ playlist.name }} — Playlist{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_playlists_index') }}" class="text-xs text-sky-700 hover:underline">← Toutes les playlists</a>
+    </div>
+
+    <div class="flex items-start justify-between mb-6 gap-4">
+        <div class="flex-1">
+            <h1 class="text-2xl font-semibold">{{ playlist.name }}</h1>
+            <p class="text-sm text-slate-500">
+                {{ playlist.songCount }} morceau{{ playlist.songCount > 1 ? 'x' : '' }} —
+                {{ (playlist.duration // 60) }} min —
+                {{ playlist.public ? 'Publique' : 'Privée' }}
+                {% if playlist.owner %} — owner <strong>{{ playlist.owner }}</strong>{% endif %}
+            </p>
+            <p class="text-xs text-slate-400">
+                {% if playlist.created %}Créée le {{ playlist.created|slice(0, 10) }}{% endif %}
+                {% if playlist.changed %} — modifiée le {{ playlist.changed|slice(0, 10) }}{% endif %}
+            </p>
+            {% if playlist.comment %}
+                <p class="text-sm text-slate-600 mt-2 italic">« {{ playlist.comment }} »</p>
+            {% endif %}
+        </div>
+        <div class="flex items-center gap-2">
+            <a href="{{ path('app_playlists_export_m3u', {id: playlist.id}) }}"
+               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Exporter M3U</a>
+            <form method="post" action="{{ path('app_playlists_duplicate', {id: playlist.id}) }}" class="inline">
+                <input type="hidden" name="_token" value="{{ csrf_token('duplicate' ~ playlist.id) }}">
+                <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Dupliquer</button>
+            </form>
+        </div>
+    </div>
+
+    {# Stats card #}
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6 text-sm">
+        <div class="rounded border bg-white p-3">
+            <div class="text-xs text-slate-500">Durée totale</div>
+            <div class="text-lg font-semibold">{{ (stats.totalDuration // 60) }} min</div>
+        </div>
+        <div class="rounded border bg-white p-3">
+            <div class="text-xs text-slate-500">Morceaux starrés</div>
+            <div class="text-lg font-semibold">{{ stats.starredCount }} / {{ stats.trackCount }}</div>
+        </div>
+        <div class="rounded border bg-white p-3">
+            <div class="text-xs text-slate-500">Jamais joués</div>
+            <div class="text-lg font-semibold">
+                {{ stats.neverPlayedCount }}
+                <span class="text-xs text-slate-400 font-normal">
+                    ({{ (stats.neverPlayedRatio * 100)|number_format(0) }}%)
+                </span>
+            </div>
+        </div>
+        <div class="rounded border bg-white p-3 {{ missingIds is not empty ? 'border-amber-300 bg-amber-50' : '' }}">
+            <div class="text-xs text-slate-500">Morceaux morts</div>
+            <div class="text-lg font-semibold {{ missingIds is not empty ? 'text-amber-700' : '' }}">
+                {{ missingIds|length }}
+            </div>
+            {% if missingIds is not empty %}
+                <form method="post" action="{{ path('app_playlists_purge_dead', {id: playlist.id}) }}"
+                      onsubmit="return confirm('Retirer {{ missingIds|length }} morceau(x) absent(s) de la library ?');"
+                      class="mt-1">
+                    <input type="hidden" name="_token" value="{{ csrf_token('purge-dead' ~ playlist.id) }}">
+                    <button type="submit" class="text-xs text-amber-700 hover:underline">Purger</button>
+                </form>
+            {% endif %}
+        </div>
+    </div>
+
+    {# Top artists / albums + year distribution side-by-side #}
+    {% if stats.topArtists is not empty or stats.yearDistribution is not empty %}
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 text-sm">
+            <div class="rounded border bg-white p-3">
+                <div class="font-medium mb-2">Top artistes</div>
+                {% if stats.topArtists is empty %}
+                    <div class="text-xs text-slate-400">—</div>
+                {% else %}
+                    <ul class="space-y-1">
+                        {% for a in stats.topArtists|slice(0, 5) %}
+                            <li class="flex justify-between"><span>{{ a.artist }}</span><span class="text-slate-500">{{ a.count }}</span></li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+            <div class="rounded border bg-white p-3">
+                <div class="font-medium mb-2">Top albums</div>
+                {% if stats.topAlbums is empty %}
+                    <div class="text-xs text-slate-400">—</div>
+                {% else %}
+                    <ul class="space-y-1">
+                        {% for al in stats.topAlbums|slice(0, 5) %}
+                            <li class="flex justify-between">
+                                <span>{{ al.album }} <span class="text-slate-400 text-xs">— {{ al.artist }}</span></span>
+                                <span class="text-slate-500">{{ al.count }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            </div>
+            <div class="rounded border bg-white p-3">
+                <div class="font-medium mb-2">Distribution par année</div>
+                {% if stats.yearDistribution is empty %}
+                    <div class="text-xs text-slate-400">—</div>
+                {% else %}
+                    {% set maxCount = max(stats.yearDistribution) %}
+                    <ul class="space-y-1 text-xs">
+                        {% for year, count in stats.yearDistribution %}
+                            <li class="flex items-center gap-2">
+                                <span class="w-12 text-slate-500">{{ year }}</span>
+                                <span class="h-2 bg-sky-400 rounded" style="width: {{ (count / maxCount * 100)|round }}%"></span>
+                                <span class="text-slate-500">{{ count }}</span>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                    {% if stats.missingYearCount > 0 %}
+                        <div class="text-xs text-slate-400 mt-2">{{ stats.missingYearCount }} morceau(x) sans année.</div>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+
+    {# Rename + delete + bulk star toolbar #}
+    <div class="bg-white border border-slate-200 rounded p-3 mb-4 flex flex-wrap gap-3 items-center">
+        <form method="post" action="{{ path('app_playlists_rename', {id: playlist.id}) }}"
+              class="flex items-center gap-2 flex-1 min-w-0">
+            <input type="hidden" name="_token" value="{{ csrf_token('rename' ~ playlist.id) }}">
+            <input type="text" name="name" value="{{ playlist.name }}" required maxlength="200"
+                   class="border rounded px-2 py-1 text-sm flex-1 min-w-0">
+            <button type="submit" class="text-sm bg-sky-600 hover:bg-sky-700 text-white px-3 py-1.5 rounded">Renommer</button>
+        </form>
+
+        <form method="post" action="{{ path('app_playlists_star_all', {id: playlist.id}) }}"
+              onsubmit="return {{ playlist.songCount > 50 ? 'confirm(\'Starrer ' ~ playlist.songCount ~ ' morceaux ?\')' : 'true' }};">
+            <input type="hidden" name="_token" value="{{ csrf_token('star-all' ~ playlist.id) }}">
+            <button type="submit" class="text-sm bg-amber-100 hover:bg-amber-200 text-amber-800 px-3 py-1.5 rounded">★ Tout starrer</button>
+        </form>
+        <form method="post" action="{{ path('app_playlists_star_all', {id: playlist.id}) }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('star-all' ~ playlist.id) }}">
+            <input type="hidden" name="unstar" value="1">
+            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">☆ Tout dé-starrer</button>
+        </form>
+
+        <form method="post" action="{{ path('app_playlists_delete', {id: playlist.id}) }}"
+              onsubmit="return confirm('Supprimer définitivement « {{ playlist.name }} » côté Navidrome ?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ playlist.id) }}">
+            <button type="submit" class="text-sm bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded">Supprimer</button>
+        </form>
+    </div>
+
+    {# Tracks table #}
+    {% if playlist.tracks is empty %}
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded p-6 text-center text-sm">
+            Cette playlist est vide.
+        </div>
+    {% else %}
+        <table class="w-full text-sm bg-white border border-slate-200 rounded overflow-hidden">
+            <thead class="bg-slate-100 text-slate-600">
+                <tr>
+                    <th class="px-3 py-2 w-8 text-center">★</th>
+                    <th class="px-3 py-2 w-12 text-right">#</th>
+                    <th class="px-3 py-2 text-left">Titre</th>
+                    <th class="px-3 py-2 text-left">Artiste</th>
+                    <th class="px-3 py-2 text-left">Album</th>
+                    <th class="px-3 py-2 text-right">Plays</th>
+                    <th class="px-3 py-2 text-right">Durée</th>
+                    <th class="px-3 py-2 text-right">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for t in playlist.tracks %}
+                    {% set isStarred = t.starred is not null and t.starred is not empty %}
+                    {% set isDead = missingIds[t.id] is defined %}
+                    <tr class="border-t hover:bg-slate-50 {{ isDead ? 'bg-rose-50' : '' }}">
+                        <td class="px-3 py-2 text-center">
+                            <form method="post" action="{{ path('app_playlists_toggle_star', {id: playlist.id, songId: t.id}) }}" class="inline">
+                                <input type="hidden" name="_token" value="{{ csrf_token('toggle-star' ~ t.id) }}">
+                                {% if isStarred %}<input type="hidden" name="unstar" value="1">{% endif %}
+                                <button type="submit"
+                                        title="{{ isStarred ? 'Dé-starrer' : 'Starrer' }}"
+                                        class="text-base {{ isStarred ? 'text-amber-500' : 'text-slate-300 hover:text-amber-400' }}">
+                                    {{ isStarred ? '★' : '☆' }}
+                                </button>
+                            </form>
+                        </td>
+                        <td class="px-3 py-2 text-right text-xs text-slate-400">{{ loop.index }}</td>
+                        <td class="px-3 py-2">
+                            {{ t.title }}
+                            {% if isDead %}<span class="text-xs text-rose-700 ml-1">[absent de la library]</span>{% endif %}
+                        </td>
+                        <td class="px-3 py-2 text-slate-600">{{ t.artist }}</td>
+                        <td class="px-3 py-2 text-slate-500 text-xs">{{ t.album }}{% if t.year %} <span class="text-slate-400">({{ t.year }})</span>{% endif %}</td>
+                        <td class="px-3 py-2 text-right">{{ t.playCount }}</td>
+                        <td class="px-3 py-2 text-right text-xs text-slate-500">
+                            {% set m = (t.duration // 60) %}{% set s = (t.duration % 60) %}
+                            {{ m }}:{{ s|format('%02d') }}
+                        </td>
+                        <td class="px-3 py-2 text-right">
+                            <form method="post" action="{{ path('app_playlists_remove_track', {id: playlist.id, position: loop.index0}) }}"
+                                  onsubmit="return confirm('Retirer ce morceau de la playlist ?');"
+                                  class="inline">
+                                <input type="hidden" name="_token" value="{{ csrf_token('remove-track' ~ playlist.id ~ ':' ~ loop.index0) }}">
+                                <button type="submit" class="text-xs text-rose-600 hover:underline">Retirer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% endif %}
+{% endblock %}

--- a/tests/Service/M3uExporterTest.php
+++ b/tests/Service/M3uExporterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Navidrome\TrackSummary;
+use App\Service\M3uExporter;
+use PHPUnit\Framework\TestCase;
+
+class M3uExporterTest extends TestCase
+{
+    public function testExportFromArrays(): void
+    {
+        $exporter = new M3uExporter();
+        $body = $exporter->export([
+            ['title' => 'Halo', 'artist' => 'Beyoncé', 'duration' => 200, 'path' => 'B/I Am/01 - Halo.mp3'],
+            ['title' => 'Smile', 'artist' => 'Lily Allen', 'duration' => 160, 'path' => 'L/Alright Still/05 - Smile.mp3'],
+        ]);
+
+        $this->assertStringStartsWith("#EXTM3U\n", $body);
+        $this->assertStringContainsString("#EXTINF:200,Beyoncé - Halo\n", $body);
+        $this->assertStringContainsString("B/I Am/01 - Halo.mp3\n", $body);
+        $this->assertStringContainsString("#EXTINF:160,Lily Allen - Smile\n", $body);
+    }
+
+    public function testExportFromTrackSummary(): void
+    {
+        $exporter = new M3uExporter();
+        $body = $exporter->export([
+            new TrackSummary('mf-1', 'Halo', 'Beyoncé', 'I Am', 200, 12),
+        ]);
+
+        // TrackSummary has no `path`, so we fall back to the title.
+        $this->assertStringContainsString("#EXTINF:200,Beyoncé - Halo\n", $body);
+        $this->assertStringContainsString("Halo\n", $body);
+    }
+
+    public function testExportStripsCommaInLabel(): void
+    {
+        $exporter = new M3uExporter();
+        $body = $exporter->export([
+            ['title' => 'Hello, World', 'artist' => 'A, B', 'duration' => 100, 'path' => 'p.mp3'],
+        ]);
+
+        $this->assertStringContainsString("#EXTINF:100,A B - Hello World\n", $body);
+        $this->assertStringNotContainsString(',Hello, World', $body);
+    }
+
+    public function testExportEmptyListProducesHeaderOnly(): void
+    {
+        $exporter = new M3uExporter();
+        $this->assertSame("#EXTM3U\n", $exporter->export([]));
+    }
+
+    public function testFilenameForSlugifies(): void
+    {
+        $exporter = new M3uExporter();
+        $this->assertSame('Top-Rock.m3u', $exporter->filenameFor('Top Rock'));
+        $this->assertSame('Top-100-2025.m3u', $exporter->filenameFor('Top 100 — 2025!'));
+        $this->assertSame('playlist.m3u', $exporter->filenameFor('!!!'));
+    }
+}

--- a/tests/Service/PlaylistStatsServiceTest.php
+++ b/tests/Service/PlaylistStatsServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Navidrome\NavidromeRepository;
+use App\Service\PlaylistStatsService;
+use PHPUnit\Framework\TestCase;
+
+class PlaylistStatsServiceTest extends TestCase
+{
+    public function testComputeAggregatesArtistsYearsAndStarred(): void
+    {
+        $navidrome = $this->createNavidromeStub(false);
+        $svc = new PlaylistStatsService($navidrome);
+
+        $stats = $svc->compute([
+            $this->track('mf-1', 'Halo', 'Beyoncé', 'I Am', 200, 12, 2008, '2025-01-01T00:00:00Z'),
+            $this->track('mf-2', 'Single Ladies', 'Beyoncé', 'I Am', 220, 0, 2008, null),
+            $this->track('mf-3', 'Smile', 'Lily Allen', 'Alright Still', 160, 5, 2006, null),
+        ]);
+
+        $this->assertSame(3, $stats['trackCount']);
+        $this->assertSame(580, $stats['totalDuration']);
+        $this->assertSame(1, $stats['starredCount']);
+        $this->assertSame(1, $stats['neverPlayedCount']);
+        $this->assertEqualsWithDelta(1 / 3, $stats['neverPlayedRatio'], 0.0001);
+
+        $this->assertSame('Beyoncé', $stats['topArtists'][0]['artist']);
+        $this->assertSame(2, $stats['topArtists'][0]['count']);
+
+        $this->assertSame([2006 => 1, 2008 => 2], $stats['yearDistribution']);
+        $this->assertSame(0, $stats['missingYearCount']);
+
+        $this->assertSame('I Am', $stats['topAlbums'][0]['album']);
+        $this->assertSame(2, $stats['topAlbums'][0]['count']);
+    }
+
+    public function testComputeBacksOffWhenNavidromeOfflineForMissingYears(): void
+    {
+        $navidrome = $this->createNavidromeStub(false);
+        $svc = new PlaylistStatsService($navidrome);
+
+        $stats = $svc->compute([
+            $this->track('mf-1', 'A', 'X', 'Y', 100, 0, null, null),
+            $this->track('mf-2', 'B', 'X', 'Y', 100, 0, 2010, null),
+        ]);
+
+        $this->assertSame([2010 => 1], $stats['yearDistribution']);
+        $this->assertSame(1, $stats['missingYearCount']);
+    }
+
+    public function testComputeBacksFillsMissingYearsFromMediaFile(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('isAvailable')->willReturn(true);
+        $navidrome->method('getMediaFileMetadata')
+            ->with(['mf-1'])
+            ->willReturn([['id' => 'mf-1', 'artist' => 'X', 'album' => 'Y', 'year' => 1995, 'duration' => 100]]);
+
+        $svc = new PlaylistStatsService($navidrome);
+        $stats = $svc->compute([
+            $this->track('mf-1', 'A', 'X', 'Y', 100, 0, null, null),
+            $this->track('mf-2', 'B', 'X', 'Y', 100, 0, 2010, null),
+        ]);
+
+        $this->assertSame([1995 => 1, 2010 => 1], $stats['yearDistribution']);
+        $this->assertSame(0, $stats['missingYearCount']);
+    }
+
+    public function testComputeEmptyPlaylistReturnsZeroes(): void
+    {
+        $navidrome = $this->createNavidromeStub(false);
+        $svc = new PlaylistStatsService($navidrome);
+
+        $stats = $svc->compute([]);
+
+        $this->assertSame(0, $stats['trackCount']);
+        $this->assertSame(0, $stats['totalDuration']);
+        $this->assertSame(0.0, $stats['neverPlayedRatio']);
+        $this->assertSame([], $stats['topArtists']);
+        $this->assertSame([], $stats['topAlbums']);
+        $this->assertSame([], $stats['yearDistribution']);
+    }
+
+    /**
+     * @return array{
+     *     id: string, title: string, artist: string, album: string,
+     *     duration: int, playCount: int, year: ?int, starred: ?string, path: string
+     * }
+     */
+    private function track(
+        string $id,
+        string $title,
+        string $artist,
+        string $album,
+        int $duration,
+        int $playCount,
+        ?int $year,
+        ?string $starred,
+    ): array {
+        return [
+            'id' => $id,
+            'title' => $title,
+            'artist' => $artist,
+            'album' => $album,
+            'duration' => $duration,
+            'playCount' => $playCount,
+            'year' => $year,
+            'starred' => $starred,
+            'path' => '',
+        ];
+    }
+
+    private function createNavidromeStub(bool $available): NavidromeRepository
+    {
+        $stub = $this->createMock(NavidromeRepository::class);
+        $stub->method('isAvailable')->willReturn($available);
+
+        return $stub;
+    }
+}

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -217,6 +217,200 @@ class SubsonicClientTest extends TestCase
         $this->assertFalse($sub->startScan());
     }
 
+    public function testGetPlaylistsExposesEnrichedMetadata(): void
+    {
+        $client = new MockHttpClient([
+            $this->ok([
+                'playlists' => [
+                    'playlist' => [
+                        [
+                            'id' => 'pl-1',
+                            'name' => 'Top Rock',
+                            'owner' => 'admin',
+                            'songCount' => 42,
+                            'duration' => 9876,
+                            'public' => true,
+                            'created' => '2025-01-01T00:00:00.000Z',
+                            'changed' => '2025-06-15T12:34:56.000Z',
+                            'comment' => 'auto-generated',
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $playlists = $sub->getPlaylists();
+
+        $this->assertCount(1, $playlists);
+        $p = $playlists[0];
+        $this->assertSame('pl-1', $p['id']);
+        $this->assertSame('Top Rock', $p['name']);
+        $this->assertSame('admin', $p['owner']);
+        $this->assertSame(42, $p['songCount']);
+        $this->assertSame(9876, $p['duration']);
+        $this->assertTrue($p['public']);
+        $this->assertSame('2025-01-01T00:00:00.000Z', $p['created']);
+        $this->assertSame('2025-06-15T12:34:56.000Z', $p['changed']);
+        $this->assertSame('auto-generated', $p['comment']);
+    }
+
+    public function testGetPlaylistsDefaultsMissingFields(): void
+    {
+        $client = new MockHttpClient([
+            $this->ok([
+                'playlists' => [
+                    'playlist' => [
+                        ['id' => 'pl-9', 'name' => 'Bare', 'owner' => 'admin'],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $p = $sub->getPlaylists()[0];
+
+        $this->assertSame(0, $p['songCount']);
+        $this->assertSame(0, $p['duration']);
+        $this->assertFalse($p['public']);
+        $this->assertNull($p['created']);
+        $this->assertNull($p['changed']);
+        $this->assertSame('', $p['comment']);
+    }
+
+    public function testGetPlaylistReturnsTracksWithStarredStatus(): void
+    {
+        $client = new MockHttpClient([
+            $this->ok([
+                'playlist' => [
+                    'id' => 'pl-1',
+                    'name' => 'Top Rock',
+                    'owner' => 'admin',
+                    'songCount' => 2,
+                    'duration' => 360,
+                    'public' => false,
+                    'created' => '2025-01-01T00:00:00.000Z',
+                    'changed' => '2025-06-15T12:34:56.000Z',
+                    'comment' => '',
+                    'entry' => [
+                        [
+                            'id' => 'mf-1',
+                            'title' => 'Halo',
+                            'artist' => 'Beyoncé',
+                            'album' => 'I Am',
+                            'duration' => 200,
+                            'playCount' => 12,
+                            'year' => 2008,
+                            'starred' => '2025-02-03T10:00:00Z',
+                            'path' => 'Beyoncé/I Am/01 - Halo.mp3',
+                        ],
+                        [
+                            'id' => 'mf-2',
+                            'title' => 'Smile',
+                            'artist' => 'Lily Allen',
+                            'album' => 'Alright Still',
+                            'duration' => 160,
+                            'playCount' => 5,
+                        ],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $pl = $sub->getPlaylist('pl-1');
+
+        $this->assertSame('pl-1', $pl['id']);
+        $this->assertSame('Top Rock', $pl['name']);
+        $this->assertCount(2, $pl['tracks']);
+        $this->assertSame('mf-1', $pl['tracks'][0]['id']);
+        $this->assertSame(2008, $pl['tracks'][0]['year']);
+        $this->assertSame('2025-02-03T10:00:00Z', $pl['tracks'][0]['starred']);
+        $this->assertSame('Beyoncé/I Am/01 - Halo.mp3', $pl['tracks'][0]['path']);
+        $this->assertNull($pl['tracks'][1]['starred']);
+        $this->assertNull($pl['tracks'][1]['year']);
+    }
+
+    public function testGetPlaylistRejectsEmptyId(): void
+    {
+        $sub = new SubsonicClient(new MockHttpClient(static function () {
+            throw new \RuntimeException('Should not perform HTTP for empty id.');
+        }), 'http://navi.test', 'admin', 'changeme');
+
+        $this->expectException(\RuntimeException::class);
+        $sub->getPlaylist('');
+    }
+
+    public function testUpdatePlaylistRenameOnlyTransmitsName(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok([]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $sub->updatePlaylist('pl-1', name: 'Renamed');
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/rest/updatePlaylist.view?', $captured);
+        $this->assertStringContainsString('playlistId=pl-1', $captured);
+        $this->assertStringContainsString('name=Renamed', $captured);
+        $this->assertStringNotContainsString('comment=', $captured);
+        $this->assertStringNotContainsString('public=', $captured);
+        $this->assertStringNotContainsString('songIdToAdd=', $captured);
+    }
+
+    public function testUpdatePlaylistAddRemoveSongs(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok([]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $sub->updatePlaylist(
+            'pl-1',
+            songIdToAdd: ['mf-10', 'mf-11'],
+            songIndexToRemove: [3, 7],
+        );
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('songIdToAdd=mf-10', $captured);
+        $this->assertStringContainsString('songIdToAdd=mf-11', $captured);
+        $this->assertStringContainsString('songIndexToRemove=3', $captured);
+        $this->assertStringContainsString('songIndexToRemove=7', $captured);
+    }
+
+    public function testUpdatePlaylistPublicFlag(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok([]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $sub->updatePlaylist('pl-1', public: false);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('public=false', $captured);
+    }
+
+    public function testUpdatePlaylistRejectsEmptyId(): void
+    {
+        $sub = new SubsonicClient(new MockHttpClient(static function () {
+            throw new \RuntimeException('Should not perform HTTP for empty id.');
+        }), 'http://navi.test', 'admin', 'changeme');
+
+        $this->expectException(\RuntimeException::class);
+        $sub->updatePlaylist('', name: 'X');
+    }
+
     /**
      * @param array<string, mixed> $payload
      */


### PR DESCRIPTION
Implémente l'epic #71 (gestion des playlists Navidrome) en un seul commit, en réutilisant l'infra Subsonic/Doctrine existante. Toutes les écritures passent par l'API Subsonic — la DB Navidrome reste mountée `:ro`.

## Pages

- **`/playlists`** : liste les playlists Navidrome avec aperçu (count, durée, dates création/modif, owner, public/privé), bouton M3U par ligne, sélection multi + bulk delete.
- **`/playlists/{id}`** : détail avec table des morceaux (statut starred ★), stats (durée totale, top 10 artistes/albums, distribution par année, % jamais joués), badge « morceaux morts » + bouton purge, toolbar (rename, dupliquer, bulk star/unstar, supprimer), actions par ligne (toggle star, retirer).
- **`/playlist/{id}/preview.m3u`** : export M3U mutualisé sur la prévisualisation des `PlaylistDefinition` (closes #8).

## Couche technique

- `SubsonicClient::getPlaylists()` enrichi (`songCount`, `duration`, `public`, `created`, `changed`, `comment`).
- `SubsonicClient::getPlaylist(string $id)` — wrap `getPlaylist.view`.
- `SubsonicClient::updatePlaylist($id, ?name, ?comment, ?public, songIdToAdd, songIndexToRemove)` — wrap `updatePlaylist.view`.
- Réutilise `starTracks` / `unstarTracks` déjà disponibles (closes les sous-tickets #76/#77 sans nouveau code SubsonicClient).
- `M3uExporter` : service générique acceptant arrays Subsonic ou `TrackSummary`.
- `PlaylistStatsService` : agrégat par playlist + fallback `media_file.year` via DBAL si Subsonic ne renvoie pas l'année.
- `NavidromeRepository::filterMissingMediaFileIds()` + `getMediaFileMetadata()` pour la détection des morceaux morts.
- `PlaylistController` : 11 routes CSRF-protected. La suppression nettoie le `lastSubsonicPlaylistId` des `PlaylistDefinition` rattachées.
- Lien « Playlists » ajouté dans la nav (`templates/base.html.twig`).

## Sous-tickets fermés

#72 liste · #73 détail · #74 rename · #75 delete · #76 star · #77 bulk star · #79 dupliquer · #80 stats · #81 morceaux morts · #82 bulk delete · #83 export M3U.

#78 partiellement : retrait d'un morceau livré ; ajout/réordonnancement (drag & drop + search box) restent à faire.

## Tests

`composer ci` vert : phpcs + phpstan niveau 6 + 278 tests / 705 assertions (16 nouveaux).

- `tests/Subsonic/SubsonicClientTest.php` : 8 nouveaux tests (getPlaylists enrichi, getPlaylist, updatePlaylist rename/add+remove/public/empty-id).
- `tests/Service/M3uExporterTest.php` : 5 tests (arrays, TrackSummary, comma stripping, slug filename).
- `tests/Service/PlaylistStatsServiceTest.php` : 4 tests (agrégat complet, fallback année DB online/offline, playlist vide).

## Test plan

- [ ] Pull, login UI → cliquer « Playlists » dans la nav, vérifier que la liste s'affiche avec count/durée/dates.
- [ ] Ouvrir une playlist → vérifier table tracks + stats + statut starred.
- [ ] Renommer une playlist → vérifier côté Navidrome.
- [ ] Star un morceau → unstar → bulk star.
- [ ] Dupliquer → vérifier suffixe « (copie) ».
- [ ] Exporter M3U (page liste + page détail + preview PlaylistDefinition) → ouvrir dans VLC.
- [ ] Sur une playlist contenant des id obsolètes : vérifier le badge « morceaux morts » + purge.
- [ ] Supprimer une playlist rattachée à un `PlaylistDefinition` → vérifier que `lastSubsonicPlaylistId` est nullé.
- [ ] Bulk delete sur 2+ playlists.

Closes #71, #72, #73, #74, #75, #76, #77, #79, #80, #81, #82, #83.

https://claude.ai/code/session_018hbtjBjsEHdAmzGVBjBxud

---
_Generated by [Claude Code](https://claude.ai/code/session_018hbtjBjsEHdAmzGVBjBxud)_