### PR TITLE
feat(docker): pilotage du conteneur Navidrome depuis le dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,17 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   rouge devient un bandeau vert « écritures sûres » quand Navidrome est
   arrêté, et embarque un bouton « ⏸ Arrêter Navidrome » quand il
   tourne.
+- **Flag `--auto-stop`** sur `app:lastfm:import` et `app:lastfm:rematch` :
+  pilote tout le cycle automatiquement (stop Navidrome → import → restart
+  Navidrome, **toujours**, même en cas d'erreur de l'import via
+  try/finally). Active sur le cron `app:lastfm:rematch` généré par
+  `app:cron:dump` quand `NAVIDROME_CONTAINER_NAME` est renseigné — le job
+  tourne désormais entièrement non-attendu sans verrou WAL. No-op si la
+  feature est désactivée ou si Navidrome est déjà arrêté. Si le socket
+  Docker est `unknown`, refuse l'orchestration (impossible de garantir
+  un état cohérent). En cas de double échec (import KO + restart KO), la
+  `NavidromeContainerException` finale chaîne l'exception d'origine en
+  `previous` pour tracer les deux problèmes.
 - **`app:lastfm:rematch --random`** : nouveau flag qui mélange l'ordre
   des unmatched avant d'appliquer `--limit`. Utile pour échantillonner
   un sous-ensemble représentatif quand on debugge une nouvelle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,13 @@ Fonctionnalités livrées :
   `NavidromeContainerManager`, enum `ContainerStatus`,
   `NavidromeContainerException`), POST routes
   `/navidrome/container/{start,stop}` avec CSRF
-  `navidrome_container`.
+  `navidrome_container`. Flag CLI `--auto-stop` (sur
+  `app:lastfm:import` et `app:lastfm:rematch`) : alternative au
+  pré-flight bloquant — orchestre stop Navidrome → action → restart
+  via `NavidromeContainerManager::runWithNavidromeStopped()` (try/
+  finally, restart même en cas d'erreur de l'action). Activé
+  automatiquement par `app:cron:dump` sur la ligne rematch quand le
+  conteneur est configuré.
 
 ---
 

--- a/src/Command/DumpCronCommand.php
+++ b/src/Command/DumpCronCommand.php
@@ -2,6 +2,7 @@
 
 namespace App\Command;
 
+use App\Docker\NavidromeContainerConfig;
 use App\Repository\PlaylistDefinitionRepository;
 use Cron\CronExpression;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -17,6 +18,7 @@ class DumpCronCommand extends Command
 {
     public function __construct(
         private readonly PlaylistDefinitionRepository $repository,
+        private readonly NavidromeContainerConfig $containerConfig,
         private readonly string $projectDir,
         private readonly string $statsRefreshSchedule,
         private readonly string $loveSyncSchedule = '',
@@ -88,10 +90,12 @@ class DumpCronCommand extends Command
                 new CronExpression($this->rematchSchedule);
                 $output->writeln('');
                 $output->writeln('# Re-match Last.fm unmatched scrobbles (LASTFM_REMATCH_SCHEDULE)');
+                $autoStopFlag = $this->containerConfig->isConfigured() ? ' --auto-stop' : '';
                 $output->writeln(sprintf(
-                    '%s php %s app:lastfm:rematch',
+                    '%s php %s app:lastfm:rematch%s',
                     $this->rematchSchedule,
                     $bin,
+                    $autoStopFlag,
                 ));
             } catch (\Throwable $e) {
                 $output->writeln('# SKIP rematch: invalid LASTFM_REMATCH_SCHEDULE (' . $e->getMessage() . ')');

--- a/src/Command/ImportLastFmCommand.php
+++ b/src/Command/ImportLastFmCommand.php
@@ -92,6 +92,12 @@ class ImportLastFmCommand extends Command
                 'f',
                 InputOption::VALUE_NONE,
                 'Bypass the Navidrome container pre-flight check (only when NAVIDROME_CONTAINER_NAME is set). Use at your own risk: writing while Navidrome runs can corrupt the SQLite WAL.',
+            )
+            ->addOption(
+                'auto-stop',
+                null,
+                InputOption::VALUE_NONE,
+                'When NAVIDROME_CONTAINER_NAME is set, stop Navidrome before the import and restart it afterwards (always, even on error). No-op when the feature is disabled or when Navidrome is already stopped. Mutually exclusive with the default pre-flight check — pass this for unattended runs (cron).',
             );
     }
 
@@ -117,8 +123,9 @@ class ImportLastFmCommand extends Command
         $tolerance = max(0, (int) $input->getOption('tolerance'));
         $dryRun = (bool) $input->getOption('dry-run');
         $force = (bool) $input->getOption('force');
+        $autoStop = (bool) $input->getOption('auto-stop');
 
-        if (!$dryRun) {
+        if (!$dryRun && !$autoStop) {
             try {
                 $this->container->assertSafeToWrite($force);
             } catch (NavidromeContainerException $e) {
@@ -140,7 +147,7 @@ class ImportLastFmCommand extends Command
             $maxScrobbles = $input->getOption('max-scrobbles');
             $maxScrobblesInt = $maxScrobbles !== null ? max(1, (int) $maxScrobbles) : null;
             $em = $this->em;
-            $report = $this->recorder->record(
+            $runImport = fn () => $this->recorder->record(
                 type: RunHistory::TYPE_LASTFM_IMPORT,
                 reference: $user,
                 label: 'Last.fm import — ' . $user . ($dryRun ? ' [dry-run]' : ''),
@@ -191,6 +198,12 @@ class ImportLastFmCommand extends Command
                     'date_max' => $dateMax?->format('Y-m-d'),
                 ],
             );
+
+            if ($autoStop && !$dryRun) {
+                $report = $this->container->runWithNavidromeStopped($runImport);
+            } else {
+                $report = $runImport();
+            }
         } catch (\Throwable $e) {
             $io->error($e->getMessage());
 

--- a/src/Command/RematchUnmatchedCommand.php
+++ b/src/Command/RematchUnmatchedCommand.php
@@ -69,6 +69,12 @@ class RematchUnmatchedCommand extends Command
                 'f',
                 InputOption::VALUE_NONE,
                 'Bypass the Navidrome container pre-flight check (only when NAVIDROME_CONTAINER_NAME is set). Use at your own risk: writing while Navidrome runs can corrupt the SQLite WAL.',
+            )
+            ->addOption(
+                'auto-stop',
+                null,
+                InputOption::VALUE_NONE,
+                'When NAVIDROME_CONTAINER_NAME is set, stop Navidrome before the rematch and restart it afterwards (always, even on error). No-op when the feature is disabled or when Navidrome is already stopped. Mutually exclusive with the default pre-flight check — pass this for unattended runs (cron).',
             );
     }
 
@@ -82,8 +88,9 @@ class RematchUnmatchedCommand extends Command
         $tolerance = max(0, (int) $input->getOption('tolerance'));
         $random = (bool) $input->getOption('random');
         $force = (bool) $input->getOption('force');
+        $autoStop = (bool) $input->getOption('auto-stop');
 
-        if (!$dryRun) {
+        if (!$dryRun && !$autoStop) {
             try {
                 $this->container->assertSafeToWrite($force);
             } catch (NavidromeContainerException $e) {
@@ -97,7 +104,7 @@ class RematchUnmatchedCommand extends Command
         $label = 'Rematch unmatched — ' . $reference . ($dryRun ? ' [dry-run]' : '');
 
         try {
-            $report = $this->recorder->record(
+            $runRematch = fn () => $this->recorder->record(
                 type: RunHistory::TYPE_LASTFM_REMATCH,
                 reference: $reference,
                 label: $label,
@@ -123,6 +130,12 @@ class RematchUnmatchedCommand extends Command
                     'random' => $random,
                 ],
             );
+
+            if ($autoStop && !$dryRun) {
+                $report = $this->container->runWithNavidromeStopped($runRematch);
+            } else {
+                $report = $runRematch();
+            }
         } catch (\Throwable $e) {
             $io->error($e->getMessage());
 

--- a/src/Docker/NavidromeContainerManager.php
+++ b/src/Docker/NavidromeContainerManager.php
@@ -90,4 +90,75 @@ class NavidromeContainerManager
 
         throw new NavidromeContainerException($message);
     }
+
+    /**
+     * Run $action with Navidrome guaranteed stopped, then restart it if
+     * we stopped it ourselves. Restart happens in a finally-equivalent
+     * block, so an action that throws still leaves Navidrome running.
+     *
+     * - Feature disabled (`NAVIDROME_CONTAINER_NAME` empty) → run as-is.
+     * - Status `Stopped` / `NotFound` → run as-is, don't try to restart
+     *   something we didn't stop.
+     * - Status `Running` → stop, run, restart (always).
+     * - Status `Unknown` → throw, since we can't safely orchestrate
+     *   stop/start without confirming current state.
+     *
+     * If both the action and the restart fail, the restart failure is
+     * raised with the action error chained as `previous`.
+     *
+     * @template T
+     * @param  callable(): T $action
+     * @return T
+     */
+    public function runWithNavidromeStopped(callable $action): mixed
+    {
+        if (!$this->config->isConfigured()) {
+            return $action();
+        }
+
+        $status = $this->getStatus();
+        if ($status === ContainerStatus::Unknown) {
+            throw new NavidromeContainerException(sprintf(
+                'Statut du conteneur Navidrome « %s » indéterminé — impossible d\'orchestrer un stop/restart automatique. Vérifier le mount /var/run/docker.sock.',
+                $this->config->containerName,
+            ));
+        }
+
+        if ($status !== ContainerStatus::Running) {
+            return $action();
+        }
+
+        $this->stop();
+
+        $actionException = null;
+        $result = null;
+        try {
+            $result = $action();
+        } catch (\Throwable $e) {
+            $actionException = $e;
+        }
+
+        try {
+            $this->start();
+        } catch (\Throwable $startException) {
+            if ($actionException !== null) {
+                throw new NavidromeContainerException(
+                    sprintf(
+                        '%s — et le redémarrage du conteneur Navidrome a aussi échoué : %s',
+                        $actionException->getMessage(),
+                        $startException->getMessage(),
+                    ),
+                    0,
+                    $actionException,
+                );
+            }
+            throw $startException;
+        }
+
+        if ($actionException !== null) {
+            throw $actionException;
+        }
+
+        return $result;
+    }
 }

--- a/tests/Docker/FakeDockerCli.php
+++ b/tests/Docker/FakeDockerCli.php
@@ -6,21 +6,29 @@ use App\Docker\DockerCli;
 use App\Docker\NavidromeContainerException;
 
 /**
- * Test double for DockerCli — never spawns a process. Captures the last
- * start/stop call so tests can assert it, and lets each test pre-program
- * the inspect outcome (a state array, null = "not found", or a thrown
- * exception simulating a Docker daemon failure).
+ * Test double for DockerCli — never spawns a process. Records every
+ * start/stop call so tests can assert sequences, and lets each test
+ * pre-program the inspect outcome (a state array, null = "not found",
+ * or a thrown exception simulating a Docker daemon failure). Calling
+ * start/stop also mutates the inspected state so subsequent
+ * `inspectState` calls reflect the new running state.
  */
 final class FakeDockerCli extends DockerCli
 {
     /** @var array{0: string, 1: string}|null */
     public ?array $lastAction = null;
 
+    /** @var list<array{0: string, 1: string}> */
+    public array $actions = [];
+
+    public bool $startShouldFail = false;
+    public bool $stopShouldFail = false;
+
     /**
      * @param array<string, mixed>|null $state
      */
     public function __construct(
-        private readonly ?array $state = null,
+        private ?array $state = null,
         private readonly ?string $throwOnInspect = null,
     ) {
         parent::__construct();
@@ -38,10 +46,24 @@ final class FakeDockerCli extends DockerCli
     public function start(string $containerName): void
     {
         $this->lastAction = ['start', $containerName];
+        $this->actions[] = ['start', $containerName];
+        if ($this->startShouldFail) {
+            throw new NavidromeContainerException('docker start a échoué (simulé).');
+        }
+        if ($this->state !== null) {
+            $this->state['Running'] = true;
+        }
     }
 
     public function stop(string $containerName, int $timeoutSeconds = 10): void
     {
         $this->lastAction = ['stop', $containerName];
+        $this->actions[] = ['stop', $containerName];
+        if ($this->stopShouldFail) {
+            throw new NavidromeContainerException('docker stop a échoué (simulé).');
+        }
+        if ($this->state !== null) {
+            $this->state['Running'] = false;
+        }
     }
 }

--- a/tests/Docker/NavidromeContainerManagerTest.php
+++ b/tests/Docker/NavidromeContainerManagerTest.php
@@ -101,6 +101,113 @@ class NavidromeContainerManagerTest extends TestCase
         $manager->start();
     }
 
+    public function testRunWithStoppedSkipsOrchestrationWhenDisabled(): void
+    {
+        $cli = new FakeDockerCli();
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig(''));
+        $result = $manager->runWithNavidromeStopped(fn () => 42);
+        $this->assertSame(42, $result);
+        $this->assertSame([], $cli->actions);
+    }
+
+    public function testRunWithStoppedSkipsOrchestrationWhenAlreadyStopped(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => false]);
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $result = $manager->runWithNavidromeStopped(fn () => 'ok');
+        $this->assertSame('ok', $result);
+        $this->assertSame([], $cli->actions);
+    }
+
+    public function testRunWithStoppedSkipsOrchestrationWhenNotFound(): void
+    {
+        $cli = new FakeDockerCli(state: null);
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager->runWithNavidromeStopped(fn () => null);
+        $this->assertSame([], $cli->actions);
+    }
+
+    public function testRunWithStoppedThrowsWhenStatusUnknown(): void
+    {
+        $cli = new FakeDockerCli(throwOnInspect: 'cannot connect');
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $this->expectException(NavidromeContainerException::class);
+        $this->expectExceptionMessageMatches('/ind[ée]termin[ée]/u');
+        $manager->runWithNavidromeStopped(fn () => 'never');
+    }
+
+    public function testRunWithStoppedStopsRunsAndRestartsWhenRunning(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $calls = [];
+        $result = $manager->runWithNavidromeStopped(function () use (&$calls): string {
+            $calls[] = 'action';
+
+            return 'imported';
+        });
+        $this->assertSame('imported', $result);
+        $this->assertSame(
+            [['stop', 'navidrome'], ['start', 'navidrome']],
+            $cli->actions,
+        );
+        $this->assertSame(['action'], $calls);
+    }
+
+    public function testRunWithStoppedRestartsEvenWhenActionThrows(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function (): void {
+                throw new \RuntimeException('import boom');
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame('import boom', $thrown->getMessage());
+        $this->assertSame(
+            [['stop', 'navidrome'], ['start', 'navidrome']],
+            $cli->actions,
+        );
+    }
+
+    public function testRunWithStoppedReportsCompoundFailureWhenStartAlsoFails(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $cli->startShouldFail = true;
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function (): void {
+                throw new \RuntimeException('import boom');
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(NavidromeContainerException::class, $thrown);
+        $this->assertStringContainsString('import boom', $thrown->getMessage());
+        $this->assertStringContainsString('redémarrage', $thrown->getMessage());
+        $this->assertInstanceOf(\RuntimeException::class, $thrown->getPrevious());
+    }
+
+    public function testRunWithStoppedPropagatesStartFailureWhenActionSucceeded(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $cli->startShouldFail = true;
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+
+        $this->expectException(NavidromeContainerException::class);
+        $this->expectExceptionMessageMatches('/docker start/');
+        $manager->runWithNavidromeStopped(fn () => 'ok');
+    }
+
     /**
      * @param array<string, mixed>|null $state
      */


### PR DESCRIPTION
## Summary

- **Card dashboard UP/DOWN + boutons Start/Stop** pour le conteneur Navidrome, activée si `NAVIDROME_CONTAINER_NAME` est renseignée (vide = feature désactivée, mirror du pattern `LIDARR_URL`).
- **Pré-flight automatique** sur les commandes qui écrivent dans la DB Navidrome (`app:lastfm:import`, `app:lastfm:rematch` + leurs HTTP counterparts) : refuse de tourner si Navidrome est UP. CLI `--force` pour outrepasser, UI flash error + redirect. Statut `unknown` (socket KO) = écritures bloquées par sécurité.
- **Flag `--auto-stop`** sur les deux commandes CLI : alternative au pré-flight bloquant — orchestre stop Navidrome → action → restart **toujours** (try/catch interne, restart même si l'action crashe). En cas de double échec (action KO + restart KO), `NavidromeContainerException` chaîne l'exception d'origine en `previous`. Activé automatiquement par `app:cron:dump` sur la ligne rematch quand le conteneur est configuré.
- Implémenté via `docker` CLI (`apk add docker-cli` ajouté au Dockerfile) + Symfony Process. Socket `/var/run/docker.sock` à mounter manuellement (bloc commenté dans `docker-compose.example.yml`).

**Code ajouté :**
- `src/Docker/` : `NavidromeContainerConfig`, enum `ContainerStatus`, `DockerCli` (wrapper testable), `NavidromeContainerManager` (avec `getStatus()`, `start()`, `stop()`, `assertSafeToWrite($force)`, `runWithNavidromeStopped(callable)`), `NavidromeContainerException`.
- `src/Controller/NavidromeContainerController.php` : POST `/navidrome/container/{start,stop}` avec CSRF `navidrome_container`.
- Nouvelle dep `symfony/process`.

**Code modifié :** `DashboardController` + template (card health), `LastFmImportController` + `RematchController` (pré-flight HTTP), `ImportLastFmCommand` + `RematchUnmatchedCommand` (`--force` + `--auto-stop`), `DumpCronCommand` (auto-stop conditionnel sur le cron rematch), `templates/lastfm/import.html.twig` (bandeau dynamique vert/rouge + bouton stop inline). Wirée dans les 5 emplacements habituels (`.env`, `.env.dist`, `phpunit.xml.dist`, `.lando.yml.dist`, `docker-compose.example.yml`) + `config/services.yaml`. Doc : `README.md`, `CHANGELOG.md`, `CLAUDE.md`.

## Test plan

- [x] `composer ci` vert (phpcs + phpstan niveau 6 + 300 tests)
- [x] 13 nouveaux tests dans `tests/Docker/NavidromeContainerManagerTest.php` (statuts Disabled/Running/Stopped/NotFound/Unknown ; `assertSafeToWrite` avec/sans `--force` ; `runWithNavidromeStopped` happy path + exceptions + double échec avec chaînage)
- [x] `php bin/console app:cron:dump` avec `NAVIDROME_CONTAINER_NAME` renseigné → ligne rematch contient `--auto-stop` ; sans la variable → flag absent
- [ ] Manuel UI : renseigner `NAVIDROME_CONTAINER_NAME` + monter `/var/run/docker.sock`, vérifier la card dashboard, cliquer Stop → Last.fm import sans `confirm()` JS, soumettre dry-run → OK ; cliquer Start → import bloqué avec flash error
- [ ] Manuel CLI : `bin/console app:lastfm:import` exit 1 avec message rouge ; `--force` → warn et passe ; `--auto-stop` → stop Navidrome / import / restart Navidrome
- [ ] Manuel : laisser le cron tourner avec `LASTFM_REMATCH_SCHEDULE` renseigné et vérifier l'orchestration auto

https://claude.ai/code/session_01RefSDxQnV3r4ZULUDFdtu5

---
_Generated by [Claude Code](https://claude.ai/code/session_01RefSDxQnV3r4ZULUDFdtu5)_