### PR TITLE
fix(lastfm): dedup match cache upserts within an unflushed import batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Fixed
+- **`UNIQUE constraint failed: lastfm_match_cache.source_artist_norm,
+  lastfm_match_cache.source_title_norm` pendant `app:lastfm:import`** :
+  l'import ne flushe pas entre deux scrobbles, donc lorsque la même
+  couple `(artiste, titre)` revenait plusieurs fois (cas typique : un
+  morceau écouté plusieurs fois dans l'historique) ou que deux entrées
+  source distinctes se réduisaient à la même forme normalisée,
+  `LastFmMatchCacheRepository::upsert()` `persist()`-ait deux entités
+  différentes pour la même couple normalisée — l'index unique
+  `uniq_lastfm_match_cache_source_norm` les attrapait au flush final
+  et l'import s'arrêtait en erreur. Le repo maintient maintenant un
+  index en mémoire des entités persistées dans la même requête, qui
+  est consulté avant `findOneBy()` dans `findByCouple()`. Index purgé
+  en cohérence par `purgeByCouple` / `purgeByArtist` / `purgeAll`.
 - **Heures Last.fm history affichées dans `APP_TIMEZONE`** : la page
   `/stats/lastfm-history` affichait les heures de scrobble avec le
   décalage UTC (ex. `10:00` au lieu de `12:00` à Paris en été). Cause :

--- a/src/Repository/LastFmMatchCacheRepository.php
+++ b/src/Repository/LastFmMatchCacheRepository.php
@@ -12,13 +12,30 @@ use Doctrine\Persistence\ManagerRegistry;
  */
 class LastFmMatchCacheRepository extends ServiceEntityRepository
 {
+    /**
+     * In-memory map of entries `persist()`ed during the current request,
+     * keyed by `"<artistNorm>\0<titleNorm>"`. `findOneBy()` only sees rows
+     * that already hit the DB, so without this index a long import (which
+     * never flushes between scrobbles) would `persist()` a second entity
+     * for the same normalized couple — the unique index
+     * `uniq_lastfm_match_cache_source_norm` then blows up at flush time.
+     * The map also catches inputs that differ in the source columns but
+     * collapse to the same normalized form.
+     *
+     * @var array<string, LastFmMatchCacheEntry>
+     */
+    private array $pendingByKey = [];
+
     public function __construct(ManagerRegistry $registry)
     {
         parent::__construct($registry, LastFmMatchCacheEntry::class);
     }
 
     /**
-     * Look up a memoized resolution by normalized `(artist, title)`.
+     * Look up a memoized resolution by normalized `(artist, title)`. Checks
+     * the in-memory pending map first so an entry persisted earlier in the
+     * same request (and not yet flushed) is reused instead of triggering a
+     * fresh persist.
      */
     public function findByCouple(string $artist, string $title): ?LastFmMatchCacheEntry
     {
@@ -26,6 +43,11 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         $titleNorm = NavidromeRepository::normalize($title);
         if ($artistNorm === '' || $titleNorm === '') {
             return null;
+        }
+
+        $pending = $this->pendingByKey[$this->key($artistNorm, $titleNorm)] ?? null;
+        if ($pending !== null) {
+            return $pending;
         }
 
         return $this->findOneBy([
@@ -66,10 +88,12 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         string $strategy,
         ?int $confidenceScore,
     ): void {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
         // Don't cache rows that would normalize to an empty key — they'd
         // collide on the unique (norm, norm) index after the first insert
         // and the cascade can't lookup them anyway.
-        if (NavidromeRepository::normalize($artist) === '' || NavidromeRepository::normalize($title) === '') {
+        if ($artistNorm === '' || $titleNorm === '') {
             return;
         }
         $existing = $this->findByCouple($artist, $title);
@@ -81,6 +105,7 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         }
         $entry = new LastFmMatchCacheEntry($artist, $title, $mediaFileId, $strategy, $confidenceScore);
         $this->getEntityManager()->persist($entry);
+        $this->pendingByKey[$this->key($artistNorm, $titleNorm)] = $entry;
     }
 
     /**
@@ -95,6 +120,8 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         if ($artistNorm === '' || $titleNorm === '') {
             return 0;
         }
+
+        unset($this->pendingByKey[$this->key($artistNorm, $titleNorm)]);
 
         return (int) $this->createQueryBuilder('c')
             ->delete()
@@ -117,6 +144,12 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         $artistNorm = NavidromeRepository::normalize($artist);
         if ($artistNorm === '') {
             return 0;
+        }
+
+        foreach ($this->pendingByKey as $key => $entry) {
+            if ($entry->getSourceArtistNorm() === $artistNorm) {
+                unset($this->pendingByKey[$key]);
+            }
         }
 
         return (int) $this->createQueryBuilder('c')
@@ -159,8 +192,20 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
         $qb = $this->createQueryBuilder('c')->delete();
         if ($negativeOnly) {
             $qb->where('c.targetMediaFileId IS NULL');
+            foreach ($this->pendingByKey as $key => $entry) {
+                if (!$entry->isPositive()) {
+                    unset($this->pendingByKey[$key]);
+                }
+            }
+        } else {
+            $this->pendingByKey = [];
         }
 
         return (int) $qb->getQuery()->execute();
+    }
+
+    private function key(string $artistNorm, string $titleNorm): string
+    {
+        return $artistNorm . "\0" . $titleNorm;
     }
 }

--- a/tests/Repository/LastFmMatchCacheRepositoryTest.php
+++ b/tests/Repository/LastFmMatchCacheRepositoryTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\LastFmMatchCacheEntry;
+use App\Repository\LastFmMatchCacheRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class LastFmMatchCacheRepositoryTest extends TestCase
+{
+    /**
+     * Regression for the SQLite UNIQUE constraint violation observed during
+     * `app:lastfm:import` runs. The importer never flushes between scrobbles,
+     * so `findOneBy()` (which only sees committed rows) returned null on the
+     * second occurrence of the same (normalized artist, title) couple — and
+     * the repo `persist()`-ed a duplicate. At end-of-run flush the unique
+     * index `uniq_lastfm_match_cache_source_norm` then fired:
+     *   « UNIQUE constraint failed: lastfm_match_cache.source_artist_norm,
+     *      lastfm_match_cache.source_title_norm »
+     */
+    public function testRepeatedRecordPositiveForSameCoupleOnlyPersistsOnce(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+        $persisted = &$h['persisted'];
+
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+
+        $this->assertCount(1, $persisted);
+    }
+
+    public function testRepeatedRecordNegativeForSameCoupleOnlyPersistsOnce(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+        $persisted = &$h['persisted'];
+
+        $repo->recordNegative('Unknown', 'Nothing');
+        $repo->recordNegative('Unknown', 'Nothing');
+
+        $this->assertCount(1, $persisted);
+    }
+
+    /**
+     * Two distinct source strings whose normalized form collapses to the
+     * same value would also collide on the unique index — the in-memory
+     * dedup must key on the normalized form too.
+     */
+    public function testInputsThatCollapseToSameNormalizedFormDoNotDoublePersist(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+        $persisted = &$h['persisted'];
+
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+        // Different casing + trailing punctuation → identical np_normalize output.
+        $repo->recordPositive('HOZIER!', 'Take me to church.', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+
+        $this->assertCount(1, $persisted);
+    }
+
+    public function testFindByCoupleReturnsPendingEntryBeforeFlush(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+
+        $found = $repo->findByCouple('Hozier', 'Take Me to Church');
+        $this->assertNotNull($found);
+        $this->assertSame('mf-1', $found->getTargetMediaFileId());
+    }
+
+    /**
+     * If the cascade later upgrades the verdict for a couple already cached
+     * in this run (e.g. negative → positive after a Last.fm correction),
+     * upsert() must mutate the pending entry in place rather than persist a
+     * second one — same root cause, same constraint to dodge.
+     */
+    public function testNegativeFollowedByPositiveMutatesPendingEntry(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+        $persisted = &$h['persisted'];
+
+        $repo->recordNegative('Hozier', 'Take Me to Church');
+        $repo->recordPositive('Hozier', 'Take Me to Church', 'mf-1', LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION);
+
+        $this->assertCount(1, $persisted);
+        /** @var LastFmMatchCacheEntry $entry */
+        $entry = $persisted[0];
+        $this->assertSame('mf-1', $entry->getTargetMediaFileId());
+        $this->assertSame(LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION, $entry->getStrategy());
+    }
+
+    public function testEmptyNormalizedKeyIsIgnoredAndNeverPersists(): void
+    {
+        $h = $this->buildRepo();
+        $repo = $h['repo'];
+        $persisted = &$h['persisted'];
+
+        $repo->recordPositive('!!!', '   ', 'mf-x', LastFmMatchCacheEntry::STRATEGY_COUPLE);
+        $repo->recordNegative('   ', '!!!');
+
+        $this->assertCount(0, $persisted);
+    }
+
+    /**
+     * @return array{repo: LastFmMatchCacheRepository, persisted: list<LastFmMatchCacheEntry>}
+     */
+    private function buildRepo(): array
+    {
+        $persisted = [];
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist')->willReturnCallback(function (object $e) use (&$persisted): void {
+            $persisted[] = $e;
+        });
+
+        $repo = new class ($em) extends LastFmMatchCacheRepository {
+            /** @var list<array<string, mixed>> */
+            public array $findOneByCalls = [];
+
+            public function __construct(private readonly EntityManagerInterface $em)
+            {
+                // Skip parent::__construct — no Doctrine registry needed for unit tests.
+            }
+
+            public function getEntityManager(): EntityManagerInterface
+            {
+                return $this->em;
+            }
+
+            // Stub the DB lookup: a real EM would query the unflushed rows
+            // separately from the unit of work. Returning null forces the
+            // repository to lean on its in-memory pending map — exactly the
+            // production code path that triggered the unique constraint
+            // failure before this fix.
+            public function findOneBy(array $criteria, ?array $orderBy = null): ?object
+            {
+                $this->findOneByCalls[] = $criteria;
+
+                return null;
+            }
+        };
+
+        return ['repo' => $repo, 'persisted' => &$persisted];
+    }
+}


### PR DESCRIPTION
`app:lastfm:import` processes scrobbles in a long loop without flushing
between iterations. The repo's `upsert()` only consulted Doctrine's
`findOneBy()` (a DB SELECT) to decide whether to `persist()` a new
entity ; unflushed pending entities were invisible, so a second
scrobble for the same `(artist, title)` couple — or two source strings
that collapse to the same normalized form — created a duplicate
managed entity. At end-of-run flush the unique index
`uniq_lastfm_match_cache_source_norm` then fired and aborted the whole
import.

Maintain an in-memory map of pending persists keyed on
`<artistNorm>\0<titleNorm>` and probe it from `findByCouple()` before
falling back to the DB. Purge ops keep the map consistent.