### PR TITLE
fix(stats): scrobble timestamps shifted by APP_TIMEZONE offset (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+- **Heures Last.fm history affichées dans `APP_TIMEZONE`** : la page
+  `/stats/lastfm-history` affichait les heures de scrobble avec le
+  décalage UTC (ex. `10:00` au lieu de `12:00` à Paris en été). Cause :
+  Doctrine `datetime_immutable` sérialisait l'heure dans la timezone
+  de l'objet (UTC) puis la relisait en l'étiquetant avec la timezone
+  PHP par défaut (`Europe/Paris`), ce qui décalait silencieusement
+  l'instant ; Twig `|date` ne corrigeait plus rien. Nouveau type
+  Doctrine `utc_datetime_immutable` (`App\Doctrine\UtcDateTimeImmutableType`)
+  qui force la sérialisation en UTC à l'écriture et tague la valeur
+  UTC à la relecture, indépendamment de `APP_TIMEZONE`. Appliqué à
+  `LastFmHistoryEntry::$playedAt` / `$fetchedAt` et
+  `LastFmImportTrack::$playedAt`. Aucune migration de données : les
+  rows existantes en base étaient déjà au bon wall-clock UTC pour
+  `played_at` ; `fetched_at` se réaligne au prochain « Rafraîchir ».
+  Closes #102.
+
 ### Added
 - **`app:lastfm:rematch --random`** : nouveau flag qui mélange l'ordre
   des unmatched avant d'appliquer `--limit`. Utile pour échantillonner

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -1,5 +1,12 @@
 doctrine:
     dbal:
+        types:
+            # Stores DateTimeImmutable as UTC and reads it back UTC-tagged,
+            # so APP_TIMEZONE doesn't silently shift the instant. Use on
+            # any column whose value is a true point in time (a scrobble
+            # timestamp, an audit row's start/end), not a wall-clock that
+            # only makes sense in the operator's local time.
+            utc_datetime_immutable: App\Doctrine\UtcDateTimeImmutableType
         default_connection: default
         connections:
             default:

--- a/src/Doctrine/UtcDateTimeImmutableType.php
+++ b/src/Doctrine/UtcDateTimeImmutableType.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctrine;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\DateTimeImmutableType;
+use Doctrine\DBAL\Types\Exception\InvalidFormat;
+
+/**
+ * Stores and reads `DateTimeImmutable` values as UTC, regardless of the PHP
+ * default timezone in effect.
+ *
+ * Doctrine's built-in `datetime_immutable` writes the wall-clock string in
+ * the value's current timezone and reads it back tagged with PHP's default
+ * timezone. With `APP_TIMEZONE=Europe/Paris`, that round-trip silently
+ * shifts an UTC instant by the offset (a `2026-05-03 10:00:00 UTC` value
+ * becomes `2026-05-03 10:00:00 Europe/Paris` on read — same wall clock,
+ * different instant). Twig's `|date` filter, configured with the same
+ * timezone, then renders the UTC clock value as if it were local.
+ *
+ * This type forces both directions to UTC so the stored wall clock is
+ * always UTC and the loaded `DateTimeImmutable` is always UTC-tagged,
+ * leaving Twig (and any downstream code) free to convert to the display
+ * timezone correctly.
+ */
+final class UtcDateTimeImmutableType extends DateTimeImmutableType
+{
+    public const NAME = 'utc_datetime_immutable';
+
+    private static ?DateTimeZone $utc = null;
+
+    public function convertToDatabaseValue(mixed $value, AbstractPlatform $platform): ?string
+    {
+        if ($value instanceof DateTimeImmutable) {
+            $value = $value->setTimezone(self::utc());
+        }
+
+        return parent::convertToDatabaseValue($value, $platform);
+    }
+
+    public function convertToPHPValue(mixed $value, AbstractPlatform $platform): ?DateTimeImmutable
+    {
+        if ($value === null || $value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        $dateTime = DateTimeImmutable::createFromFormat(
+            $platform->getDateTimeFormatString(),
+            $value,
+            self::utc(),
+        );
+
+        if ($dateTime !== false) {
+            return $dateTime;
+        }
+
+        try {
+            return new DateTimeImmutable($value, self::utc());
+        } catch (\Exception $e) {
+            throw InvalidFormat::new(
+                $value,
+                static::class,
+                $platform->getDateTimeFormatString(),
+                $e,
+            );
+        }
+    }
+
+    private static function utc(): DateTimeZone
+    {
+        return self::$utc ??= new DateTimeZone('UTC');
+    }
+}

--- a/src/Entity/LastFmHistoryEntry.php
+++ b/src/Entity/LastFmHistoryEntry.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Doctrine\UtcDateTimeImmutableType;
 use App\Repository\LastFmHistoryEntryRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -27,7 +28,7 @@ class LastFmHistoryEntry
     #[ORM\Column(length: 255)]
     private string $lastfmUser;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME)]
     private \DateTimeImmutable $playedAt;
 
     #[ORM\Column(length: 255)]
@@ -42,7 +43,7 @@ class LastFmHistoryEntry
     #[ORM\Column(length: 64, nullable: true)]
     private ?string $mbid = null;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME)]
     private \DateTimeImmutable $fetchedAt;
 
     public function __construct(
@@ -59,7 +60,7 @@ class LastFmHistoryEntry
         $this->title = $title;
         $this->album = $album !== null && $album !== '' ? $album : null;
         $this->mbid = $mbid !== null && $mbid !== '' ? $mbid : null;
-        $this->fetchedAt = new \DateTimeImmutable();
+        $this->fetchedAt = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
     }
 
     public function getId(): ?int

--- a/src/Entity/LastFmImportTrack.php
+++ b/src/Entity/LastFmImportTrack.php
@@ -2,6 +2,7 @@
 
 namespace App\Entity;
 
+use App\Doctrine\UtcDateTimeImmutableType;
 use App\Repository\LastFmImportTrackRepository;
 use Doctrine\DBAL\Types\Types;
 use Doctrine\ORM\Mapping as ORM;
@@ -44,7 +45,7 @@ class LastFmImportTrack
     #[ORM\Column(length: 64, nullable: true)]
     private ?string $mbid = null;
 
-    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME)]
     private \DateTimeImmutable $playedAt;
 
     #[ORM\Column(length: 16)]

--- a/src/Repository/LastFmHistoryEntryRepository.php
+++ b/src/Repository/LastFmHistoryEntryRepository.php
@@ -48,7 +48,10 @@ class LastFmHistoryEntryRepository extends ServiceEntityRepository
             return null;
         }
 
-        return new \DateTimeImmutable($row['last_fetched']);
+        // fetchedAt is stored in UTC (see UtcDateTimeImmutableType); MAX() returns
+        // the raw wall-clock string, so we must tag it UTC explicitly — otherwise
+        // PHP's default timezone re-interprets it and shifts the instant.
+        return new \DateTimeImmutable($row['last_fetched'], new \DateTimeZone('UTC'));
     }
 
     public function deleteForUser(string $lastfmUser): int

--- a/tests/Doctrine/UtcDateTimeImmutableTypeTest.php
+++ b/tests/Doctrine/UtcDateTimeImmutableTypeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Tests\Doctrine;
+
+use App\Doctrine\UtcDateTimeImmutableType;
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Doctrine\DBAL\Types\Type;
+use PHPUnit\Framework\TestCase;
+
+class UtcDateTimeImmutableTypeTest extends TestCase
+{
+    private SQLitePlatform $platform;
+    private UtcDateTimeImmutableType $type;
+    private string $previousTimezone = 'UTC';
+
+    protected function setUp(): void
+    {
+        $this->previousTimezone = date_default_timezone_get();
+        if (!Type::hasType(UtcDateTimeImmutableType::NAME)) {
+            Type::addType(UtcDateTimeImmutableType::NAME, UtcDateTimeImmutableType::class);
+        }
+        $type = Type::getType(UtcDateTimeImmutableType::NAME);
+        $this->assertInstanceOf(UtcDateTimeImmutableType::class, $type);
+        $this->type = $type;
+        $this->platform = new SQLitePlatform();
+    }
+
+    protected function tearDown(): void
+    {
+        date_default_timezone_set($this->previousTimezone);
+    }
+
+    public function testWritesUtcWallClockEvenWhenValueIsLocal(): void
+    {
+        // 12:00 in Paris is 10:00 UTC; we want the on-disk string to be 10:00.
+        $paris = new \DateTimeImmutable('2026-05-03 12:00:00', new \DateTimeZone('Europe/Paris'));
+        $this->assertSame(
+            '2026-05-03 10:00:00',
+            $this->type->convertToDatabaseValue($paris, $this->platform),
+        );
+    }
+
+    public function testReadBackPreservesInstantAcrossPhpDefaultTimezone(): void
+    {
+        // Simulate the bug condition: PHP default tz is non-UTC at read time.
+        date_default_timezone_set('Europe/Paris');
+        $loaded = $this->type->convertToPHPValue('2026-05-03 10:00:00', $this->platform);
+        $this->assertNotNull($loaded);
+        $this->assertSame('UTC', $loaded->getTimezone()->getName());
+        // Same wall-clock interpreted as UTC, not Paris.
+        $this->assertSame('2026-05-03T10:00:00+00:00', $loaded->format(\DATE_ATOM));
+    }
+
+    public function testRoundTripIsIdempotent(): void
+    {
+        date_default_timezone_set('Europe/Paris');
+        $original = new \DateTimeImmutable('2026-05-03 12:00:00', new \DateTimeZone('Europe/Paris'));
+        $stored = $this->type->convertToDatabaseValue($original, $this->platform);
+        $loaded = $this->type->convertToPHPValue($stored, $this->platform);
+        $this->assertNotNull($loaded);
+        // Same instant, expressed in UTC after the round-trip.
+        $this->assertSame($original->getTimestamp(), $loaded->getTimestamp());
+        $this->assertSame('UTC', $loaded->getTimezone()->getName());
+    }
+
+    public function testNullPassthrough(): void
+    {
+        $this->assertNull($this->type->convertToDatabaseValue(null, $this->platform));
+        $this->assertNull($this->type->convertToPHPValue(null, $this->platform));
+    }
+}


### PR DESCRIPTION
## Summary

- Sur `/stats/lastfm-history`, les heures de scrobble s'affichaient en UTC au lieu de `APP_TIMEZONE`. Cause : Doctrine `datetime_immutable` sérialise dans la timezone de l'objet (UTC) puis relit en l'étiquetant avec la timezone PHP par défaut (`Europe/Paris`), ce qui décale silencieusement l'instant ; Twig `|date` ne corrige plus rien.
- Nouveau type Doctrine `utc_datetime_immutable` (`App\Doctrine\UtcDateTimeImmutableType`) qui force UTC dans les deux sens, indépendamment de `APP_TIMEZONE`. Appliqué à `LastFmHistoryEntry::{playedAt,fetchedAt}` et `LastFmImportTrack::playedAt`.
- `LastFmHistoryEntry::__construct` initialise désormais `fetchedAt` en UTC, et `LastFmHistoryEntryRepository::findLastFetchedAt()` tague explicitement UTC le résultat brut de `MAX(fetched_at)` pour le badge « mis en cache le … ».

## Pas de migration de données

- `played_at` : déjà stocké en UTC (LastFmClient taguait UTC avant persist) → aucun changement nécessaire.
- `fetched_at` : était stocké en local (Paris). Self-heal au prochain `Rafraîchir` puisque la table est wipe + re-insert.

Closes #102.

## Test plan

- [x] `composer ci` (phpcs + phpstan + 283 tests, 719 assertions, all green).
- [x] Tests unitaires sur `UtcDateTimeImmutableType` (round-trip, lecture avec PHP tz non-UTC, écriture d'une valeur locale).
- [x] `bin/console doctrine:schema:update --dump-sql` : aucune diff sur `lastfm_history` / `lastfm_import_track` (changement de type purement comportemental, pas de DDL).
- [ ] Vérification manuelle : avec `APP_TIMEZONE=Europe/Paris`, sur `/stats/lastfm-history` après un Rafraîchir, les heures matchent celles de last.fm/user/<u>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)