### PR TITLE
feat(integrations): widget Homepage avec stats scrobbles

### DIFF
--- a/.env
+++ b/.env
@@ -78,6 +78,10 @@ BEETS_QUEUE_PATH=
 COVERS_CACHE_PATH=%kernel.project_dir%/var/covers
 ###< Album/artist covers ###
 
+###> Homepage widget integration (Bearer token, empty = enriched mode disabled) ###
+HOMEPAGE_API_TOKEN=
+###< Homepage widget integration ###
+
 ###> Last.fm (optional — fallbacks when import form/CLI is called without explicit values) ###
 # API key: get one at https://www.last.fm/api/account/create
 LASTFM_API_KEY=

--- a/.env.dist
+++ b/.env.dist
@@ -80,6 +80,18 @@ BEETS_QUEUE_PATH=
 COVERS_CACHE_PATH=/app/var/covers
 ###< Album/artist covers ###
 
+###> Homepage widget integration (optional — leave empty to disable enriched mode) ###
+# Bearer token consumed by the JSON endpoint /api/status, designed to
+# feed a [Homepage](https://gethomepage.dev/widgets/services/customapi/)
+# custom API widget. Without this variable set, /api/status only serves
+# the no-auth healthcheck mode (status: ok|degraded, codes 200/503).
+# When set, callers passing the matching token (query `?token=…` or
+# header `Authorization: Bearer …`) get the enriched payload :
+# scrobbles_total, unmatched_total, missing_mbid, navidrome_container,
+# last_run. Use a long random string : `openssl rand -hex 32`.
+HOMEPAGE_API_TOKEN=
+###< Homepage widget integration ###
+
 ###> Last.fm (optional — fallbacks when import form/CLI is called without explicit values) ###
 # API key: get one at https://www.last.fm/api/account/create
 LASTFM_API_KEY=

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -72,6 +72,10 @@ services:
         LASTFM_REMATCH_SCHEDULE: ''
         # Local on-disk cache for album/artist cover art (proxy + cache).
         COVERS_CACHE_PATH: '/app/var/covers'
+        # Homepage (gethomepage.dev) integration. Bearer token consumed
+        # by the JSON endpoint /api/status. Empty = enriched mode
+        # disabled, only the no-auth healthcheck mode is served.
+        HOMEPAGE_API_TOKEN: ''
 
   cron:
     type: php:8.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+- **Endpoint JSON `/api/status` + widget Homepage (gethomepage)** :
+  nouveau controller `App\Controller\Api\StatusController` qui expose
+  les métriques clés du tool en JSON. Sert deux usages avec un seul
+  endpoint :
+  - **Healthcheck Docker** sans auth : `GET /api/status` retourne
+    `{status, navidrome_db}` avec code HTTP 200 (ok) ou 503 (degraded)
+    selon que la DB Navidrome est joignable ou non. Utilisable
+    directement dans un `HEALTHCHECK` compose.
+  - **Widget [Homepage](https://gethomepage.dev/widgets/services/customapi/)**
+    avec auth par bearer token (env `HOMEPAGE_API_TOKEN`, transmis via
+    `?token=…` ou header `Authorization: Bearer …`) : retourne un
+    payload enrichi avec `scrobbles_total`, `unmatched_total`,
+    `missing_mbid`, `navidrome_container` et le dernier `RunHistory`
+    (type/status/started_at/duration_ms). Token vide = mode enrichi
+    désactivé (404 sur les requêtes tokenisées) ; token erroné = 401.
+    Comparaison via `hash_equals` (timing-safe). Section dédiée dans
+    le README avec snippet `services.yaml` Homepage prêt à coller.
+    Ajout d'une exception `PUBLIC_ACCESS` sur `^/api/` dans
+    `config/packages/security.yaml`. Closes #106.
+
 ### Fixed
 - **Heures Last.fm history affichées dans `APP_TIMEZONE`** : la page
   `/stats/lastfm-history` affichait les heures de scrobble avec le

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ pouvez les éditer puis les activer.
 | `CRON_REGEN_INTERVAL`| non (`300`) | Intervalle en secondes entre 2 régénérations du crontab (mode cron).     |
 | `COVERS_CACHE_PATH`  | non         | Cache disque des miniatures album/artiste. Défaut : `/app/var/covers` (volume Docker dédié dans le compose). |
 | `NAVIDROME_CONTAINER_NAME` | non   | Nom du conteneur Navidrome dans la même stack docker-compose. Quand renseigné, le dashboard affiche un statut UP/DOWN avec boutons Start/Stop, et les commandes d'import refusent de tourner si Navidrome est détecté UP (`--force` pour outrepasser). Requiert le mount `/var/run/docker.sock` (cf. `docker-compose.example.yml`). |
+| `HOMEPAGE_API_TOKEN` | non       | Bearer token pour le widget [Homepage](https://gethomepage.dev/widgets/services/customapi/) sur l'endpoint `/api/status`. Vide = mode enrichi désactivé (seul le mode healthcheck no-auth est servi). Voir la section [Widget Homepage](#widget-homepage-gethomepage). |
 
 ### Mise à jour
 
@@ -677,6 +678,97 @@ complète.
 Une commande `app:history:purge` supprime les entrées plus vieilles que
 `RUN_HISTORY_RETENTION_DAYS` (défaut 90). Elle est ajoutée
 automatiquement au crontab par `app:cron:dump` (1×/jour à 4h30).
+
+## Widget Homepage (gethomepage)
+
+Endpoint JSON `/api/status` consommable par le widget
+[Custom API](https://gethomepage.dev/widgets/services/customapi/) de
+[Homepage](https://gethomepage.dev/). Sert aussi de healthcheck Docker.
+
+Deux modes d'accès :
+
+| Sans token (no-auth)                                     | Avec token (`HOMEPAGE_API_TOKEN`)                                  |
+|----------------------------------------------------------|--------------------------------------------------------------------|
+| `GET /api/status`                                        | `GET /api/status?token=…` ou `Authorization: Bearer …`             |
+| Payload minimal `{status, navidrome_db}`                 | Payload enrichi : compteurs, dernier run, statut conteneur         |
+| Codes HTTP 200 (ok) / 503 (degraded) — Docker friendly   | Code HTTP 200 ; 401 si token erroné, 404 si feature désactivée     |
+
+### Activer le mode enrichi
+
+Générer un token et l'injecter dans l'environnement du conteneur web :
+
+```bash
+openssl rand -hex 32                  # copier dans HOMEPAGE_API_TOKEN
+```
+
+Puis configurer le widget Homepage (`services.yaml`) :
+
+```yaml
+- Navidrome Tools:
+    icon: navidrome.png
+    href: https://navidrome-tools.example.com
+    widget:
+      type: customapi
+      url: https://navidrome-tools.example.com/api/status?token={{HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}}
+      refreshInterval: 60000
+      mappings:
+        - field: scrobbles_total
+          label: Scrobbles
+          format: number
+        - field: unmatched_total
+          label: Unmatched
+          format: number
+        - field: { last_run: status }
+          label: Dernier run
+        - field: { last_run: started_at }
+          label: À
+          format: relativeDate
+```
+
+Et déclarer la variable Homepage côté docker-compose :
+
+```yaml
+environment:
+  HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN: ${HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}
+```
+
+### Payload enrichi
+
+```json
+{
+  "status": "ok",
+  "navidrome_db": true,
+  "scrobbles_total": 142387,
+  "unmatched_total": 312,
+  "missing_mbid": 47,
+  "navidrome_container": "running",
+  "last_run": {
+    "type": "lastfm-import",
+    "reference": "me",
+    "label": "Last.fm import (me)",
+    "status": "success",
+    "started_at": "2026-05-03T08:00:01+00:00",
+    "finished_at": "2026-05-03T08:03:05+00:00",
+    "duration_ms": 184230
+  }
+}
+```
+
+`navidrome_container` reprend l'enum `ContainerStatus` :
+`disabled` / `running` / `stopped` / `notfound` / `unknown`. `last_run`
+vaut `null` quand `run_history` est vide.
+
+### Healthcheck Docker
+
+Sans HOMEPAGE_API_TOKEN, l'endpoint reste un healthcheck pratique :
+
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/status"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+```
 
 ## Configuration éditeur
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -75,6 +75,7 @@ l'ordre d'attaque recommandé.
 |-------|--------------------------------------------------------------------|--------|
 | [#95] | Backup automatique programmable de la DB locale                    | S      |
 | [#96] | Endpoint `/health` pour Docker healthcheck                         | S      |
+| [#106]| Widget Homepage (gethomepage), construit sur [#96]                 | S      |
 | [#92] | Suggestions d'artistes via Last.fm `artist.getSimilar`             | M      |
 | [#37] | Export/import de la DB locale du tool                              | M      |
 | [#69] | Permettre des générateurs custom en déploiement Docker             | M      |
@@ -168,3 +169,4 @@ quand on tagge des releases) :
 [#98]: https://github.com/kgaut/navidrome-playlist-generator/issues/98
 [#99]: https://github.com/kgaut/navidrome-playlist-generator/issues/99
 [#100]: https://github.com/kgaut/navidrome-playlist-generator/issues/100
+[#106]: https://github.com/kgaut/navidrome-playlist-generator/issues/106

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -25,6 +25,7 @@ security:
 
     access_control:
         - { path: ^/login, roles: PUBLIC_ACCESS }
+        - { path: ^/api/, roles: PUBLIC_ACCESS }
         - { path: ^/, roles: ROLE_USER }
 
 when@test:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,7 @@ parameters:
     lidarr.metadata_profile_id: '%env(int:LIDARR_METADATA_PROFILE_ID)%'
     lidarr.monitor: '%env(LIDARR_MONITOR)%'
     navidrome.container_name: '%env(NAVIDROME_CONTAINER_NAME)%'
+    app.homepage_api_token: '%env(HOMEPAGE_API_TOKEN)%'
 
 services:
     _defaults:
@@ -96,6 +97,10 @@ services:
     App\Controller\NavidromeHistoryController:
         arguments:
             $navidromeUrl: '%navidrome.url%'
+
+    App\Controller\Api\StatusController:
+        arguments:
+            $apiToken: '%app.homepage_api_token%'
 
     App\LastFm\LastFmClient:
         arguments:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -43,6 +43,10 @@ services:
       LASTFM_LOVE_SYNC_SCHEDULE: ${LASTFM_LOVE_SYNC_SCHEDULE:-}
       LASTFM_REMATCH_SCHEDULE: ${LASTFM_REMATCH_SCHEDULE:-}
       COVERS_CACHE_PATH: /app/var/covers
+      # Bearer token for the Homepage (gethomepage.dev) /api/status
+      # endpoint. Empty = enriched mode disabled, only the no-auth
+      # healthcheck mode is served. Generate with `openssl rand -hex 32`.
+      HOMEPAGE_API_TOKEN: ${HOMEPAGE_API_TOKEN:-}
     volumes:
       # Mount Navidrome's SQLite DB read-only.
       - ${NAVIDROME_DATA_DIR:-/srv/navidrome/data}/navidrome.db:/data/navidrome.db:ro
@@ -97,6 +101,7 @@ services:
       LASTFM_LOVE_SYNC_SCHEDULE: ${LASTFM_LOVE_SYNC_SCHEDULE:-}
       LASTFM_REMATCH_SCHEDULE: ${LASTFM_REMATCH_SCHEDULE:-}
       COVERS_CACHE_PATH: /app/var/covers
+      HOMEPAGE_API_TOKEN: ${HOMEPAGE_API_TOKEN:-}
     volumes:
       - ${NAVIDROME_DATA_DIR:-/srv/navidrome/data}/navidrome.db:/data/navidrome.db:ro
       - navidrome-tools-data:/app/var

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,6 +38,7 @@
         <env name="LASTFM_LOVE_SYNC_SCHEDULE" value=""/>
         <env name="LASTFM_REMATCH_SCHEDULE" value=""/>
         <env name="COVERS_CACHE_PATH" value="%kernel.project_dir%/var/covers_test"/>
+        <env name="HOMEPAGE_API_TOKEN" value=""/>
     </php>
 
     <testsuites>

--- a/src/Controller/Api/StatusController.php
+++ b/src/Controller/Api/StatusController.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Controller\Api;
+
+use App\Docker\NavidromeContainerManager;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmImportTrackRepository;
+use App\Repository\RunHistoryRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * JSON status endpoint serving both a no-auth Docker healthcheck and
+ * the gethomepage.dev custom-API widget. Without a token, returns a
+ * minimal payload (200 healthy / 503 degraded). With a valid token —
+ * matched against `HOMEPAGE_API_TOKEN`, supplied via `?token=…` or
+ * `Authorization: Bearer …` — returns the enriched payload.
+ */
+class StatusController extends AbstractController
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly LastFmImportTrackRepository $importTracks,
+        private readonly RunHistoryRepository $runHistory,
+        private readonly NavidromeContainerManager $navidromeContainer,
+        private readonly string $apiToken,
+    ) {
+    }
+
+    #[Route('/api/status', name: 'app_api_status', methods: ['GET'])]
+    public function index(Request $request): JsonResponse
+    {
+        $providedToken = $this->extractToken($request);
+        $navidromeOk = $this->navidrome->isAvailable();
+
+        if ($providedToken === null) {
+            return $this->basic($navidromeOk);
+        }
+
+        if ($this->apiToken === '') {
+            return new JsonResponse(['error' => 'Not Found'], Response::HTTP_NOT_FOUND);
+        }
+        if (!hash_equals($this->apiToken, $providedToken)) {
+            return new JsonResponse(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
+        }
+
+        return $this->enriched($navidromeOk);
+    }
+
+    private function basic(bool $navidromeOk): JsonResponse
+    {
+        return new JsonResponse(
+            [
+                'status' => $navidromeOk ? 'ok' : 'degraded',
+                'navidrome_db' => $navidromeOk,
+            ],
+            $navidromeOk ? Response::HTTP_OK : Response::HTTP_SERVICE_UNAVAILABLE,
+        );
+    }
+
+    private function enriched(bool $navidromeOk): JsonResponse
+    {
+        $hasScrobbles = $navidromeOk && $this->navidrome->hasScrobblesTable();
+        $lastRun = $this->runHistory->findFilteredPaginated([], 1, 1)['items'][0] ?? null;
+
+        return new JsonResponse([
+            'status' => $navidromeOk ? 'ok' : 'degraded',
+            'navidrome_db' => $navidromeOk,
+            'scrobbles_total' => $hasScrobbles ? $this->navidrome->getScrobblesCount() : 0,
+            'unmatched_total' => $this->importTracks->countUnmatched(),
+            'missing_mbid' => $navidromeOk ? $this->navidrome->countMediaFilesWithoutMbid() : 0,
+            'navidrome_container' => $this->navidromeContainer->getStatus()->value,
+            'last_run' => $lastRun === null ? null : [
+                'type' => $lastRun->getType(),
+                'reference' => $lastRun->getReference(),
+                'label' => $lastRun->getLabel(),
+                'status' => $lastRun->getStatus(),
+                'started_at' => $lastRun->getStartedAt()->format(\DateTimeInterface::ATOM),
+                'finished_at' => $lastRun->getFinishedAt()?->format(\DateTimeInterface::ATOM),
+                'duration_ms' => $lastRun->getDurationMs(),
+            ],
+        ]);
+    }
+
+    private function extractToken(Request $request): ?string
+    {
+        $query = $request->query->get('token');
+        if (is_string($query) && $query !== '') {
+            return $query;
+        }
+        $header = (string) $request->headers->get('Authorization', '');
+        if (str_starts_with($header, 'Bearer ')) {
+            $token = substr($header, 7);
+
+            return $token === '' ? null : $token;
+        }
+
+        return null;
+    }
+}

--- a/tests/Controller/Api/StatusControllerTest.php
+++ b/tests/Controller/Api/StatusControllerTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Tests\Controller\Api;
+
+use App\Controller\Api\StatusController;
+use App\Docker\ContainerStatus;
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmImportTrackRepository;
+use App\Repository\RunHistoryRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class StatusControllerTest extends TestCase
+{
+    public function testNoTokenReturnsBasicHealth(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: true, apiToken: 'secret');
+
+        $response = $controller->index(new Request());
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertSame(['status' => 'ok', 'navidrome_db' => true], $payload);
+    }
+
+    public function testNoTokenWithNavidromeDownReturns503(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: false, apiToken: '');
+
+        $response = $controller->index(new Request());
+
+        $this->assertSame(Response::HTTP_SERVICE_UNAVAILABLE, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertSame(['status' => 'degraded', 'navidrome_db' => false], $payload);
+    }
+
+    public function testTokenWhenFeatureDisabledReturns404(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: true, apiToken: '');
+
+        $response = $controller->index(new Request(['token' => 'whatever']));
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testWrongTokenReturns401(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: true, apiToken: 'secret');
+
+        $response = $controller->index(new Request(['token' => 'nope']));
+
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+    }
+
+    public function testValidQueryTokenReturnsEnrichedPayload(): void
+    {
+        $lastRun = (new RunHistory(RunHistory::TYPE_LASTFM_IMPORT, 'me', 'Last.fm import (me)'))
+            ->setStatus(RunHistory::STATUS_SUCCESS)
+            ->setDurationMs(1234);
+
+        $controller = $this->makeController(
+            navidromeAvailable: true,
+            apiToken: 'secret',
+            scrobblesCount: 142387,
+            unmatchedCount: 312,
+            missingMbid: 47,
+            containerStatus: ContainerStatus::Running,
+            lastRun: $lastRun,
+        );
+
+        $response = $controller->index(new Request(['token' => 'secret']));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = $this->decode($response);
+
+        $this->assertSame('ok', $payload['status']);
+        $this->assertTrue($payload['navidrome_db']);
+        $this->assertSame(142387, $payload['scrobbles_total']);
+        $this->assertSame(312, $payload['unmatched_total']);
+        $this->assertSame(47, $payload['missing_mbid']);
+        $this->assertSame('running', $payload['navidrome_container']);
+        $this->assertSame('lastfm-import', $payload['last_run']['type']);
+        $this->assertSame('success', $payload['last_run']['status']);
+        $this->assertSame(1234, $payload['last_run']['duration_ms']);
+        $this->assertNotNull($payload['last_run']['started_at']);
+    }
+
+    public function testValidBearerHeaderTokenWorks(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: true, apiToken: 'secret');
+
+        $request = new Request();
+        $request->headers->set('Authorization', 'Bearer secret');
+
+        $response = $controller->index($request);
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertArrayHasKey('scrobbles_total', $payload);
+    }
+
+    public function testValidTokenWithNoLastRunReturnsNullLastRun(): void
+    {
+        $controller = $this->makeController(navidromeAvailable: true, apiToken: 'secret', lastRun: null);
+
+        $response = $controller->index(new Request(['token' => 'secret']));
+
+        $payload = $this->decode($response);
+        $this->assertNull($payload['last_run']);
+    }
+
+    public function testValidTokenWhenNavidromeDownReturnsZeroCounters(): void
+    {
+        $controller = $this->makeController(
+            navidromeAvailable: false,
+            apiToken: 'secret',
+            scrobblesCount: 999,
+            missingMbid: 999,
+        );
+
+        $response = $controller->index(new Request(['token' => 'secret']));
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $payload = $this->decode($response);
+        $this->assertSame('degraded', $payload['status']);
+        $this->assertFalse($payload['navidrome_db']);
+        $this->assertSame(0, $payload['scrobbles_total']);
+        $this->assertSame(0, $payload['missing_mbid']);
+    }
+
+    private function makeController(
+        bool $navidromeAvailable,
+        string $apiToken,
+        int $scrobblesCount = 0,
+        int $unmatchedCount = 0,
+        int $missingMbid = 0,
+        ContainerStatus $containerStatus = ContainerStatus::Disabled,
+        ?RunHistory $lastRun = null,
+    ): StatusController {
+        return new StatusController(
+            $this->fakeNavidrome($navidromeAvailable, $scrobblesCount, $missingMbid),
+            $this->fakeImportTracks($unmatchedCount),
+            $this->fakeRunHistory($lastRun),
+            $this->fakeContainer($containerStatus),
+            $apiToken,
+        );
+    }
+
+    private function fakeNavidrome(bool $available, int $scrobblesCount, int $missingMbid): NavidromeRepository
+    {
+        return new class ($available, $scrobblesCount, $missingMbid) extends NavidromeRepository {
+            public function __construct(
+                private readonly bool $available,
+                private readonly int $scrobblesCount,
+                private readonly int $missingMbid,
+            ) {
+            }
+
+            public function isAvailable(): bool
+            {
+                return $this->available;
+            }
+
+            public function hasScrobblesTable(): bool
+            {
+                return $this->available;
+            }
+
+            public function getScrobblesCount(): int
+            {
+                return $this->scrobblesCount;
+            }
+
+            public function countMediaFilesWithoutMbid(?string $artistFilter = null, ?string $albumFilter = null): int
+            {
+                return $this->missingMbid;
+            }
+        };
+    }
+
+    private function fakeImportTracks(int $unmatchedCount): LastFmImportTrackRepository
+    {
+        return new class ($unmatchedCount) extends LastFmImportTrackRepository {
+            public function __construct(private readonly int $unmatchedCount)
+            {
+            }
+
+            public function countUnmatched(?int $runId = null): int
+            {
+                return $this->unmatchedCount;
+            }
+        };
+    }
+
+    private function fakeRunHistory(?RunHistory $lastRun): RunHistoryRepository
+    {
+        return new class ($lastRun) extends RunHistoryRepository {
+            public function __construct(private readonly ?RunHistory $lastRun)
+            {
+            }
+
+            public function findFilteredPaginated(array $filters, int $page, int $perPage): array
+            {
+                return [
+                    'items' => $this->lastRun === null ? [] : [$this->lastRun],
+                    'total' => $this->lastRun === null ? 0 : 1,
+                ];
+            }
+        };
+    }
+
+    private function fakeContainer(ContainerStatus $status): NavidromeContainerManager
+    {
+        return new class ($status) extends NavidromeContainerManager {
+            public function __construct(private readonly ContainerStatus $status)
+            {
+            }
+
+            public function getStatus(): ContainerStatus
+            {
+                return $this->status;
+            }
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(JsonResponse $response): array
+    {
+        $body = (string) $response->getContent();
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## Summary

Implémente #106 : nouvel endpoint JSON `GET /api/status` qui sert à la fois de healthcheck Docker et de source pour un widget [Homepage](https://gethomepage.dev/widgets/services/customapi/) (gethomepage.dev).

### Deux modes sur un seul endpoint

| Sans token (no-auth)                                     | Avec token (`HOMEPAGE_API_TOKEN`)                                  |
|----------------------------------------------------------|--------------------------------------------------------------------|
| `GET /api/status`                                        | `GET /api/status?token=…` ou `Authorization: Bearer …`             |
| Payload minimal `{status, navidrome_db}`                 | Payload enrichi : compteurs, dernier run, statut conteneur         |
| Codes HTTP 200 (ok) / 503 (degraded) — Docker friendly   | 200 ; 401 si token erroné, 404 si feature désactivée               |

Comparaison de token via `hash_equals` (timing-safe). Token vide = mode enrichi désactivé (404 sur les requêtes tokenisées), pareille ergonomie que Lidarr aujourd'hui.

### Payload enrichi

```json
{
  "status": "ok",
  "navidrome_db": true,
  "scrobbles_total": 142387,
  "unmatched_total": 312,
  "missing_mbid": 47,
  "navidrome_container": "running",
  "last_run": {
    "type": "lastfm-import",
    "reference": "me",
    "label": "Last.fm import (me)",
    "status": "success",
    "started_at": "2026-05-03T08:00:01+00:00",
    "finished_at": "2026-05-03T08:03:05+00:00",
    "duration_ms": 184230
  }
}
```

### Changements

- `src/Controller/Api/StatusController.php` (nouveau)
- `tests/Controller/Api/StatusControllerTest.php` — 8 tests / 25 assertions couvrent : no-token ok/degraded, token désactivé (404), token erroné (401), token valide en query / Bearer, `last_run` null, Navidrome down + token
- `config/packages/security.yaml` — exception `PUBLIC_ACCESS` sur `^/api/`
- `config/services.yaml` — paramètre `app.homepage_api_token` + injection
- Env var `HOMEPAGE_API_TOKEN` déclarée dans les 5 endroits (`.env`, `.env.dist`, `phpunit.xml.dist`, `.lando.yml.dist`, `docker-compose.example.yml`)
- README — section dédiée avec snippet `services.yaml` Homepage prêt à coller + exemple healthcheck Docker compose
- CHANGELOG — entrée sous `[Unreleased] Added`
- ROADMAP — entrée ajoutée dans *Intégrations / ops* (commit `docs(roadmap): …`)

## Test plan

- [x] `composer ci` vert (phpcs, PHPStan niveau 6, 304 tests / 759 assertions)
- [x] Route enregistrée : `php bin/console debug:router | grep api_status` → `app_api_status GET /api/status`
- [x] Cache prod compile : `php bin/console cache:clear --env=prod` OK (pas de souci de wiring)
- [ ] Test manuel sans token : `curl -i http://localhost:8080/api/status` → JSON minimal + code 200/503
- [ ] Test manuel avec token : `curl -i 'http://localhost:8080/api/status?token=…'` → JSON enrichi 200
- [ ] Test manuel mauvais token : `curl -i 'http://localhost:8080/api/status?token=wrong'` → 401
- [ ] Test manuel token désactivé (`HOMEPAGE_API_TOKEN=`) + token dans la requête → 404
- [ ] Test manuel widget Homepage : ajouter le snippet `services.yaml` du README et vérifier que les 4 fields s'affichent

Closes #106.

---
_Generated by [Claude Code](https://claude.ai/code/session_017F7Xx2qKJuo4D6WY41tBYo)_