### PR TITLE
feat: 6 stats/discover features + anniversary generator + dark theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Dark theme par défaut** : passe en revue de
+  `templates/base.html.twig` qui pose un thème sombre permanent
+  via une overlay CSS qui re-cible les utilitaires Tailwind les
+  plus courants (`bg-white`, `bg-slate-50/100/200`,
+  `text-slate-800/700/600/500`, bords, flash messages, inputs
+  natifs, code). Une seule modif de fichier — pas de réécriture
+  template par template, pas de `dark:` prefix à propager. Closes #87.
 - **Page « Discover » `/discover/artists`** : suggestions d'artistes
   via `LastFmClient::artistGetSimilar` (wrap `artist.getSimilar`).
   Prend tes top 20 artistes des 90 derniers jours, demande à Last.fm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,12 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Courbe de diversité d'écoute** sur `/stats/charts` : nouveau 4e
+  Chart.js qui plotte le ratio artistes uniques / écoutes mois par
+  mois (en pourcentage). Indicateur d'exploration vs. rabâchage.
+  Méthode `NavidromeRepository::getDiversityByMonth($monthsBack)` qui
+  retourne `[{month, plays, uniques}]` avec remplissage des mois sans
+  scrobbles à zéro. Closes #93.
 - **`app:lastfm:rematch --random`** : nouveau flag qui mélange l'ordre
   des unmatched avant d'appliquer `--limit`. Utile pour échantillonner
   un sous-ensemble représentatif quand on debugge une nouvelle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,17 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Split des stats par client Subsonic** sur `/stats` : nouveau select
+  « Tous / DSub / Symfonium / web… » à côté du select période, alimenté
+  par `SELECT DISTINCT client FROM scrobbles`. Filtre le total
+  d'écoutes, les morceaux distincts, le top 10 artistes et le top 50
+  morceaux. Détection auto via `NavidromeRepository::hasScrobbleClient()`
+  (PRAGMA `scrobbles`) — si la colonne est absente côté Navidrome
+  (installation très ancienne ou stripped-down), le select n'apparaît
+  pas. Le cache `stats_snapshot` clé dans (period, client) avec une
+  fonction `StatsService::cacheKey($period, $client)` qui préserve la
+  clé legacy `$period` quand le client est null. `computeAll()`
+  recalcule automatiquement chaque combo (period × client). Closes #97.
 - **Courbe de diversité d'écoute** sur `/stats/charts` : nouveau 4e
   Chart.js qui plotte le ratio artistes uniques / écoutes mois par
   mois (en pourcentage). Indicateur d'exploration vs. rabâchage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,15 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Page « métadonnées incomplètes »** sur `/stats/incomplete-metadata` :
+  liste les albums dont la colonne Navidrome `mbz_album_id` est vide
+  ou nulle, regroupés par artiste (album_artist) et triés par nombre
+  d'écoutes. Pour chaque ligne : nombre de pistes, nombre d'écoutes
+  total, lien vers Navidrome (recherche album) et MusicBrainz
+  (recherche release). Curate les albums prioritaires à retagger
+  dans Picard / beets (les plus écoutés en premier). Détection auto
+  de la colonne via `mediaFileColumns()` — fonctionnalité désactivée
+  silencieusement si la colonne n'existe pas. Closes #25.
 - **Page « artistes oubliés »** sur `/stats/forgotten-artists` :
   liste les artistes avec un historique de plays consistant
   (`min_plays`, défaut 50) qui n'ont rien tourné depuis longtemps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,13 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Page « artistes oubliés »** sur `/stats/forgotten-artists` :
+  liste les artistes avec un historique de plays consistant
+  (`min_plays`, défaut 50) qui n'ont rien tourné depuis longtemps
+  (`idle_months`, défaut 12). Tri par `plays × idle_seconds` desc
+  (les gros favoris dormants montent en haut). Liens directs vers
+  Navidrome (recherche artiste) et Last.fm. Pendant à l'échelle
+  artiste du générateur `songs-you-used-to-love`. Closes #91.
 - **Split des stats par client Subsonic** sur `/stats` : nouveau select
   « Tous / DSub / Symfonium / web… » à côté du select période, alimenté
   par `SELECT DISTINCT client FROM scrobbles`. Filtre le total

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,15 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Générateur de playlist « anniversaire »** (key `anniversary`) :
+  agrège les top morceaux écoutés à la même date il y a N années
+  (souvenirs façon Spotify). Paramètres : `years_offsets` (liste
+  CSV, défaut « 1,2,5,10 ») et `window_days` (largeur de la fenêtre
+  en ± jours, défaut 3). Si un morceau a été écouté à la même date
+  il y a 2 ans ET il y a 5 ans, il est compté deux fois et remonte
+  en tête. Nouvelle méthode
+  `NavidromeRepository::topTracksInWindows()` qui prend une liste
+  de fenêtres et UNION-aggrège côté SQL. Closes #90.
 - **Dark theme par défaut** : passe en revue de
   `templates/base.html.twig` qui pose un thème sombre permanent
   via une overlay CSS qui re-cible les utilitaires Tailwind les

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,19 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   un état cohérent). En cas de double échec (import KO + restart KO), la
   `NavidromeContainerException` finale chaîne l'exception d'origine en
   `previous` pour tracer les deux problèmes.
+- **Page « Discover » `/discover/artists`** : suggestions d'artistes
+  via `LastFmClient::artistGetSimilar` (wrap `artist.getSimilar`).
+  Prend tes top 20 artistes des 90 derniers jours, demande à Last.fm
+  les 10 plus similaires de chacun, dédoublonne par nom normalisé en
+  gardant le meilleur score de match, filtre les artistes déjà dans
+  `media_file` (via la nouvelle méthode
+  `NavidromeRepository::getKnownArtistsNormalized()` qui exploite
+  `np_normalize`). Croise avec
+  `LidarrClient::indexExistingArtists()` pour afficher « ✓ déjà dans
+  Lidarr » ou un bouton « + Lidarr » par carte. Cache 24h dans
+  `stats_snapshot` (key `discover-artists`) avec rafraîchissement
+  manuel via POST CSRF. Désactivé silencieusement si `LASTFM_API_KEY`
+  est vide. Closes #92.
 - **Page « métadonnées incomplètes »** sur `/stats/incomplete-metadata` :
   liste les albums dont la colonne Navidrome `mbz_album_id` est vide
   ou nulle, regroupés par artiste (album_artist) et triés par nombre

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -102,6 +102,10 @@ services:
         arguments:
             $apiToken: '%app.homepage_api_token%'
 
+    App\Controller\ForgottenArtistsController:
+        arguments:
+            $navidromeUrl: '%navidrome.url%'
+
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -110,6 +110,10 @@ services:
         arguments:
             $navidromeUrl: '%navidrome.url%'
 
+    App\Service\DiscoverArtistsService:
+        arguments:
+            $apiKey: '%lastfm.api_key%'
+
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -106,6 +106,10 @@ services:
         arguments:
             $navidromeUrl: '%navidrome.url%'
 
+    App\Controller\IncompleteMetadataController:
+        arguments:
+            $navidromeUrl: '%navidrome.url%'
+
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'

--- a/src/Controller/DiscoverController.php
+++ b/src/Controller/DiscoverController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Controller;
+
+use App\Lidarr\LidarrConfig;
+use App\Service\DiscoverArtistsService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class DiscoverController extends AbstractController
+{
+    public function __construct(
+        private readonly DiscoverArtistsService $service,
+        private readonly LidarrConfig $lidarrConfig,
+    ) {
+    }
+
+    #[Route('/discover/artists', name: 'app_discover_artists', methods: ['GET'])]
+    public function index(): Response
+    {
+        $snapshot = $this->service->getCached();
+
+        return $this->render('discover/artists.html.twig', [
+            'snapshot' => $snapshot,
+            'fresh' => $snapshot !== null && $this->service->isFresh($snapshot),
+            'api_key_configured' => $this->service->isApiKeyConfigured(),
+            'lidarr_configured' => $this->lidarrConfig->isConfigured(),
+            'ttl_hours' => DiscoverArtistsService::TTL_HOURS,
+        ]);
+    }
+
+    #[Route('/discover/artists/refresh', name: 'app_discover_artists_refresh', methods: ['POST'])]
+    public function refresh(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('discover_refresh', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $this->service->compute();
+            $this->addFlash('success', 'Suggestions Last.fm rafraîchies.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_discover_artists');
+    }
+}

--- a/src/Controller/ForgottenArtistsController.php
+++ b/src/Controller/ForgottenArtistsController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Controller;
+
+use App\Navidrome\NavidromeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class ForgottenArtistsController extends AbstractController
+{
+    private const DEFAULT_MIN_PLAYS = 50;
+    private const DEFAULT_IDLE_MONTHS = 12;
+    private const ALLOWED_IDLE_MONTHS = [6, 12, 18, 24, 36, 60];
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly string $navidromeUrl,
+    ) {
+    }
+
+    #[Route('/stats/forgotten-artists', name: 'app_stats_forgotten_artists', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $minPlays = max(1, (int) $request->query->get('min_plays', (string) self::DEFAULT_MIN_PLAYS));
+        $idleMonths = (int) $request->query->get('idle_months', (string) self::DEFAULT_IDLE_MONTHS);
+        if (!in_array($idleMonths, self::ALLOWED_IDLE_MONTHS, true)) {
+            $idleMonths = self::DEFAULT_IDLE_MONTHS;
+        }
+
+        $hasScrobbles = $this->navidrome->isAvailable() && $this->navidrome->hasScrobblesTable();
+        $artists = $hasScrobbles
+            ? $this->navidrome->getForgottenArtists($minPlays, $idleMonths)
+            : [];
+
+        return $this->render('stats/forgotten_artists.html.twig', [
+            'has_scrobbles' => $hasScrobbles,
+            'artists' => $artists,
+            'min_plays' => $minPlays,
+            'idle_months' => $idleMonths,
+            'allowed_idle_months' => self::ALLOWED_IDLE_MONTHS,
+            'navidrome_url' => rtrim($this->navidromeUrl, '/'),
+        ]);
+    }
+}

--- a/src/Controller/IncompleteMetadataController.php
+++ b/src/Controller/IncompleteMetadataController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Controller;
+
+use App\Navidrome\NavidromeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class IncompleteMetadataController extends AbstractController
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly string $navidromeUrl,
+    ) {
+    }
+
+    #[Route('/stats/incomplete-metadata', name: 'app_stats_incomplete_metadata', methods: ['GET'])]
+    public function index(): Response
+    {
+        $available = $this->navidrome->isAvailable();
+        $albums = $available ? $this->navidrome->getIncompleteAlbums(200) : [];
+
+        // Group by album_artist (preserves the ORDER BY plays DESC of the SQL)
+        // Each group keeps the order of the first album seen, and tracks
+        // a running total of plays — used to rank artists.
+        $byArtist = [];
+        foreach ($albums as $a) {
+            $artist = $a['album_artist'] !== '' ? $a['album_artist'] : '(artiste inconnu)';
+            if (!isset($byArtist[$artist])) {
+                $byArtist[$artist] = ['artist' => $artist, 'total_plays' => 0, 'albums' => []];
+            }
+            $byArtist[$artist]['total_plays'] += $a['plays'];
+            $byArtist[$artist]['albums'][] = $a;
+        }
+
+        // Re-sort artists by total plays descending (the SQL gave us album-level
+        // sort, but artists with several low-play albums beat single-album
+        // artists with one big-play album once we aggregate).
+        uasort($byArtist, static fn (array $a, array $b): int => $b['total_plays'] <=> $a['total_plays']);
+
+        return $this->render('stats/incomplete_metadata.html.twig', [
+            'available' => $available,
+            'by_artist' => $byArtist,
+            'total_albums' => count($albums),
+            'navidrome_url' => rtrim($this->navidromeUrl, '/'),
+        ]);
+    }
+}

--- a/src/Controller/LidarrController.php
+++ b/src/Controller/LidarrController.php
@@ -28,10 +28,13 @@ class LidarrController extends AbstractController
             '1', 'tracks' => 'app_lastfm_unmatched',
             default => null,
         };
+        $redirectDiscover = (bool) $request->request->get('_redirect_discover', false);
         if ($redirectRunId > 0) {
             $back = $this->redirectToRoute('app_history_detail', ['id' => $redirectRunId]);
         } elseif ($unmatchedRoute !== null) {
             $back = $this->redirectToRoute($unmatchedRoute);
+        } elseif ($redirectDiscover) {
+            $back = $this->redirectToRoute('app_discover_artists');
         } else {
             $back = $this->redirectToRoute('app_lastfm_import');
         }

--- a/src/Controller/StatsChartsController.php
+++ b/src/Controller/StatsChartsController.php
@@ -31,6 +31,7 @@ class StatsChartsController extends AbstractController
 
         $playsByMonth = $hasScrobbles ? $navidrome->getPlaysByMonth($months) : [];
         $topArtists = $hasScrobbles ? $navidrome->getTopArtistsTimeline($months, 5) : [];
+        $diversity = $hasScrobbles ? $navidrome->getDiversityByMonth($months) : [];
 
         $heatmap = $hasScrobbles
             ? $navidrome->getHeatmapDayHour((new \DateTimeImmutable())->modify('-90 days'), null)
@@ -55,6 +56,7 @@ class StatsChartsController extends AbstractController
             'plays_by_month' => $playsByMonth,
             'top_artists' => $topArtists,
             'top_artists_palette' => self::TOP_ARTISTS_PALETTE,
+            'diversity' => $diversity,
             'day_labels' => $dayLabels,
             'day_values' => $dayValues,
         ]);

--- a/src/Controller/StatsController.php
+++ b/src/Controller/StatsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Navidrome\NavidromeRepository;
 use App\Service\StatsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,14 +12,21 @@ use Symfony\Component\Routing\Attribute\Route;
 class StatsController extends AbstractController
 {
     #[Route('/stats', name: 'app_stats', methods: ['GET'])]
-    public function index(Request $request, StatsService $stats): Response
+    public function index(Request $request, StatsService $stats, NavidromeRepository $navidrome): Response
     {
         $period = (string) $request->query->get('period', StatsService::PERIOD_ALL_TIME);
         if (!isset(StatsService::periods()[$period])) {
             $period = StatsService::PERIOD_ALL_TIME;
         }
 
-        $snapshot = $stats->getCached($period);
+        $clients = $navidrome->isAvailable() ? $navidrome->listScrobbleClients() : [];
+        $client = (string) $request->query->get('client', '');
+        if ($client !== '' && !in_array($client, $clients, true)) {
+            $client = '';
+        }
+        $clientFilter = $client !== '' ? $client : null;
+
+        $snapshot = $stats->getCached($period, $clientFilter);
         $stale = $snapshot === null;
 
         return $this->render('stats/index.html.twig', [
@@ -26,31 +34,47 @@ class StatsController extends AbstractController
             'periods' => StatsService::periods(),
             'snapshot' => $snapshot,
             'stale' => $stale,
+            'clients' => $clients,
+            'client' => $client,
         ]);
     }
 
     #[Route('/stats/refresh', name: 'app_stats_refresh', methods: ['POST'])]
-    public function refresh(Request $request, StatsService $stats): Response
+    public function refresh(Request $request, StatsService $stats, NavidromeRepository $navidrome): Response
     {
         $period = (string) $request->request->get('period', StatsService::PERIOD_ALL_TIME);
         if (!isset(StatsService::periods()[$period])) {
             $period = StatsService::PERIOD_ALL_TIME;
         }
 
-        if (!$this->isCsrfTokenValid('stats_refresh_' . $period, (string) $request->request->get('_token'))) {
+        $client = (string) $request->request->get('client', '');
+        $clients = $navidrome->isAvailable() ? $navidrome->listScrobbleClients() : [];
+        if ($client !== '' && !in_array($client, $clients, true)) {
+            $client = '';
+        }
+        $clientFilter = $client !== '' ? $client : null;
+
+        $tokenId = 'stats_refresh_' . StatsService::cacheKey($period, $clientFilter);
+        if (!$this->isCsrfTokenValid($tokenId, (string) $request->request->get('_token'))) {
             throw $this->createAccessDeniedException();
         }
 
         try {
-            $stats->compute($period);
+            $stats->compute($period, $clientFilter);
             $this->addFlash('success', sprintf(
-                'Statistiques recalculées pour « %s ».',
+                'Statistiques recalculées pour « %s »%s.',
                 StatsService::periods()[$period],
+                $clientFilter !== null ? ' (client : ' . $clientFilter . ')' : '',
             ));
         } catch (\Throwable $e) {
             $this->addFlash('error', 'Erreur : ' . $e->getMessage());
         }
 
-        return $this->redirectToRoute('app_stats', ['period' => $period]);
+        $params = ['period' => $period];
+        if ($client !== '') {
+            $params['client'] = $client;
+        }
+
+        return $this->redirectToRoute('app_stats', $params);
     }
 }

--- a/src/Generator/AnniversaryGenerator.php
+++ b/src/Generator/AnniversaryGenerator.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Generator;
+
+use App\Navidrome\NavidromeRepository;
+
+/**
+ * « Souvenirs » à la Spotify : top morceaux écoutés autour du jour J,
+ * mais N années en arrière (1, 2, 5, 10 ans…).
+ *
+ * Plusieurs offsets possibles dans une seule playlist : si un morceau
+ * était au top à la même date il y a 2 ans ET il y a 5 ans, il remonte
+ * en tête (somme des plays sur les fenêtres).
+ */
+class AnniversaryGenerator implements PlaylistGeneratorInterface
+{
+    public function __construct(private readonly NavidromeRepository $navidrome)
+    {
+    }
+
+    public function getKey(): string
+    {
+        return 'anniversary';
+    }
+
+    public function getLabel(): string
+    {
+        return 'Anniversaire (jour J il y a N années)';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Top morceaux écoutés à la même date il y a 1 / 2 / 5 / 10 ans (configurable).';
+    }
+
+    public function getParameterSchema(): array
+    {
+        return [
+            new ParameterDefinition(
+                name: 'years_offsets',
+                label: 'Années en arrière (séparées par virgule)',
+                type: ParameterDefinition::TYPE_STRING,
+                default: '1,2,5,10',
+                help: 'Liste d\'offsets en années, ex. « 1,2,5,10 ». Le générateur agrège tous ces souvenirs.',
+            ),
+            new ParameterDefinition(
+                name: 'window_days',
+                label: 'Largeur de la fenêtre (± jours)',
+                type: ParameterDefinition::TYPE_INT,
+                default: 3,
+                min: 0,
+                max: 30,
+                help: '0 = strictement le même jour calendaire ; 7 = la semaine autour.',
+            ),
+        ];
+    }
+
+    public function generate(array $parameters, int $limit): array
+    {
+        $windows = $this->buildWindows($parameters);
+        if ($windows === []) {
+            return [];
+        }
+
+        return $this->navidrome->topTracksInWindows($windows, $limit);
+    }
+
+    /**
+     * Bounding box of every offset window — used by the preview to scope
+     * the « Plays » column. The displayed counts will be a slight
+     * over-estimate (any play that happens to fall outside an offset
+     * window but inside the bounding box gets counted) but the trade-off
+     * is acceptable : for typical offsets the gaps between windows are
+     * mostly empty (we're talking about ±3 days each, separated by
+     * years).
+     */
+    public function getActiveWindow(array $parameters): ?array
+    {
+        $windows = $this->buildWindows($parameters);
+        if ($windows === []) {
+            return null;
+        }
+
+        $earliest = $windows[0]['from'];
+        $latest = $windows[0]['to'];
+        foreach ($windows as $w) {
+            if ($w['from'] < $earliest) {
+                $earliest = $w['from'];
+            }
+            if ($w['to'] > $latest) {
+                $latest = $w['to'];
+            }
+        }
+
+        return ['from' => $earliest, 'to' => $latest];
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     *
+     * @return list<array{from: \DateTimeImmutable, to: \DateTimeImmutable}>
+     */
+    private function buildWindows(array $parameters): array
+    {
+        $offsets = self::parseOffsets($parameters['years_offsets'] ?? '1,2,5,10');
+        $windowDays = max(0, min(30, (int) ($parameters['window_days'] ?? 3)));
+
+        $today = new \DateTimeImmutable('today');
+        $windows = [];
+        foreach ($offsets as $years) {
+            $center = $today->modify(sprintf('-%d years', $years));
+            $from = $center->modify(sprintf('-%d days', $windowDays));
+            $to = $center->modify(sprintf('+%d days', $windowDays + 1));
+            $windows[] = ['from' => $from, 'to' => $to];
+        }
+
+        return $windows;
+    }
+
+    /**
+     * @return list<int> deduped & sorted positive integer offsets
+     */
+    public static function parseOffsets(mixed $raw): array
+    {
+        $items = is_array($raw) ? $raw : explode(',', (string) $raw);
+        $clean = [];
+        foreach ($items as $item) {
+            $n = (int) trim((string) $item);
+            if ($n > 0 && $n <= 100) {
+                $clean[$n] = true;
+            }
+        }
+        $sorted = array_keys($clean);
+        sort($sorted);
+
+        return $sorted;
+    }
+}

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -168,6 +168,52 @@ class LastFmClient
     }
 
     /**
+     * Returns up to $limit artists similar to $artist, ranked by Last.fm's
+     * own `match` score (0..1). Each entry: name, MBID (when known), match
+     * score, and the Last.fm URL of the artist page. Empty array when the
+     * seed name is unknown or Last.fm returns no neighbours.
+     *
+     * @return list<array{name: string, mbid: ?string, match: float, url: string}>
+     */
+    public function artistGetSimilar(string $apiKey, string $artist, int $limit = 10): array
+    {
+        $payload = $this->call([
+            'method' => 'artist.getSimilar',
+            'artist' => $artist,
+            'api_key' => $apiKey,
+            'limit' => $limit,
+            'autocorrect' => 1,
+            'format' => 'json',
+        ]);
+
+        $items = $payload['similarartists']['artist'] ?? [];
+        // Last.fm returns a single object instead of an array when one
+        // sibling is found.
+        if (isset($items['name'])) {
+            $items = [$items];
+        }
+
+        $out = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $name = trim((string) ($item['name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+            $out[] = [
+                'name' => $name,
+                'mbid' => ($item['mbid'] ?? '') !== '' ? (string) $item['mbid'] : null,
+                'match' => (float) ($item['match'] ?? 0),
+                'url' => (string) ($item['url'] ?? ''),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
      * Cheaper sibling of {@see trackGetInfo()} : returns only the
      * canonical artist / track names suggested by Last.fm, no MBID. Same
      * autocorrect normalization as `trackGetInfo`.

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -573,6 +573,32 @@ class NavidromeRepository
     }
 
     /**
+     * Set of normalized artist names already present in `media_file`.
+     * Returned as `[normalized => true]` for O(1) « do we already own X? »
+     * lookups (used by the discover suggestions). Uses the same
+     * `np_normalize` UDF as `findArtistIdByName` so the keys match what
+     * external matchers produce client-side.
+     *
+     * @return array<string, true>
+     */
+    public function getKnownArtistsNormalized(): array
+    {
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT np_normalize(artist) AS norm FROM media_file WHERE artist != ''",
+        );
+
+        $out = [];
+        foreach ($rows as $r) {
+            $key = (string) $r['norm'];
+            if ($key !== '') {
+                $out[$key] = true;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
      * Albums with no MusicBrainz album id, ranked by lifetime plays.
      * Plays count is taken from `scrobbles` when available (lifetime),
      * falls back to `annotation.play_count` otherwise. Returns [] when

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -573,6 +573,65 @@ class NavidromeRepository
     }
 
     /**
+     * Albums with no MusicBrainz album id, ranked by lifetime plays.
+     * Plays count is taken from `scrobbles` when available (lifetime),
+     * falls back to `annotation.play_count` otherwise. Returns [] when
+     * the `mbz_album_id` column doesn't exist (very old Navidrome).
+     *
+     * @return list<array{album: string, album_artist: string, tracks: int, plays: int}>
+     */
+    public function getIncompleteAlbums(int $limit = 200): array
+    {
+        $columns = $this->mediaFileColumns();
+        if (!in_array('mbz_album_id', $columns, true)) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = "SELECT mf.album AS album,
+                           mf.album_artist AS album_artist,
+                           COUNT(DISTINCT mf.id) AS tracks,
+                           COUNT(s.id) AS plays
+                    FROM media_file mf
+                    LEFT JOIN scrobbles s ON s.media_file_id = mf.id AND s.user_id = :uid
+                    WHERE (mf.mbz_album_id IS NULL OR mf.mbz_album_id = '')
+                      AND mf.album != ''
+                    GROUP BY mf.album, mf.album_artist
+                    ORDER BY plays DESC, tracks DESC, album_artist ASC, album ASC
+                    LIMIT :lim";
+        } else {
+            $sql = "SELECT mf.album AS album,
+                           mf.album_artist AS album_artist,
+                           COUNT(DISTINCT mf.id) AS tracks,
+                           COALESCE(SUM(a.play_count), 0) AS plays
+                    FROM media_file mf
+                    LEFT JOIN annotation a ON a.item_id = mf.id
+                                          AND a.item_type = 'media_file'
+                                          AND a.user_id = :uid
+                    WHERE (mf.mbz_album_id IS NULL OR mf.mbz_album_id = '')
+                      AND mf.album != ''
+                    GROUP BY mf.album, mf.album_artist
+                    ORDER BY plays DESC, tracks DESC, album_artist ASC, album ASC
+                    LIMIT :lim";
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): array => [
+            'album' => (string) $r['album'],
+            'album_artist' => (string) $r['album_artist'],
+            'tracks' => (int) $r['tracks'],
+            'plays' => (int) $r['plays'],
+        ], $rows);
+    }
+
+    /**
      * Artists with high lifetime plays that haven't been played in the
      * last $idleMonths months. Sorted by `plays * idle_seconds` desc
      * (so heavy listening + long silence ranks first). Returns at most

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -11,6 +11,8 @@ class NavidromeRepository
     private ?Connection $connection = null;
     private ?bool $hasScrobblesCache = null;
     private ?string $userIdCache = null;
+    /** @var array<string>|null */
+    private ?array $scrobbleColumnsCache = null;
 
     public function __construct(
         private readonly string $dbPath,
@@ -87,6 +89,56 @@ class NavidromeRepository
         );
 
         return $this->hasScrobblesCache = ($row !== false);
+    }
+
+    /**
+     * Columns of the scrobbles table (lower-cased), or [] when the table
+     * is missing. Used to feature-detect optional columns like `client`
+     * (Subsonic client name) which exist on Navidrome 0.55+ but not on
+     * older or stripped-down installs.
+     *
+     * @return array<string>
+     */
+    public function scrobbleColumns(): array
+    {
+        if ($this->scrobbleColumnsCache !== null) {
+            return $this->scrobbleColumnsCache;
+        }
+        if (!$this->hasScrobblesTable()) {
+            return $this->scrobbleColumnsCache = [];
+        }
+        $rows = $this->connection()->fetchAllAssociative('PRAGMA table_info(scrobbles)');
+
+        return $this->scrobbleColumnsCache = array_map(
+            static fn (array $r): string => strtolower((string) $r['name']),
+            $rows,
+        );
+    }
+
+    public function hasScrobbleClient(): bool
+    {
+        return in_array('client', $this->scrobbleColumns(), true);
+    }
+
+    /**
+     * Distinct non-empty Subsonic clients found in the scrobbles table.
+     * Returns [] when the column doesn't exist.
+     *
+     * @return list<string>
+     */
+    public function listScrobbleClients(): array
+    {
+        if (!$this->hasScrobbleClient()) {
+            return [];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT DISTINCT client FROM scrobbles
+             WHERE client IS NOT NULL AND client != \'\'
+             ORDER BY client ASC',
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['client'], $rows);
     }
 
     public function resolveUserId(): string
@@ -228,7 +280,7 @@ class NavidromeRepository
      * fallback's "windowed" mode is only an approximation: it counts
      * tracks whose *last* play falls inside the window.
      */
-    public function getTotalPlays(?\DateTimeInterface $from, ?\DateTimeInterface $to): int
+    public function getTotalPlays(?\DateTimeInterface $from, ?\DateTimeInterface $to, ?string $client = null): int
     {
         $userId = $this->resolveUserId();
 
@@ -242,6 +294,10 @@ class NavidromeRepository
                 $params['t'] = $to->getTimestamp();
                 $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
                 $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND client = :client';
+                $params['client'] = $client;
             }
 
             return (int) $this->connection()->fetchOne($sql, $params, $types);
@@ -270,7 +326,7 @@ class NavidromeRepository
      * Number of distinct media files played at least once in [from, to).
      * Uses scrobbles when available (always accurate), annotation otherwise.
      */
-    public function getDistinctTracksPlayed(?\DateTimeInterface $from, ?\DateTimeInterface $to): int
+    public function getDistinctTracksPlayed(?\DateTimeInterface $from, ?\DateTimeInterface $to, ?string $client = null): int
     {
         $userId = $this->resolveUserId();
 
@@ -284,6 +340,10 @@ class NavidromeRepository
                 $params['t'] = $to->getTimestamp();
                 $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
                 $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND client = :client';
+                $params['client'] = $client;
             }
 
             return (int) $this->connection()->fetchOne($sql, $params, $types);
@@ -313,7 +373,7 @@ class NavidromeRepository
      *
      * @return list<array{artist: string, plays: int}>
      */
-    public function getTopArtists(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit): array
+    public function getTopArtists(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
     {
         $userId = $this->resolveUserId();
 
@@ -331,6 +391,10 @@ class NavidromeRepository
                 $params['t'] = $to->getTimestamp();
                 $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
                 $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND s.client = :client';
+                $params['client'] = $client;
             }
             $sql .= ' GROUP BY mf.artist ORDER BY plays DESC, artist ASC LIMIT :lim';
 
@@ -385,7 +449,7 @@ class NavidromeRepository
      *
      * @return list<array{id: string, title: string, artist: string, album: string, plays: int}>
      */
-    public function getTopTracksWithDetails(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit): array
+    public function getTopTracksWithDetails(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
     {
         $userId = $this->resolveUserId();
 
@@ -403,6 +467,10 @@ class NavidromeRepository
                 $params['t'] = $to->getTimestamp();
                 $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
                 $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND s.client = :client';
+                $params['client'] = $client;
             }
             $sql .= ' GROUP BY mf.id, mf.title, mf.artist, mf.album
                       ORDER BY plays DESC, title ASC LIMIT :lim';

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -573,6 +573,66 @@ class NavidromeRepository
     }
 
     /**
+     * Artists with high lifetime plays that haven't been played in the
+     * last $idleMonths months. Sorted by `plays * idle_seconds` desc
+     * (so heavy listening + long silence ranks first). Returns at most
+     * $limit rows. Empty array when scrobbles is missing — annotation
+     * fallback would be unreliable here (no MAX(play_date) per artist).
+     *
+     * @return list<array{artist: string, plays: int, last_played_at: \DateTimeImmutable, idle_days: int}>
+     */
+    public function getForgottenArtists(int $minPlays = 50, int $idleMonths = 12, int $limit = 200): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $idleThreshold = $now->modify(sprintf('-%d months', $idleMonths))->getTimestamp();
+        $nowTs = $now->getTimestamp();
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT mf.artist AS artist,
+                    COUNT(*) AS plays,
+                    MAX(s.submission_time) AS last_play
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND mf.artist != ''
+             GROUP BY mf.artist
+             HAVING plays >= :min_plays AND last_play < :idle_threshold
+             ORDER BY plays * (:now_ts - last_play) DESC
+             LIMIT :lim",
+            [
+                'uid' => $userId,
+                'min_plays' => $minPlays,
+                'idle_threshold' => $idleThreshold,
+                'now_ts' => $nowTs,
+                'lim' => $limit,
+            ],
+            [
+                'min_plays' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'idle_threshold' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'now_ts' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+
+        $tz = new \DateTimeZone(date_default_timezone_get());
+
+        return array_map(static function (array $r) use ($tz, $nowTs): array {
+            $lastPlay = (int) $r['last_play'];
+
+            return [
+                'artist' => (string) $r['artist'],
+                'plays' => (int) $r['plays'],
+                'last_played_at' => (new \DateTimeImmutable('@' . $lastPlay))->setTimezone($tz),
+                'idle_days' => (int) floor(($nowTs - $lastPlay) / 86400),
+            ];
+        }, $rows);
+    }
+
+    /**
      * Plays + distinct artists per month over the last $monthsBack months.
      * Months without scrobbles return plays=0, uniques=0.
      *

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -214,6 +214,79 @@ class NavidromeRepository
     }
 
     /**
+     * Top tracks aggregated across several disjoint windows. Identical
+     * semantics to {@see topTracksInWindow()} but the WHERE clause unions
+     * each `[from, to)` pair so a track played in multiple windows ranks
+     * higher (used by the anniversary generator that aggregates « same
+     * day of year, 1 / 2 / 5 / 10 years ago »).
+     *
+     * @param list<array{from: \DateTimeInterface, to: \DateTimeInterface}> $windows
+     *
+     * @return string[] media_file ids ordered by total play count DESC
+     */
+    public function topTracksInWindows(array $windows, int $limit): array
+    {
+        if ($windows === []) {
+            return [];
+        }
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $clauses = [];
+            $params = ['uid' => $userId, 'lim' => $limit];
+            $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+            foreach ($windows as $i => $w) {
+                $fromKey = "f{$i}";
+                $toKey = "t{$i}";
+                $clauses[] = "(s.submission_time >= :{$fromKey} AND s.submission_time < :{$toKey})";
+                $params[$fromKey] = $w['from']->getTimestamp();
+                $params[$toKey] = $w['to']->getTimestamp();
+                $types[$fromKey] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types[$toKey] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            $sql = sprintf(
+                "SELECT s.media_file_id AS id
+                 FROM scrobbles s
+                 WHERE s.user_id = :uid AND (%s)
+                 GROUP BY s.media_file_id
+                 ORDER BY COUNT(*) DESC, MAX(s.submission_time) DESC
+                 LIMIT :lim",
+                implode(' OR ', $clauses),
+            );
+
+            $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+            return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+        }
+
+        // Annotation fallback: only the LAST play matters, so we just match
+        // any window the row's play_date falls in. Less reliable but keeps
+        // the generator usable on Navidrome < 0.55.
+        $clauses = [];
+        $params = ['uid' => $userId, 'lim' => $limit];
+        $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+        foreach ($windows as $i => $w) {
+            $fromKey = "f{$i}";
+            $toKey = "t{$i}";
+            $clauses[] = "(a.play_date >= :{$fromKey} AND a.play_date < :{$toKey})";
+            $params[$fromKey] = $w['from']->format('Y-m-d H:i:s');
+            $params[$toKey] = $w['to']->format('Y-m-d H:i:s');
+        }
+        $sql = sprintf(
+            "SELECT a.item_id AS id
+             FROM annotation a
+             WHERE a.item_type = 'media_file' AND a.user_id = :uid AND (%s)
+             ORDER BY a.play_count DESC, a.play_date DESC
+             LIMIT :lim",
+            implode(' OR ', $clauses),
+        );
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
      * All-time top: based on annotation.play_count (always available).
      *
      * @return string[]

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -505,6 +505,58 @@ class NavidromeRepository
     }
 
     /**
+     * Plays + distinct artists per month over the last $monthsBack months.
+     * Months without scrobbles return plays=0, uniques=0.
+     *
+     * @return list<array{month: string, plays: int, uniques: int}>
+     */
+    public function getDiversityByMonth(int $monthsBack): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $from = $now->modify('first day of this month')->setTime(0, 0)
+            ->modify(sprintf('-%d months', max(0, $monthsBack - 1)));
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT strftime('%Y-%m', s.submission_time, 'unixepoch') AS month,
+                    COUNT(*) AS plays,
+                    COUNT(DISTINCT mf.artist) AS uniques
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND s.submission_time >= :from AND mf.artist != ''
+             GROUP BY month
+             ORDER BY month ASC",
+            ['uid' => $userId, 'from' => $from->getTimestamp()],
+            ['from' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+        $byMonth = [];
+        foreach ($rows as $r) {
+            $byMonth[(string) $r['month']] = [
+                'plays' => (int) $r['plays'],
+                'uniques' => (int) $r['uniques'],
+            ];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $monthsBack; $i++) {
+            $key = $cursor->format('Y-m');
+            $out[] = [
+                'month' => $key,
+                'plays' => $byMonth[$key]['plays'] ?? 0,
+                'uniques' => $byMonth[$key]['uniques'] ?? 0,
+            ];
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        return $out;
+    }
+
+    /**
      * Top $topN artists by total plays over the last $monthsBack months,
      * with a per-month timeseries for each.
      *

--- a/src/Service/DiscoverArtistsService.php
+++ b/src/Service/DiscoverArtistsService.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\StatsSnapshot;
+use App\LastFm\LastFmClient;
+use App\Lidarr\LidarrClient;
+use App\Lidarr\LidarrConfig;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\StatsSnapshotRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Builds and caches a list of « artists you don't have but might like »
+ * by combining your top Navidrome listens with Last.fm's
+ * `artist.getSimilar` graph. Results are cross-referenced with the Lidarr
+ * library so the UI can offer a one-click « + Lidarr » action with a
+ * « already there » hint.
+ */
+class DiscoverArtistsService
+{
+    public const KEY = 'discover-artists';
+    public const TTL_HOURS = 24;
+    public const DEFAULT_TOP_N = 20;
+    public const DEFAULT_SIMILAR_PER_SEED = 10;
+    public const SEED_WINDOW_DAYS = 90;
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly LastFmClient $lastFm,
+        private readonly LidarrClient $lidarr,
+        private readonly LidarrConfig $lidarrConfig,
+        private readonly StatsSnapshotRepository $repository,
+        private readonly EntityManagerInterface $em,
+        private readonly string $apiKey,
+    ) {
+    }
+
+    public function isApiKeyConfigured(): bool
+    {
+        return $this->apiKey !== '';
+    }
+
+    public function getCached(): ?StatsSnapshot
+    {
+        return $this->repository->findOneByPeriod(self::KEY);
+    }
+
+    public function isFresh(StatsSnapshot $snapshot): bool
+    {
+        $age = (new \DateTimeImmutable())->getTimestamp() - $snapshot->getComputedAt()->getTimestamp();
+
+        return $age < self::TTL_HOURS * 3600;
+    }
+
+    public function compute(int $topN = self::DEFAULT_TOP_N, int $simPerSeed = self::DEFAULT_SIMILAR_PER_SEED): StatsSnapshot
+    {
+        if (!$this->isApiKeyConfigured()) {
+            throw new \RuntimeException('LASTFM_API_KEY n\'est pas configuré.');
+        }
+        if (!$this->navidrome->isAvailable()) {
+            throw new \RuntimeException('La base Navidrome est inaccessible.');
+        }
+
+        $now = new \DateTimeImmutable();
+        $from = $now->modify('-' . self::SEED_WINDOW_DAYS . ' days');
+        $seeds = $this->navidrome->getTopArtists($from, $now, $topN);
+        $known = $this->navidrome->getKnownArtistsNormalized();
+
+        $suggestions = [];
+        foreach ($seeds as $seed) {
+            $seedName = $seed['artist'];
+            try {
+                $similar = $this->lastFm->artistGetSimilar($this->apiKey, $seedName, $simPerSeed);
+            } catch (\Throwable) {
+                // Network / API error on one seed shouldn't break the whole batch.
+                continue;
+            }
+            foreach ($similar as $sim) {
+                $norm = NavidromeRepository::normalize($sim['name']);
+                if ($norm === '' || isset($known[$norm])) {
+                    continue;
+                }
+                if (!isset($suggestions[$norm]) || $sim['match'] > $suggestions[$norm]['match']) {
+                    $suggestions[$norm] = [
+                        'name' => $sim['name'],
+                        'mbid' => $sim['mbid'],
+                        'match' => $sim['match'],
+                        'url' => $sim['url'],
+                        'seed' => $seedName,
+                    ];
+                }
+            }
+        }
+
+        $items = array_values($suggestions);
+        usort($items, static fn (array $a, array $b): int => $b['match'] <=> $a['match']);
+
+        $lidarrIndex = [];
+        if ($this->lidarrConfig->isConfigured()) {
+            try {
+                $lidarrIndex = $this->lidarr->indexExistingArtists();
+            } catch (\Throwable) {
+                $lidarrIndex = [];
+            }
+        }
+        foreach ($items as &$it) {
+            $key = mb_strtolower(trim($it['name']));
+            $it['in_lidarr'] = $lidarrIndex !== [] && isset($lidarrIndex[$key]);
+        }
+        unset($it);
+
+        $snapshot = $this->repository->findOneByPeriod(self::KEY) ?? new StatsSnapshot(self::KEY);
+        $snapshot->setData([
+            'items' => $items,
+            'seeds' => array_map(static fn (array $s): string => $s['artist'], $seeds),
+            'lidarr_configured' => $this->lidarrConfig->isConfigured(),
+        ]);
+
+        if ($snapshot->getId() === null) {
+            $this->em->persist($snapshot);
+        }
+        $this->em->flush();
+
+        return $snapshot;
+    }
+}

--- a/src/Service/StatsService.php
+++ b/src/Service/StatsService.php
@@ -39,22 +39,31 @@ class StatsService
     ) {
     }
 
-    public function getOrCompute(string $period): StatsSnapshot
+    /**
+     * Compose the cache key for a (period, client) combo. `null`/empty client
+     * keeps the legacy `$period` key (no migration needed for existing rows).
+     */
+    public static function cacheKey(string $period, ?string $client = null): string
     {
-        $existing = $this->repository->findOneByPeriod($period);
+        return ($client !== null && $client !== '') ? $period . '|' . $client : $period;
+    }
+
+    public function getOrCompute(string $period, ?string $client = null): StatsSnapshot
+    {
+        $existing = $this->repository->findOneByPeriod(self::cacheKey($period, $client));
         if ($existing !== null) {
             return $existing;
         }
 
-        return $this->compute($period);
+        return $this->compute($period, $client);
     }
 
-    public function getCached(string $period): ?StatsSnapshot
+    public function getCached(string $period, ?string $client = null): ?StatsSnapshot
     {
-        return $this->repository->findOneByPeriod($period);
+        return $this->repository->findOneByPeriod(self::cacheKey($period, $client));
     }
 
-    public function compute(string $period): StatsSnapshot
+    public function compute(string $period, ?string $client = null): StatsSnapshot
     {
         if (!isset(self::periods()[$period])) {
             throw new \InvalidArgumentException(sprintf('Unknown stats period "%s".', $period));
@@ -63,15 +72,17 @@ class StatsService
         [$from, $to] = $this->resolveWindow($period);
 
         $data = [
-            'total_plays' => $this->navidrome->getTotalPlays($from, $to),
-            'distinct_tracks' => $this->navidrome->getDistinctTracksPlayed($from, $to),
-            'top_artists' => $this->navidrome->getTopArtists($from, $to, self::TOP_ARTISTS_LIMIT),
-            'top_tracks' => $this->navidrome->getTopTracksWithDetails($from, $to, self::TOP_TRACKS_LIMIT),
+            'total_plays' => $this->navidrome->getTotalPlays($from, $to, $client),
+            'distinct_tracks' => $this->navidrome->getDistinctTracksPlayed($from, $to, $client),
+            'top_artists' => $this->navidrome->getTopArtists($from, $to, self::TOP_ARTISTS_LIMIT, $client),
+            'top_tracks' => $this->navidrome->getTopTracksWithDetails($from, $to, self::TOP_TRACKS_LIMIT, $client),
             'window_from' => $from?->format(\DateTimeInterface::ATOM),
             'window_to' => $to?->format(\DateTimeInterface::ATOM),
+            'client' => $client,
         ];
 
-        $snapshot = $this->repository->findOneByPeriod($period) ?? new StatsSnapshot($period);
+        $key = self::cacheKey($period, $client);
+        $snapshot = $this->repository->findOneByPeriod($key) ?? new StatsSnapshot($key);
         $snapshot->setData($data);
 
         if ($snapshot->getId() === null) {
@@ -83,17 +94,29 @@ class StatsService
     }
 
     /**
+     * Recompute every (period × client) combo currently observed in scrobbles
+     * plus the unfiltered baseline. Used by the cron snapshotter so that any
+     * client-filtered tab on /stats is served from cache.
+     *
      * @return array{StatsSnapshot[], string[]} [snapshots, errors]
      */
     public function computeAll(): array
     {
         $snapshots = [];
         $errors = [];
+        $clients = array_merge([null], $this->navidrome->listScrobbleClients());
         foreach (array_keys(self::periods()) as $period) {
-            try {
-                $snapshots[] = $this->compute($period);
-            } catch (\Throwable $e) {
-                $errors[] = sprintf('%s: %s', $period, $e->getMessage());
+            foreach ($clients as $client) {
+                try {
+                    $snapshots[] = $this->compute($period, $client);
+                } catch (\Throwable $e) {
+                    $errors[] = sprintf(
+                        '%s%s: %s',
+                        $period,
+                        $client !== null ? ' [' . $client . ']' : '',
+                        $e->getMessage(),
+                    );
+                }
             }
         }
 

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="fr" class="h-full bg-slate-50">
+<html lang="fr" class="h-full bg-slate-900">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,16 +9,81 @@
     <style>
         /* Album/artist cover thumbnails — used by templates/_macros/cover.html.twig.
            Tailwind via CDN doesn't include these utility classes by default. */
-        .cover { display: inline-block; border-radius: 0.25rem; background: #e2e8f0; }
+        .cover { display: inline-block; border-radius: 0.25rem; background: #334155; }
         .cover-fallback {
             display: inline-flex; align-items: center; justify-content: center;
             color: #fff; font-weight: 600; font-size: 0.7em;
             border-radius: 0.25rem; user-select: none;
         }
+
+        /* === Dark theme overrides (#87) ===
+           App-wide dark mode without rewriting every template's class
+           names. Tailwind via CDN emits utility classes at runtime ; we
+           re-target the most common light-theme utilities used across
+           templates. !important wins over the JIT-emitted rules. The
+           palette stays Tailwind-slate ; we just shift the brightness:
+           - bg-white   #ffffff → slate-800 #1e293b
+           - bg-slate-50  → slate-900 #0f172a (page bg already)
+           - bg-slate-100 → slate-700 #334155
+           - bg-slate-200 → slate-600 #475569 (hover states)
+           - text-slate-800/700/600 lighten ; -500/-400 stay muted. */
+        body { color-scheme: dark; }
+        .bg-white { background-color: #1e293b !important; }
+        .bg-slate-50 { background-color: #0f172a !important; }
+        .bg-slate-100 { background-color: #334155 !important; }
+        .bg-slate-200 { background-color: #475569 !important; }
+        .hover\:bg-slate-100:hover { background-color: #334155 !important; }
+        .hover\:bg-slate-200:hover { background-color: #475569 !important; }
+
+        .text-slate-800 { color: #f1f5f9 !important; }
+        .text-slate-700 { color: #e2e8f0 !important; }
+        .text-slate-600 { color: #cbd5e1 !important; }
+        .text-slate-500 { color: #94a3b8 !important; }
+        .text-slate-400 { color: #64748b !important; }
+
+        .border, .border-slate-200, .border-slate-300, .border-b, .border-t {
+            border-color: #334155 !important;
+        }
+        .divide-y > :not([hidden]) ~ :not([hidden]) { border-color: #334155 !important; }
+
+        /* Table heads / striped rows: keep them tinted but darker */
+        thead.bg-slate-100 { background-color: #1e293b !important; }
+        thead.bg-slate-100 th { color: #94a3b8 !important; }
+
+        /* Flash message tints — keep the hue, drop the brightness so they
+           read on a dark background */
+        .bg-amber-50  { background-color: rgba(251, 191,  36, 0.10) !important; }
+        .bg-emerald-50{ background-color: rgba( 16, 185, 129, 0.10) !important; }
+        .bg-rose-50   { background-color: rgba(244,  63,  94, 0.10) !important; }
+        .bg-sky-50    { background-color: rgba( 14, 165, 233, 0.10) !important; }
+        .text-amber-800   { color: #fcd34d !important; }
+        .text-emerald-800 { color: #6ee7b7 !important; }
+        .text-rose-800    { color: #fda4af !important; }
+        .text-sky-800     { color: #7dd3fc !important; }
+        .border-amber-300   { border-color: rgba(251, 191,  36, 0.40) !important; }
+        .border-emerald-300 { border-color: rgba( 16, 185, 129, 0.40) !important; }
+        .border-rose-300    { border-color: rgba(244,  63,  94, 0.40) !important; }
+        .border-sky-300     { border-color: rgba( 14, 165, 233, 0.40) !important; }
+
+        /* Form inputs: native widgets default to white on dark, hard to read */
+        input[type=text], input[type=number], input[type=email], input[type=password],
+        input[type=search], input[type=date], input[type=url], textarea, select {
+            background-color: #0f172a !important;
+            color: #f1f5f9 !important;
+            border-color: #334155 !important;
+        }
+        input::placeholder, textarea::placeholder { color: #64748b !important; }
+
+        /* Code blocks and inline code */
+        code { background-color: #0f172a !important; color: #f1f5f9 !important;
+               padding: 1px 4px; border-radius: 3px; }
+
+        /* Shadow on dark needs a stronger contrast */
+        .shadow { box-shadow: 0 1px 3px 0 rgba(0,0,0,0.5), 0 1px 2px -1px rgba(0,0,0,0.5) !important; }
     </style>
     {% block stylesheets %}{% endblock %}
 </head>
-<body class="h-full text-slate-800">
+<body class="h-full text-slate-100">
 <div class="min-h-full flex flex-col">
     <header class="bg-slate-900 text-slate-100">
         <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -69,6 +69,7 @@
                             <a href="{{ path('app_stats_charts') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Graphiques</a>
                             <a href="{{ path('app_stats_heatmap') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Heatmap</a>
                             <a href="{{ path('app_stats_forgotten_artists') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Artistes oubliés</a>
+                            <a href="{{ path('app_stats_incomplete_metadata') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Métadonnées incomplètes</a>
                             <a href="{{ path('app_wrapped_default') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Wrapped</a>
                             <a href="{{ path('app_stats_lastfm_history') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Historique Last.fm</a>
                             <a href="{{ path('app_stats_navidrome_history') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Historique Navidrome</a>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -55,6 +55,7 @@
                     <a href="{{ path('app_dashboard') }}" class="hover:underline">Dashboard</a>
                     <a href="{{ path('app_playlists_index') }}" class="hover:underline">Playlists</a>
                     <a href="{{ path('app_playlist_new') }}" class="hover:underline">Nouvelle playlist</a>
+                    <a href="{{ path('app_discover_artists') }}" class="hover:underline">Discover</a>
 
                     {# Stats dropdown — pure CSS hover/focus, no JS #}
                     <div class="relative group">

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -68,6 +68,7 @@
                             <a href="{{ path('app_stats_compare') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Comparer 2 périodes</a>
                             <a href="{{ path('app_stats_charts') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Graphiques</a>
                             <a href="{{ path('app_stats_heatmap') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Heatmap</a>
+                            <a href="{{ path('app_stats_forgotten_artists') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Artistes oubliés</a>
                             <a href="{{ path('app_wrapped_default') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Wrapped</a>
                             <a href="{{ path('app_stats_lastfm_history') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Historique Last.fm</a>
                             <a href="{{ path('app_stats_navidrome_history') }}" class="block px-4 py-2 text-sm hover:bg-slate-700">Historique Navidrome</a>

--- a/templates/discover/artists.html.twig
+++ b/templates/discover/artists.html.twig
@@ -1,0 +1,85 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Discover — artistes{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold">Discover — artistes</h1>
+
+        <form method="post" action="{{ path('app_discover_artists_refresh') }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('discover_refresh') }}">
+            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+                ↻ Rafraîchir
+            </button>
+        </form>
+    </div>
+
+    <p class="text-sm text-slate-600 mb-6">
+        Suggestions construites à partir de tes top {{ 20 }} artistes des 90 derniers jours,
+        croisées avec <code>artist.getSimilar</code> de Last.fm. Les artistes que tu as déjà dans
+        Navidrome sont filtrés. Le statut Lidarr indique si l'artiste est déjà suivi.
+    </p>
+
+    {% if not api_key_configured %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+            <strong>LASTFM_API_KEY</strong> n'est pas configuré. Cette page nécessite une clé d'API Last.fm.
+        </div>
+    {% endif %}
+
+    {% if snapshot is null %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 text-sm">
+            Aucune suggestion en cache. Clique sur <strong>Rafraîchir</strong> pour interroger Last.fm
+            (cela peut prendre 30 secondes — un appel API par artiste seed).
+        </div>
+    {% else %}
+        <p class="text-xs text-slate-500 mb-4">
+            Calculé le <strong>{{ snapshot.computedAt|date('Y-m-d H:i:s') }}</strong>
+            ({{ fresh ? 'frais' : '> ' ~ ttl_hours ~ 'h, à rafraîchir' }})
+            — {{ snapshot.data.items|length }} suggestion(s) à partir de
+            {{ snapshot.data.seeds|length }} artiste(s) seed.
+        </p>
+
+        {% if snapshot.data.items is empty %}
+            <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded p-4 text-sm">
+                Pas de suggestion neuve : Last.fm ne trouve que des artistes déjà dans ta lib.
+            </div>
+        {% else %}
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {% for item in snapshot.data.items %}
+                    <div class="bg-white shadow rounded p-4 flex flex-col gap-2">
+                        <div class="flex items-start justify-between gap-2">
+                            <div class="font-semibold text-base">{{ item.name }}</div>
+                            <div class="text-xs text-slate-400 whitespace-nowrap">
+                                {{ (item.match * 100)|round(0) }}% match
+                            </div>
+                        </div>
+                        <div class="text-xs text-slate-500">
+                            similaire à <span class="font-medium">{{ item.seed }}</span>
+                        </div>
+                        <div class="flex items-center gap-2 text-xs mt-2">
+                            <a href="{{ item.url ?: 'https://www.last.fm/music/' ~ item.name|url_encode }}"
+                               target="_blank" rel="noopener"
+                               class="text-sky-600 hover:underline">Last.fm</a>
+
+                            {% if snapshot.data.lidarr_configured %}
+                                {% if item.in_lidarr %}
+                                    <span class="text-emerald-600">✓ déjà dans Lidarr</span>
+                                {% else %}
+                                    <form method="post" action="{{ path('app_lidarr_add_artist') }}" class="inline">
+                                        <input type="hidden" name="artist" value="{{ item.name }}">
+                                        <input type="hidden" name="_redirect_discover" value="1">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('lidarr_add') }}">
+                                        <button type="submit"
+                                                class="text-xs px-2 py-1 rounded bg-amber-50 border border-amber-300 text-amber-800 hover:bg-amber-100">
+                                            + Lidarr
+                                        </button>
+                                    </form>
+                                {% endif %}
+                            {% endif %}
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/stats/charts.html.twig
+++ b/templates/stats/charts.html.twig
@@ -66,6 +66,17 @@
                 <canvas id="chart-dow"></canvas>
             </div>
         </div>
+
+        <div class="bg-white shadow rounded p-5">
+            <h2 class="font-semibold text-sm mb-3">Diversité d'écoute ({{ months }} mois)</h2>
+            <p class="text-xs text-slate-500 mb-3">
+                Ratio artistes uniques par écoute, mois par mois. Plus c'est haut, plus tu explores ;
+                plus c'est bas, plus tu rabâches les mêmes morceaux.
+            </p>
+            <div class="h-64">
+                <canvas id="chart-diversity"></canvas>
+            </div>
+        </div>
     </div>
 {% endblock %}
 
@@ -74,6 +85,7 @@
         (function () {
             const playsMonthly = {{ plays_by_month|json_encode|raw }};
             const topArtists = {{ top_artists|json_encode|raw }};
+            const diversity = {{ diversity|json_encode|raw }};
             const dayLabels = {{ day_labels|json_encode|raw }};
             const dayValues = {{ day_values|json_encode|raw }};
 
@@ -143,6 +155,46 @@
                     responsive: true,
                     maintainAspectRatio: false,
                     plugins: { legend: { display: false } },
+                },
+            });
+
+            // Chart 4: diversity (uniques / plays per month, line)
+            const diversityRatio = diversity.map(r => r.plays > 0 ? r.uniques / r.plays : 0);
+            new Chart(document.getElementById('chart-diversity'), {
+                type: 'line',
+                data: {
+                    labels: diversity.map(r => r.month),
+                    datasets: [{
+                        label: 'Artistes uniques / écoutes',
+                        data: diversityRatio,
+                        borderColor: '#8b5cf6',
+                        backgroundColor: 'rgba(139, 92, 246, 0.15)',
+                        tension: 0.3,
+                        fill: true,
+                    }],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: function (ctx) {
+                                    const r = diversity[ctx.dataIndex];
+                                    const pct = (ctx.parsed.y * 100).toFixed(1);
+                                    return pct + '%  (' + r.uniques + ' artistes / ' + r.plays + ' écoutes)';
+                                },
+                            },
+                        },
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            max: 1,
+                            ticks: { callback: v => Math.round(v * 100) + '%' },
+                        },
+                    },
                 },
             });
         })();

--- a/templates/stats/forgotten_artists.html.twig
+++ b/templates/stats/forgotten_artists.html.twig
@@ -1,0 +1,98 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Artistes oubliés{% endblock %}
+
+{% block body %}
+    <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
+        <span class="text-slate-500">Voir aussi :</span>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Heatmap</a>
+        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Wrapped</a>
+    </div>
+
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold">Artistes oubliés</h1>
+    </div>
+
+    <p class="text-sm text-slate-600 mb-6">
+        Artistes que tu as beaucoup écoutés et qui n'ont rien tourné depuis un moment.
+        Tri par <em>plays × ancienneté du dernier play</em> — plus c'est en haut, plus
+        ça fait longtemps qu'un favori dort.
+    </p>
+
+    {% if not has_scrobbles %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+            La table <code>scrobbles</code> de Navidrome est introuvable. Cette page nécessite Navidrome ≥ 0.55.
+        </div>
+    {% endif %}
+
+    <form method="get" class="bg-white shadow rounded p-4 mb-6 flex flex-wrap items-end gap-4">
+        <div>
+            <label class="block text-xs uppercase text-slate-500" for="min_plays">Plays minimum</label>
+            <input type="number" name="min_plays" id="min_plays" value="{{ min_plays }}" min="1"
+                   class="border rounded px-2 py-1 text-sm w-24">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500" for="idle_months">Inactif depuis</label>
+            <select name="idle_months" id="idle_months" class="border rounded px-2 py-1 text-sm">
+                {% for m in allowed_idle_months %}
+                    <option value="{{ m }}" {{ m == idle_months ? 'selected' : '' }}>{{ m }} mois</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+            Filtrer
+        </button>
+    </form>
+
+    {% if has_scrobbles %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between">
+                <h2 class="font-semibold text-sm">{{ artists|length }} artiste(s)</h2>
+            </div>
+            {% if artists is empty %}
+                <div class="p-4 text-sm text-slate-500">
+                    Aucun artiste ne correspond à ces filtres. Essaie d'abaisser le seuil de plays
+                    ou la durée d'inactivité.
+                </div>
+            {% else %}
+                <table class="w-full text-sm">
+                    <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                    <tr>
+                        <th class="px-3 py-2 w-10">#</th>
+                        <th class="px-3 py-2">Artiste</th>
+                        <th class="px-3 py-2 w-24 text-right">Plays</th>
+                        <th class="px-3 py-2 w-44">Dernier play</th>
+                        <th class="px-3 py-2 w-28 text-right">Idle</th>
+                        <th class="px-3 py-2 w-40 text-right">Liens</th>
+                    </tr>
+                    </thead>
+                    <tbody class="divide-y">
+                    {% for a in artists %}
+                        <tr>
+                            <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
+                            <td class="px-3 py-1.5 font-medium">{{ a.artist }}</td>
+                            <td class="px-3 py-1.5 text-right">{{ a.plays|number_format(0, '.', ' ') }}</td>
+                            <td class="px-3 py-1.5 text-slate-600">{{ a.last_played_at|date('Y-m-d') }}</td>
+                            <td class="px-3 py-1.5 text-right text-slate-600">
+                                {{ (a.idle_days / 30)|round(1) }} mois
+                            </td>
+                            <td class="px-3 py-1.5 text-right text-xs space-x-2">
+                                {% if navidrome_url %}
+                                    <a href="{{ navidrome_url }}/app/#/library?searchType=artist&search={{ a.artist|url_encode }}"
+                                       target="_blank" rel="noopener"
+                                       class="text-sky-600 hover:underline">Navidrome</a>
+                                {% endif %}
+                                <a href="https://www.last.fm/music/{{ a.artist|url_encode }}"
+                                   target="_blank" rel="noopener"
+                                   class="text-sky-600 hover:underline">Last.fm</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/stats/incomplete_metadata.html.twig
+++ b/templates/stats/incomplete_metadata.html.twig
@@ -1,0 +1,84 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Métadonnées incomplètes{% endblock %}
+
+{% block body %}
+    <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
+        <span class="text-slate-500">Voir aussi :</span>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_forgotten_artists') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Artistes oubliés</a>
+        <a href="{{ path('app_tagging_missing_mbid') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Morceaux sans MBID</a>
+    </div>
+
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold">Métadonnées incomplètes</h1>
+    </div>
+
+    <p class="text-sm text-slate-600 mb-6">
+        Albums dont le <code>mbz_album_id</code> est vide. Triés par nombre d'écoutes —
+        ceux qui sont écoutés en priorité méritent d'être taggés en premier dans
+        <a href="https://picard.musicbrainz.org/" target="_blank" rel="noopener" class="underline">MusicBrainz Picard</a>
+        ou
+        <a href="https://beets.io/" target="_blank" rel="noopener" class="underline">beets</a>.
+    </p>
+
+    {% if not available %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+            La base Navidrome n'est pas accessible.
+        </div>
+    {% elseif by_artist is empty %}
+        <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded p-4 text-sm">
+            🎉 Aucun album sans <code>mbz_album_id</code> dans le top {{ 200 }}. Soit ta lib est
+            bien taggée, soit la colonne <code>mbz_album_id</code> n'existe pas (Navidrome très ancien).
+        </div>
+    {% else %}
+        <p class="text-xs text-slate-500 mb-4">
+            {{ total_albums }} album(s) sans MBID, regroupés sur {{ by_artist|length }} artiste(s).
+        </p>
+
+        <div class="space-y-4">
+            {% for group in by_artist %}
+                <div class="bg-white shadow rounded overflow-hidden">
+                    <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between">
+                        <h2 class="font-semibold text-sm">
+                            {{ group.artist }}
+                            <span class="text-xs text-slate-500 font-normal">
+                                — {{ group.albums|length }} album(s) ·
+                                {{ group.total_plays|number_format(0, '.', ' ') }} écoute(s)
+                            </span>
+                        </h2>
+                    </div>
+                    <table class="w-full text-sm">
+                        <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                        <tr>
+                            <th class="px-3 py-2">Album</th>
+                            <th class="px-3 py-2 w-24 text-right">Pistes</th>
+                            <th class="px-3 py-2 w-28 text-right">Plays</th>
+                            <th class="px-3 py-2 w-40 text-right">Liens</th>
+                        </tr>
+                        </thead>
+                        <tbody class="divide-y">
+                        {% for a in group.albums %}
+                            <tr>
+                                <td class="px-3 py-1.5">{{ a.album }}</td>
+                                <td class="px-3 py-1.5 text-right text-slate-600">{{ a.tracks }}</td>
+                                <td class="px-3 py-1.5 text-right">{{ a.plays|number_format(0, '.', ' ') }}</td>
+                                <td class="px-3 py-1.5 text-right text-xs space-x-2">
+                                    {% if navidrome_url %}
+                                        <a href="{{ navidrome_url }}/app/#/library?searchType=album&search={{ a.album|url_encode }}"
+                                           target="_blank" rel="noopener"
+                                           class="text-sky-600 hover:underline">Navidrome</a>
+                                    {% endif %}
+                                    <a href="https://musicbrainz.org/search?type=release&query=artist%3A{{ group.artist|url_encode }}+AND+release%3A{{ a.album|url_encode }}"
+                                       target="_blank" rel="noopener"
+                                       class="text-sky-600 hover:underline">MusicBrainz</a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/stats/index.html.twig
+++ b/templates/stats/index.html.twig
@@ -14,7 +14,7 @@
     <div class="flex items-start justify-between mb-6 flex-wrap gap-3">
         <h1 class="text-2xl font-semibold">Statistiques d'écoute</h1>
 
-        <form method="get" action="{{ path('app_stats') }}" class="flex items-center gap-2">
+        <form method="get" action="{{ path('app_stats') }}" class="flex items-center gap-2 flex-wrap">
             <label for="period" class="text-sm">Période :</label>
             <select name="period" id="period" onchange="this.form.submit()"
                     class="border rounded px-2 py-1 text-sm">
@@ -22,11 +22,24 @@
                     <option value="{{ key }}" {{ key == period ? 'selected' : '' }}>{{ label }}</option>
                 {% endfor %}
             </select>
+
+            {% if clients is not empty %}
+                <label for="client" class="text-sm">Client :</label>
+                <select name="client" id="client" onchange="this.form.submit()"
+                        class="border rounded px-2 py-1 text-sm">
+                    <option value="">Tous</option>
+                    {% for c in clients %}
+                        <option value="{{ c }}" {{ c == client ? 'selected' : '' }}>{{ c }}</option>
+                    {% endfor %}
+                </select>
+            {% endif %}
         </form>
 
+        {% set refreshKey = client ? period ~ '|' ~ client : period %}
         <form method="post" action="{{ path('app_stats_refresh') }}">
             <input type="hidden" name="period" value="{{ period }}">
-            <input type="hidden" name="_token" value="{{ csrf_token('stats_refresh_' ~ period) }}">
+            {% if client %}<input type="hidden" name="client" value="{{ client }}">{% endif %}
+            <input type="hidden" name="_token" value="{{ csrf_token('stats_refresh_' ~ refreshKey) }}">
             <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
                 ↻ Rafraîchir
             </button>

--- a/tests/Generator/AnniversaryGeneratorTest.php
+++ b/tests/Generator/AnniversaryGeneratorTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Tests\Generator;
+
+use App\Generator\AnniversaryGenerator;
+use App\Navidrome\NavidromeRepository;
+use App\Tests\Navidrome\NavidromeFixtureFactory;
+use PHPUnit\Framework\TestCase;
+
+class AnniversaryGeneratorTest extends TestCase
+{
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/navidrome-anniv-' . uniqid() . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testParseOffsetsCleansAndDedupes(): void
+    {
+        $this->assertSame([1, 2, 5, 10], AnniversaryGenerator::parseOffsets('1, 2, 5, 10'));
+        $this->assertSame([1, 5], AnniversaryGenerator::parseOffsets('5,1,5,abc,-3,0'));
+        $this->assertSame([], AnniversaryGenerator::parseOffsets(''));
+        $this->assertSame([1, 2], AnniversaryGenerator::parseOffsets([1, '2', 'x']));
+    }
+
+    public function testGenerateAggregatesPlaysAcrossOffsets(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+
+        $today = new \DateTimeImmutable('today');
+        $oneYearAgo = $today->modify('-1 year');
+        $twoYearsAgo = $today->modify('-2 years');
+
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-A', 'Both years', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-B', 'Year 1 only', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-C', 'Year 2 only', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-D', 'Out of windows', 'Artist');
+
+        // mf-A: played 1 year ago AND 2 years ago → should rank first
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-A', $oneYearAgo->format('Y-m-d 12:00:00'));
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-A', $twoYearsAgo->format('Y-m-d 12:00:00'));
+        // mf-B: played 1 year ago only
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-B', $oneYearAgo->format('Y-m-d 13:00:00'));
+        // mf-C: played 2 years ago only
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-C', $twoYearsAgo->format('Y-m-d 13:00:00'));
+        // mf-D: played 6 months ago — outside any window
+        NavidromeFixtureFactory::insertScrobble(
+            $conn,
+            'user-1',
+            'mf-D',
+            $today->modify('-6 months')->format('Y-m-d 12:00:00'),
+        );
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $gen = new AnniversaryGenerator($repo);
+
+        $result = $gen->generate(['years_offsets' => '1,2', 'window_days' => 1], 10);
+
+        $this->assertSame(['mf-A', 'mf-B', 'mf-C'], $result, 'mf-A first (2 plays), then mf-B & mf-C; mf-D excluded');
+    }
+
+    public function testGetActiveWindowReturnsBoundingBoxOfAllOffsets(): void
+    {
+        $repo = new NavidromeRepository(sys_get_temp_dir() . '/never-opened.db', 'admin');
+        $gen = new AnniversaryGenerator($repo);
+
+        $window = $gen->getActiveWindow(['years_offsets' => '1,5,10', 'window_days' => 3]);
+
+        $this->assertNotNull($window);
+        $today = new \DateTimeImmutable('today');
+        $expectedFrom = $today->modify('-10 years')->modify('-3 days');
+        $expectedTo = $today->modify('-1 year')->modify('+4 days');
+        $this->assertSame($expectedFrom->format('Y-m-d'), $window['from']->format('Y-m-d'));
+        $this->assertSame($expectedTo->format('Y-m-d'), $window['to']->format('Y-m-d'));
+    }
+}

--- a/tests/LastFm/LastFmClientTest.php
+++ b/tests/LastFm/LastFmClientTest.php
@@ -107,4 +107,57 @@ class LastFmClientTest extends TestCase
         $this->assertSame('Daft Punk', $info->correctedTitle);
         $this->assertNull($info->mbid);
     }
+
+    public function testArtistGetSimilarReturnsRankedNeighbours(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                'similarartists' => [
+                    'artist' => [
+                        [
+                            'name' => 'Justice',
+                            'mbid' => 'mbid-justice',
+                            'match' => '0.95',
+                            'url' => 'https://www.last.fm/music/Justice',
+                        ],
+                        [
+                            'name' => 'Mr. Oizo',
+                            'mbid' => '',
+                            'match' => '0.72',
+                            'url' => 'https://www.last.fm/music/Mr.+Oizo',
+                        ],
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $similar = (new LastFmClient($http, 0))->artistGetSimilar('apikey', 'Daft Punk', 5);
+
+        $this->assertCount(2, $similar);
+        $this->assertSame('Justice', $similar[0]['name']);
+        $this->assertSame('mbid-justice', $similar[0]['mbid']);
+        $this->assertSame(0.95, $similar[0]['match']);
+        $this->assertNull($similar[1]['mbid'], 'empty MBID coerced to null');
+    }
+
+    public function testArtistGetSimilarHandlesSingleObjectShape(): void
+    {
+        // Last.fm collapses to a single object when only one neighbour is found.
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                'similarartists' => [
+                    'artist' => [
+                        'name' => 'Lone Match',
+                        'mbid' => 'mbid-lone',
+                        'match' => '0.5',
+                        'url' => '',
+                    ],
+                ],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $similar = (new LastFmClient($http, 0))->artistGetSimilar('apikey', 'Anyone', 1);
+        $this->assertCount(1, $similar);
+        $this->assertSame('Lone Match', $similar[0]['name']);
+    }
 }

--- a/tests/Navidrome/NavidromeFixtureFactory.php
+++ b/tests/Navidrome/NavidromeFixtureFactory.php
@@ -68,12 +68,15 @@ final class NavidromeFixtureFactory
         if ($withScrobbles) {
             // Mirror the real Navidrome 0.55+ schema where submission_time is
             // an INTEGER unix timestamp (was DATETIME prior to 0.55).
+            // `client` (Subsonic client name: DSub, Symfonium, web…) is
+            // optional in tests — left NULL when callers don't pass it.
             $conn->executeStatement(<<<'SQL'
                 CREATE TABLE scrobbles (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     media_file_id VARCHAR(255) NOT NULL,
                     user_id VARCHAR(255) NOT NULL,
-                    submission_time INTEGER NOT NULL
+                    submission_time INTEGER NOT NULL,
+                    client VARCHAR(255) DEFAULT NULL
                 )
             SQL);
         }
@@ -128,15 +131,20 @@ final class NavidromeFixtureFactory
         );
     }
 
-    public static function insertScrobble(Connection $conn, string $userId, string $mediaId, string $time): void
-    {
+    public static function insertScrobble(
+        Connection $conn,
+        string $userId,
+        string $mediaId,
+        string $time,
+        ?string $client = null,
+    ): void {
         $ts = strtotime($time);
         if ($ts === false) {
             throw new \InvalidArgumentException(sprintf('Invalid scrobble time "%s".', $time));
         }
         $conn->executeStatement(
-            'INSERT INTO scrobbles (media_file_id, user_id, submission_time) VALUES (?, ?, ?)',
-            [$mediaId, $userId, $ts],
+            'INSERT INTO scrobbles (media_file_id, user_id, submission_time, client) VALUES (?, ?, ?, ?)',
+            [$mediaId, $userId, $ts, $client],
             [2 => \Doctrine\DBAL\ParameterType::INTEGER],
         );
     }

--- a/tests/Navidrome/NavidromeFixtureFactory.php
+++ b/tests/Navidrome/NavidromeFixtureFactory.php
@@ -48,7 +48,9 @@ final class NavidromeFixtureFactory
                 year INTEGER DEFAULT 0 NOT NULL,
                 genre VARCHAR(255) DEFAULT '' NOT NULL,
                 mbz_track_id VARCHAR(255) DEFAULT '',
-                mbz_recording_id VARCHAR(255) DEFAULT ''
+                mbz_recording_id VARCHAR(255) DEFAULT '',
+                mbz_album_id VARCHAR(255) DEFAULT NULL,
+                mbz_album_artist_id VARCHAR(255) DEFAULT NULL
             )
         SQL);
         $conn->executeStatement(<<<'SQL'
@@ -102,11 +104,12 @@ final class NavidromeFixtureFactory
         string $path = '',
         ?string $mbzTrackId = null,
         ?string $mbzRecordingId = null,
+        ?string $mbzAlbumId = null,
     ): void {
         $artistId = 'artist-' . md5($artist);
         $conn->executeStatement(
-            'INSERT INTO media_file (id, path, title, artist, album, artist_id, album_artist, duration, mbz_track_id, mbz_recording_id)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            'INSERT INTO media_file (id, path, title, artist, album, artist_id, album_artist, duration, mbz_track_id, mbz_recording_id, mbz_album_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             [
                 $id,
                 $path,
@@ -118,6 +121,7 @@ final class NavidromeFixtureFactory
                 $duration,
                 $mbzTrackId,
                 $mbzRecordingId,
+                $mbzAlbumId,
             ],
         );
     }

--- a/tests/Navidrome/NavidromeRepositoryStatsTest.php
+++ b/tests/Navidrome/NavidromeRepositoryStatsTest.php
@@ -87,6 +87,52 @@ class NavidromeRepositoryStatsTest extends TestCase
         $this->assertSame(3, $topArtistsSymf[0]['plays']);
     }
 
+    public function testGetForgottenArtistsRanksByPlaysAndIdleness(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'A', 'Old Favorite');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'B', 'Recent Listen');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'C', 'Low Plays Old');
+
+        $now = new \DateTimeImmutable();
+
+        // Old Favorite: 60 plays, all 18 months ago → forgotten
+        for ($i = 0; $i < 60; $i++) {
+            NavidromeFixtureFactory::insertScrobble(
+                $conn,
+                'user-1',
+                'mf-1',
+                $now->modify('-18 months')->modify('+' . $i . ' minutes')->format('Y-m-d H:i:s'),
+            );
+        }
+        // Recent Listen: 80 plays, last one yesterday → not forgotten
+        for ($i = 0; $i < 80; $i++) {
+            NavidromeFixtureFactory::insertScrobble(
+                $conn,
+                'user-1',
+                'mf-2',
+                $now->modify('-1 day')->modify('-' . $i . ' minutes')->format('Y-m-d H:i:s'),
+            );
+        }
+        // Low Plays Old: only 10 plays 18 months ago → below min_plays
+        for ($i = 0; $i < 10; $i++) {
+            NavidromeFixtureFactory::insertScrobble(
+                $conn,
+                'user-1',
+                'mf-3',
+                $now->modify('-18 months')->modify('+' . $i . ' hours')->format('Y-m-d H:i:s'),
+            );
+        }
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $forgotten = $repo->getForgottenArtists(minPlays: 50, idleMonths: 12);
+
+        $this->assertCount(1, $forgotten, 'only Old Favorite passes both thresholds');
+        $this->assertSame('Old Favorite', $forgotten[0]['artist']);
+        $this->assertSame(60, $forgotten[0]['plays']);
+        $this->assertGreaterThan(500, $forgotten[0]['idle_days'], 'about 18 months idle');
+    }
+
     public function testTopArtistsAggregatesCorrectly(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);

--- a/tests/Navidrome/NavidromeRepositoryStatsTest.php
+++ b/tests/Navidrome/NavidromeRepositoryStatsTest.php
@@ -42,6 +42,51 @@ class NavidromeRepositoryStatsTest extends TestCase
         $this->assertSame(2, $repo->getDistinctTracksPlayed($weekAgo, $now));
     }
 
+    public function testScrobbleClientHelpersDetectColumnAndListDistinctClients(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'A', 'Artist');
+
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-01-01 10:00:00', 'Symfonium');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-01-02 10:00:00', 'DSub');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-01-03 10:00:00', 'Symfonium');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-01-04 10:00:00', null);
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+
+        $this->assertTrue($repo->hasScrobbleClient(), 'fixture creates the column');
+        $this->assertSame(['DSub', 'Symfonium'], $repo->listScrobbleClients(), 'sorted, NULL excluded');
+    }
+
+    public function testStatsMethodsFilterByClientWhenColumnIsPresent(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Song 1', 'Artist X');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Song 2', 'Artist Y');
+
+        // 3 Symfonium plays for Artist X, 2 DSub plays for Artist Y
+        for ($i = 0; $i < 3; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-01-0' . ($i + 1) . ' 10:00:00', 'Symfonium');
+        }
+        for ($i = 0; $i < 2; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2', '2025-01-0' . ($i + 1) . ' 10:00:00', 'DSub');
+        }
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+
+        $this->assertSame(5, $repo->getTotalPlays(null, null), 'baseline: all plays');
+        $this->assertSame(3, $repo->getTotalPlays(null, null, 'Symfonium'));
+        $this->assertSame(2, $repo->getTotalPlays(null, null, 'DSub'));
+
+        $topArtistsAll = $repo->getTopArtists(null, null, 10);
+        $this->assertCount(2, $topArtistsAll);
+
+        $topArtistsSymf = $repo->getTopArtists(null, null, 10, 'Symfonium');
+        $this->assertCount(1, $topArtistsSymf);
+        $this->assertSame('Artist X', $topArtistsSymf[0]['artist']);
+        $this->assertSame(3, $topArtistsSymf[0]['plays']);
+    }
+
     public function testTopArtistsAggregatesCorrectly(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);

--- a/tests/Navidrome/NavidromeRepositoryStatsTest.php
+++ b/tests/Navidrome/NavidromeRepositoryStatsTest.php
@@ -87,6 +87,64 @@ class NavidromeRepositoryStatsTest extends TestCase
         $this->assertSame(3, $topArtistsSymf[0]['plays']);
     }
 
+    public function testGetIncompleteAlbumsListsAlbumsWithoutMbzAlbumId(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+
+        // Album with MBID — should NOT appear
+        NavidromeFixtureFactory::insertTrack(
+            $conn,
+            'mf-1a',
+            'Track A',
+            'Artist X',
+            180,
+            'Tagged Album',
+            null,
+            '',
+            null,
+            null,
+            mbzAlbumId: '00000000-0000-0000-0000-000000000001',
+        );
+        NavidromeFixtureFactory::insertTrack(
+            $conn,
+            'mf-1b',
+            'Track B',
+            'Artist X',
+            180,
+            'Tagged Album',
+            null,
+            '',
+            null,
+            null,
+            mbzAlbumId: '00000000-0000-0000-0000-000000000001',
+        );
+
+        // Album without MBID, 3 tracks, 5 plays
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2a', 'T1', 'Artist Y', 180, 'Untagged Album');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2b', 'T2', 'Artist Y', 180, 'Untagged Album');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2c', 'T3', 'Artist Y', 180, 'Untagged Album');
+        for ($i = 0; $i < 3; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2a', '2025-01-0' . ($i + 1) . ' 10:00:00');
+        }
+        for ($i = 0; $i < 2; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2b', '2025-01-0' . ($i + 1) . ' 11:00:00');
+        }
+
+        // Smaller untagged album, 1 track, 1 play (should rank below)
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'Solo', 'Artist Z', 180, 'Tiny Album');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-3', '2025-01-01 12:00:00');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $albums = $repo->getIncompleteAlbums();
+
+        $this->assertCount(2, $albums, 'Tagged Album excluded');
+        $this->assertSame('Untagged Album', $albums[0]['album']);
+        $this->assertSame(3, $albums[0]['tracks']);
+        $this->assertSame(5, $albums[0]['plays']);
+        $this->assertSame('Tiny Album', $albums[1]['album']);
+        $this->assertSame(1, $albums[1]['plays']);
+    }
+
     public function testGetForgottenArtistsRanksByPlaysAndIdleness(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);

--- a/tests/Navidrome/NavidromeRepositoryTimeSeriesTest.php
+++ b/tests/Navidrome/NavidromeRepositoryTimeSeriesTest.php
@@ -41,6 +41,34 @@ class NavidromeRepositoryTimeSeriesTest extends TestCase
         $this->assertSame(1, $series[2]['plays'], 'current month');
     }
 
+    public function testGetDiversityByMonthCountsUniqueArtists(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'A', 'Daft Punk');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'B', 'Aphex Twin');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'C', 'Daft Punk');
+
+        $now = new \DateTimeImmutable();
+        // current month: 3 plays / 2 unique artists
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', $now->format('Y-m-d 10:00:00'));
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-3', $now->format('Y-m-d 11:00:00'));
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2', $now->format('Y-m-d 12:00:00'));
+        // 2 months ago: 2 plays / 1 unique artist
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', $now->modify('-2 months')->format('Y-m-d 10:00:00'));
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-3', $now->modify('-2 months')->format('Y-m-d 11:00:00'));
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $series = $repo->getDiversityByMonth(3);
+
+        $this->assertCount(3, $series);
+        $this->assertSame(2, $series[0]['plays']);
+        $this->assertSame(1, $series[0]['uniques'], 'two months ago: only Daft Punk');
+        $this->assertSame(0, $series[1]['plays']);
+        $this->assertSame(0, $series[1]['uniques']);
+        $this->assertSame(3, $series[2]['plays']);
+        $this->assertSame(2, $series[2]['uniques'], 'current month: Daft Punk + Aphex Twin');
+    }
+
     public function testGetTopArtistsTimelineRanksAndExposesFullSeries(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);


### PR DESCRIPTION
## Summary

Batch de **7 features** issu du brainstorm roadmap de la session : 4 pages stats nouvelles, 1 chart sur `/stats/charts`, 1 page discover, 1 nouveau générateur de playlist, et le passage de l'UI en dark theme par défaut.

| # | Closes | Effort | Description |
|---|--------|--------|-------------|
| **1** | #93 | S | Courbe de **diversité d'écoute** (artistes uniques / écoutes par mois) sur `/stats/charts` |
| **2** | #97 | S | **Split des tops par client Subsonic** (DSub, Symfonium, web…) sur `/stats`, avec cache `(period, client)` |
| **3** | #91 | M | Page **`/stats/forgotten-artists`** — high lifetime plays + idle > N mois |
| **4** | #25 | M | Page **`/stats/incomplete-metadata`** — albums sans `mbz_album_id` regroupés par artiste |
| **5** | #92 | M | Page **`/discover/artists`** — suggestions Last.fm `artist.getSimilar` × Lidarr index |
| **6** | #87 | S | **Dark theme par défaut** via overlay CSS dans `base.html.twig` |
| **7** | #90 | S | Générateur **`anniversary`** — souvenirs façon Spotify multi-fenêtres |

### Détail technique

**`NavidromeRepository`** gagne 5 nouvelles méthodes :
- `getDiversityByMonth($monthsBack)` — `[{month, plays, uniques}]` mois par mois
- `scrobbleColumns()` / `hasScrobbleClient()` / `listScrobbleClients()` — feature-detect optionnel pour la colonne `scrobbles.client`
- `getForgottenArtists($minPlays, $idleMonths, $limit)` — tri par `plays × idle_seconds` desc
- `getIncompleteAlbums($limit)` — albums sans MBID groupables, fallback annotation
- `getKnownArtistsNormalized()` — set normalisé pour le filtrage des suggestions discover
- `topTracksInWindows(array $windows, $limit)` — UNION SQL sur N fenêtres pour le générateur anniversaire

Les 4 méthodes existantes `getTotalPlays` / `getDistinctTracksPlayed` / `getTopArtists` / `getTopTracksWithDetails` acceptent maintenant un `?string $client` optionnel (rétrocompatible).

**`StatsService`** : `cacheKey($period, $client)` préserve la clé legacy `$period` quand le client est null (pas de migration des rows existantes). `computeAll()` recalcule `(period × client)` pour que le cron alimente toutes les vues.

**`LastFmClient`** : nouvelle méthode `artistGetSimilar($apiKey, $artist, $limit)` qui wrap `artist.getSimilar`, gère le cas single-object renvoyé par Last.fm quand un seul voisin existe.

**`DiscoverArtistsService`** : top 20 sur 90 jours → `artist.getSimilar` par seed → dédoublonnage par nom normalisé (meilleur match gagne) → croisement `LidarrClient::indexExistingArtists()`. Cache 24h dans `stats_snapshot` (key `discover-artists`).

**`AnniversaryGenerator`** : params `years_offsets` (CSV, défaut « 1,2,5,10 ») + `window_days` (± jours, défaut 3). `getActiveWindow()` retourne la bounding box.

**Dark theme** : overlay CSS dans `base.html.twig` qui re-cible les utilitaires Tailwind les plus utilisés. Une seule modif de fichier — pas de réécriture template par template.

### Note sur la divergence avec main

`main` a été mis à jour pendant le batch (mobile menu, Homepage widget, `--auto-stop`, etc.) — le `chore(roadmap)` initial est déjà sur main sous un hash voisin. Les 7 commits feature ne touchent pas les fichiers modifiés par l'autre branche, donc le merge devrait être propre, mais à confirmer côté GitHub.

## Test plan

- [ ] `composer ci` vert sur la branche (déjà passé localement : phpcs ✓ phpstan ✓ **289 tests / 747 assertions**)
- [ ] `/stats/charts` affiche la 4e courbe « Diversité d'écoute » avec axes en %
- [ ] `/stats` affiche le select « Client » à côté du select « Période » si `scrobbles.client` existe
- [ ] `/stats/forgotten-artists` retourne des artistes pertinents avec les filtres `min_plays=50&idle_months=12`
- [ ] `/stats/incomplete-metadata` regroupe par `album_artist` et trie par plays desc
- [ ] `/discover/artists` peuple le cache 24h après refresh ; bouton « + Lidarr » ajoute et redirige correctement
- [ ] L'UI passe en dark sur toutes les pages sans casser de contraste
- [ ] Le générateur `anniversary` apparaît dans le formulaire de création de playlist et génère bien

https://claude.ai/code/session_01RSMyYhakoFK7DodyLwPZEA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RSMyYhakoFK7DodyLwPZEA)_