### PR TITLE
feat(lastfm): app:lastfm:rematch --random flag for sampling unmatched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **`app:lastfm:rematch --random`** : nouveau flag qui mélange l'ordre
+  des unmatched avant d'appliquer `--limit`. Utile pour échantillonner
+  un sous-ensemble représentatif quand on debugge une nouvelle
+  heuristique de matching sur un gros backlog (sans le flag, le tri
+  par défaut `id ASC` retraite toujours les mêmes morceaux en tête de
+  table).
 - **Cache de résolution Last.fm match (positif + négatif)** : nouvelle
   table `lastfm_match_cache` (`source_artist_norm`, `source_title_norm`
   UNIQUE → `target_media_file_id` nullable + `strategy`

--- a/README.md
+++ b/README.md
@@ -476,11 +476,15 @@ ré-appliquée et les scrobbles trouvés sont insérés dans Navidrome
 ### CLI
 
 ```bash
-php bin/console app:lastfm:rematch [--dry-run] [--run-id=N] [--limit=N]
+php bin/console app:lastfm:rematch [--dry-run] [--run-id=N] [--limit=N] [--random]
 ```
 
 `--dry-run` montre le rapport sans écrire. `--run-id=N` limite le
 rematch aux unmatched du run #N. `--limit=0` (défaut) = pas de limite.
+`--random` mélange l'ordre des unmatched avant d'appliquer `--limit`,
+utile pour échantillonner un sous-ensemble représentatif (par défaut
+les rows sont parcourues par id croissant, donc avec un `--limit` fixe
+on retraiterait toujours les mêmes morceaux en tête de table).
 
 ### Web
 

--- a/src/Command/RematchUnmatchedCommand.php
+++ b/src/Command/RematchUnmatchedCommand.php
@@ -54,6 +54,12 @@ class RematchUnmatchedCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Dedup tolerance in seconds for scrobbleExistsNear (default 60).',
                 '60',
+            )
+            ->addOption(
+                'random',
+                null,
+                InputOption::VALUE_NONE,
+                'Process unmatched rows in random order (combine with --limit to sample a subset).',
             );
     }
 
@@ -65,6 +71,7 @@ class RematchUnmatchedCommand extends Command
         $runId = $runId !== null ? (int) $runId : null;
         $limit = max(0, (int) $input->getOption('limit'));
         $tolerance = max(0, (int) $input->getOption('tolerance'));
+        $random = (bool) $input->getOption('random');
 
         $reference = $runId !== null ? 'run-' . $runId : 'all';
         $label = 'Rematch unmatched — ' . $reference . ($dryRun ? ' [dry-run]' : '');
@@ -79,6 +86,7 @@ class RematchUnmatchedCommand extends Command
                     limit: $limit,
                     dryRun: $dryRun,
                     toleranceSeconds: $tolerance,
+                    random: $random,
                 ),
                 extractMetrics: static fn (RematchReport $r) => [
                     'considered' => $r->considered,
@@ -92,6 +100,7 @@ class RematchUnmatchedCommand extends Command
                     'run_id_filter' => $runId,
                     'limit' => $limit,
                     'dry_run' => $dryRun,
+                    'random' => $random,
                 ],
             );
         } catch (\Throwable $e) {

--- a/src/Repository/LastFmImportTrackRepository.php
+++ b/src/Repository/LastFmImportTrackRepository.php
@@ -48,15 +48,27 @@ class LastFmImportTrackRepository extends ServiceEntityRepository
      * without buffering the whole table — useful for the rematch CLI which
      * may iterate over tens of thousands of historical unmatched entries.
      *
-     * @param int|null $runId Filter to a single run when non-null
-     * @param int      $limit Hard cap (set high for full sweeps; the cli
-     *                        passes its --limit flag through). 0 means no
-     *                        limit.
+     * When $random is true the candidates are shuffled in PHP before $limit
+     * is applied (DQL has no portable RANDOM() and adding a custom function
+     * for one feature is overkill). The memory cost is bounded by the
+     * number of unmatched IDs (integers, negligible even at 100k rows).
+     *
+     * @param int|null $runId  Filter to a single run when non-null
+     * @param int      $limit  Hard cap (set high for full sweeps; the cli
+     *                         passes its --limit flag through). 0 means no
+     *                         limit.
+     * @param bool     $random Shuffle candidates before applying $limit.
+     *                         Useful to sample a subset when debugging
+     *                         matching heuristics on a large backlog.
      *
      * @return iterable<LastFmImportTrack>
      */
-    public function streamUnmatched(?int $runId = null, int $limit = 0): iterable
+    public function streamUnmatched(?int $runId = null, int $limit = 0, bool $random = false): iterable
     {
+        if ($random) {
+            return $this->streamUnmatchedRandom($runId, $limit);
+        }
+
         $qb = $this->createQueryBuilder('t')
             ->andWhere('t.status = :s')
             ->setParameter('s', LastFmImportTrack::STATUS_UNMATCHED)
@@ -69,6 +81,35 @@ class LastFmImportTrackRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->toIterable();
+    }
+
+    /**
+     * @return \Generator<int, LastFmImportTrack>
+     */
+    private function streamUnmatchedRandom(?int $runId, int $limit): \Generator
+    {
+        $qb = $this->createQueryBuilder('t')
+            ->select('t.id')
+            ->andWhere('t.status = :s')
+            ->setParameter('s', LastFmImportTrack::STATUS_UNMATCHED);
+        if ($runId !== null) {
+            $qb->andWhere('IDENTITY(t.runHistory) = :run')->setParameter('run', $runId);
+        }
+
+        /** @var list<array{id: int}> $rows */
+        $rows = $qb->getQuery()->getArrayResult();
+        $ids = array_column($rows, 'id');
+        shuffle($ids);
+        if ($limit > 0 && count($ids) > $limit) {
+            $ids = array_slice($ids, 0, $limit);
+        }
+
+        foreach ($ids as $id) {
+            $entity = $this->find($id);
+            if ($entity !== null) {
+                yield $entity;
+            }
+        }
     }
 
     /**

--- a/src/Service/LastFmRematchService.php
+++ b/src/Service/LastFmRematchService.php
@@ -40,8 +40,13 @@ class LastFmRematchService
         $this->logger = $logger ?? new NullLogger();
     }
 
-    public function rematch(?int $runId = null, int $limit = 0, bool $dryRun = false, int $toleranceSeconds = 60): RematchReport
-    {
+    public function rematch(
+        ?int $runId = null,
+        int $limit = 0,
+        bool $dryRun = false,
+        int $toleranceSeconds = 60,
+        bool $random = false,
+    ): RematchReport {
         if (!$this->navidrome->hasScrobblesTable()) {
             throw new \RuntimeException(
                 'The Navidrome scrobbles table does not exist. Upgrade Navidrome to >= 0.55.',
@@ -56,7 +61,7 @@ class LastFmRematchService
 
         $report = new RematchReport();
         $batch = 0;
-        foreach ($this->trackRepo->streamUnmatched($runId, $limit) as $track) {
+        foreach ($this->trackRepo->streamUnmatched($runId, $limit, $random) as $track) {
             /** @var LastFmImportTrack $track */
             $report->considered++;
 

--- a/tests/Service/LastFmRematchServiceTest.php
+++ b/tests/Service/LastFmRematchServiceTest.php
@@ -156,6 +156,27 @@ class LastFmRematchServiceTest extends TestCase
         $this->assertSame(1, (int) $count);
     }
 
+    public function testRematchHonorsRandomFlagAndLimit(): void
+    {
+        // 5 unmatched rows, --random + --limit=2 should process exactly 2.
+        // We don't assert which 2 (shuffle is non-deterministic by design);
+        // the point is to validate the flag is wired through to the repo.
+        NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        $run = $this->makeRun();
+        $tracks = [
+            $this->makeUnmatchedTrack($run, 'A1', 'T1', new \DateTimeImmutable('2026-04-01 10:00:00')),
+            $this->makeUnmatchedTrack($run, 'A2', 'T2', new \DateTimeImmutable('2026-04-02 10:00:00')),
+            $this->makeUnmatchedTrack($run, 'A3', 'T3', new \DateTimeImmutable('2026-04-03 10:00:00')),
+            $this->makeUnmatchedTrack($run, 'A4', 'T4', new \DateTimeImmutable('2026-04-04 10:00:00')),
+            $this->makeUnmatchedTrack($run, 'A5', 'T5', new \DateTimeImmutable('2026-04-05 10:00:00')),
+        ];
+
+        $service = $this->makeService($tracks);
+        $report = $service->rematch(limit: 2, dryRun: true, random: true);
+
+        $this->assertSame(2, $report->considered);
+    }
+
     /**
      * @param list<LastFmImportTrack> $tracks
      */
@@ -163,11 +184,21 @@ class LastFmRematchServiceTest extends TestCase
     {
         $repo = $this->createMock(LastFmImportTrackRepository::class);
         $repo->method('streamUnmatched')->willReturnCallback(
-            function (?int $runId = null, int $limit = 0) use ($tracks): \Generator {
+            function (?int $runId = null, int $limit = 0, bool $random = false) use ($tracks): \Generator {
+                $candidates = [];
                 foreach ($tracks as $t) {
                     if ($t->getStatus() !== LastFmImportTrack::STATUS_UNMATCHED) {
                         continue;
                     }
+                    $candidates[] = $t;
+                }
+                if ($random) {
+                    shuffle($candidates);
+                }
+                if ($limit > 0 && count($candidates) > $limit) {
+                    $candidates = array_slice($candidates, 0, $limit);
+                }
+                foreach ($candidates as $t) {
                     yield $t;
                 }
             }


### PR DESCRIPTION
Le tri par défaut `id ASC` de streamUnmatched() retraite toujours les
mêmes morceaux en tête de table quand on combine avec --limit, ce qui
empêche d'échantillonner un sous-ensemble représentatif lors du debug
d'une nouvelle heuristique de matching. Le nouveau flag --random
mélange les candidats côté PHP (DQL n'a pas de RANDOM() portable et
ajouter une fonction custom serait disproportionné pour un seul cas
d'usage) avant d'appliquer la limite, en deux temps : SELECT id puis
shuffle + slice + find($id). Coût mémoire borné par les IDs unmatched.

Le flag est propagé au service, à la commande et tracé dans
RunHistory.metrics.

https://claude.ai/code/session_01V1tFQ9WzQ2yHgKf9vbuVGi