### PR TITLE
chore(roadmap): synchronize with GitHub + brainstorm tickets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,62 +26,64 @@ Améliorations granulaires du pipeline de matching scrobble Last.fm →
 `media_file` Navidrome. Voir le meta [#11] pour la stratégie globale et
 l'ordre d'attaque recommandé.
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#22] | Profil strict / default / lax configurable                      | S      |
-| [#19] | Suggestions automatiques + apprentissage par confirmation       | L      |
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#22] | Profil strict / default / lax configurable                         | S      |
+| [#17] | Récupérer le MBID manquant via `track.getInfo` / `track.getCorrection` | M  |
+| [#19] | Suggestions automatiques + apprentissage par confirmation          | L      |
 
 ### Last.fm — autres
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#3]  | Sync incrémentale Last.fm → Navidrome                           | M      |
-| [#4]  | Page permanente : diff Last.fm vs lib Navidrome                 | M      |
-| [#47] | Synthèse d'un import Last.fm sur la page détail (totaux + %)    | M      |
+| #      | Titre                                                              | Effort |
+|--------|--------------------------------------------------------------------|--------|
+| [#3]   | Sync incrémentale Last.fm → Navidrome                              | M      |
+| [#4]   | Page permanente : diff Last.fm vs lib Navidrome                    | M      |
+| [#100] | Reconciliation des timestamps Last.fm après coup                   | M      |
+| [#98]  | Enrichissement par tags (`track.getTopTags`) + générateur « mood » | M      |
+| [#35]  | Supprimer la contrainte d'arrêt de Navidrome pour l'import         | L      |
+| [#36]  | Sources de scrobbles alternatives (Listenbrainz, Maloja, …)        | L      |
 
 ### Stats / Curation
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#25] | Page « métadonnées incomplètes » : albums sans MBID groupés par artiste | M      |
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#93] | Courbe de diversité d'écoute (unique artists / plays par mois)     | S      |
+| [#97] | Split des tops par client Subsonic (DSub, Symfonium, web…)         | S      |
+| [#91] | Page « artistes oubliés » (high play_count + idle > N mois)        | M      |
+| [#25] | Page « métadonnées incomplètes » : albums sans MBID groupés par artiste | M  |
 
 ### Playlists
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#6]  | Auto-star des top morceaux (Subsonic `star.view`)               | S      |
-| [#8]  | Export M3U téléchargeable depuis la prévisualisation            | S      |
-| [#5]  | Diff entre deux runs d'une même playlist                        | M      |
-
-#### Gestion des playlists Navidrome (meta [#71])
-
-Vraie page de gestion des playlists côté navidrome-tools : voir/renommer/
-supprimer/starrer sans avoir à ouvrir Navidrome. Toutes les écritures
-restent côté Subsonic (DB Navidrome `:ro`). Voir le meta [#71] pour le
-contexte complet et l'ordre d'attaque (72 → 73 → 74-77 en parallèle).
-
 | #     | Titre                                                              | Effort |
 |-------|--------------------------------------------------------------------|--------|
-| [#72] | Liste sur `/playlists` (étend `getPlaylists` avec count/durée/dates) | S      |
-| [#73] | Page détail `/playlists/{id}` avec tracks et statut starred        | S      |
-| [#74] | Renommer une playlist via `updatePlaylist.view`                    | S      |
-| [#75] | Supprimer depuis l'UI + nettoyage `lastSubsonicPlaylistId`         | S      |
-| [#76] | Star / unstar individuel d'un morceau (réutilise `starTracks`)     | S      |
-| [#77] | Bulk star/unstar de tous les morceaux d'une playlist               | S      |
-| [#79] | Dupliquer une playlist                                             | S      |
-| [#82] | Bulk delete depuis la liste                                        | S      |
-| [#83] | Export M3U depuis la page détail (mutualisé avec [#8])             | M      |
-| [#78] | Ajouter / retirer / réordonner des morceaux                        | M      |
-| [#80] | Statistiques par playlist (durée, top artistes, distribution)      | M      |
-| [#81] | Détection des morceaux morts + purge                               | M      |
+| [#6]  | Auto-star des top morceaux (Subsonic `star.view`)                  | S      |
+| [#90] | Générateur « anniversaire » (jour J il y a N années)               | S      |
+| [#5]  | Diff entre deux runs d'une même playlist                           | M      |
 
 ### Cron / observabilité
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#7]  | Notifications cron (Discord / Slack / Pushover)                 | M      |
-| [#9]  | Webhooks sortants génériques (POST JSON après chaque run)       | M      |
-| [#58] | Tableau des 10 derniers runs sur le dashboard                   | S      |
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#99] | Note libre éditable sur un RunHistory                              | S      |
+| [#7]  | Notifications cron (Discord / Slack / Pushover)                    | M      |
+| [#9]  | Webhooks sortants génériques (POST JSON après chaque run)          | M      |
+| [#94] | Synthèse hebdo/mensuelle automatique (digest + RSS)                | M      |
+
+### Intégrations / ops
+
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#95] | Backup automatique programmable de la DB locale                    | S      |
+| [#96] | Endpoint `/health` pour Docker healthcheck                         | S      |
+| [#92] | Suggestions d'artistes via Last.fm `artist.getSimilar`             | M      |
+| [#37] | Export/import de la DB locale du tool                              | M      |
+| [#69] | Permettre des générateurs custom en déploiement Docker             | M      |
+
+### UI
+
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#87] | Dark theme par défaut sur l'UI                                     | S      |
 
 ### UI — Miniatures album/artiste (meta [#26])
 
@@ -92,12 +94,12 @@ cache sur disque dans un volume Docker dédié, déduplication par
 `album_id`. Voir le meta [#26] pour la stratégie globale et l'ordre
 d'attaque (A est prérequis pour B-F).
 
-| #   | Titre                                                              | Effort |
-|-----|--------------------------------------------------------------------|--------|
-| [#28] | B. Miniatures sur /stats (index + compare)                      | S      |
-| [#29] | C. Miniatures sur /wrapped/{year}                               | S      |
-| [#30] | D. Miniatures sur les histories (Last.fm, Navidrome, run detail)| S      |
-| [#31] | E. Miniatures sur la preview de playlist                        | S      |
+| #     | Titre                                                              | Effort |
+|-------|--------------------------------------------------------------------|--------|
+| [#28] | B. Miniatures sur /stats (index + compare)                         | S      |
+| [#29] | C. Miniatures sur /wrapped/{year}                                  | S      |
+| [#30] | D. Miniatures sur les histories (Last.fm, Navidrome, run detail)   | S      |
+| [#31] | E. Miniatures sur la preview de playlist                           | S      |
 
 ---
 
@@ -123,6 +125,10 @@ quand on tagge des releases) :
 - v0.7 — Générateur `songs-you-used-to-love`.
 - v0.8 — UX dashboard : filtres + sort + duplicate + lien Subsonic +
   pastille santé live + boutons `+ Nouvelle playlist` contextuels.
+- v0.9 — Gestion playlists Navidrome (epic [#71] : liste/détail/rename/
+  delete/star/bulk star/duplicate/bulk delete + export M3U [#8]),
+  tableau dashboard 10 derniers runs [#58], synthèse % sur les imports
+  Last.fm [#47].
 
 ---
 
@@ -134,6 +140,7 @@ quand on tagge des releases) :
 [#8]: https://github.com/kgaut/navidrome-playlist-generator/issues/8
 [#9]: https://github.com/kgaut/navidrome-playlist-generator/issues/9
 [#11]: https://github.com/kgaut/navidrome-playlist-generator/issues/11
+[#17]: https://github.com/kgaut/navidrome-playlist-generator/issues/17
 [#19]: https://github.com/kgaut/navidrome-playlist-generator/issues/19
 [#22]: https://github.com/kgaut/navidrome-playlist-generator/issues/22
 [#25]: https://github.com/kgaut/navidrome-playlist-generator/issues/25
@@ -142,18 +149,22 @@ quand on tagge des releases) :
 [#29]: https://github.com/kgaut/navidrome-playlist-generator/issues/29
 [#30]: https://github.com/kgaut/navidrome-playlist-generator/issues/30
 [#31]: https://github.com/kgaut/navidrome-playlist-generator/issues/31
+[#35]: https://github.com/kgaut/navidrome-playlist-generator/issues/35
+[#36]: https://github.com/kgaut/navidrome-playlist-generator/issues/36
+[#37]: https://github.com/kgaut/navidrome-playlist-generator/issues/37
 [#47]: https://github.com/kgaut/navidrome-playlist-generator/issues/47
 [#58]: https://github.com/kgaut/navidrome-playlist-generator/issues/58
+[#69]: https://github.com/kgaut/navidrome-playlist-generator/issues/69
 [#71]: https://github.com/kgaut/navidrome-playlist-generator/issues/71
-[#72]: https://github.com/kgaut/navidrome-playlist-generator/issues/72
-[#73]: https://github.com/kgaut/navidrome-playlist-generator/issues/73
-[#74]: https://github.com/kgaut/navidrome-playlist-generator/issues/74
-[#75]: https://github.com/kgaut/navidrome-playlist-generator/issues/75
-[#76]: https://github.com/kgaut/navidrome-playlist-generator/issues/76
-[#77]: https://github.com/kgaut/navidrome-playlist-generator/issues/77
-[#78]: https://github.com/kgaut/navidrome-playlist-generator/issues/78
-[#79]: https://github.com/kgaut/navidrome-playlist-generator/issues/79
-[#80]: https://github.com/kgaut/navidrome-playlist-generator/issues/80
-[#81]: https://github.com/kgaut/navidrome-playlist-generator/issues/81
-[#82]: https://github.com/kgaut/navidrome-playlist-generator/issues/82
-[#83]: https://github.com/kgaut/navidrome-playlist-generator/issues/83
+[#87]: https://github.com/kgaut/navidrome-playlist-generator/issues/87
+[#90]: https://github.com/kgaut/navidrome-playlist-generator/issues/90
+[#91]: https://github.com/kgaut/navidrome-playlist-generator/issues/91
+[#92]: https://github.com/kgaut/navidrome-playlist-generator/issues/92
+[#93]: https://github.com/kgaut/navidrome-playlist-generator/issues/93
+[#94]: https://github.com/kgaut/navidrome-playlist-generator/issues/94
+[#95]: https://github.com/kgaut/navidrome-playlist-generator/issues/95
+[#96]: https://github.com/kgaut/navidrome-playlist-generator/issues/96
+[#97]: https://github.com/kgaut/navidrome-playlist-generator/issues/97
+[#98]: https://github.com/kgaut/navidrome-playlist-generator/issues/98
+[#99]: https://github.com/kgaut/navidrome-playlist-generator/issues/99
+[#100]: https://github.com/kgaut/navidrome-playlist-generator/issues/100


### PR DESCRIPTION
Sync ROADMAP.md after a long batch of merges (gestion playlists epic
#71 + sub-issues #72-#83, export M3U #8, dashboard last runs #58,
import synthesis #47) plus the brainstorm round of new tickets.

Removed from Icebox (now shipped): #8, #47, #58, #71, #72-#83.
Added "v0.9" line under "Livré" to record the playlist management batch.

Indexed previously-missing open issues: #17, #35, #36, #37, #69, #87.

Created and indexed 11 new tickets from the brainstorm:
- #90  feat(playlists): générateur anniversaire
- #91  feat(stats): page artistes oubliés
- #92  feat(integrations): suggestions via artist.getSimilar
- #93  feat(stats): courbe de diversité d'écoute
- #94  feat(integrations): digest hebdo/mensuel + RSS
- #95  feat(export): backup auto programmable
- #96  feat(integrations): endpoint /health
- #97  feat(stats): split tops par client Subsonic
- #98  feat(lastfm): tags track.getTopTags + générateur mood
- #99  feat(history): note libre éditable sur RunHistory
- #100 feat(lastfm): reconciliation timestamps Last.fm

New sections "Intégrations / ops" and "UI" introduced to host items
that didn't fit cleanly under existing area buckets.

https://claude.ai/code/session_01RSMyYhakoFK7DodyLwPZEA