### PR TITLE
fix(lastfm): traiter Last.fm error 6 (Track not found) comme un miss soft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,21 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   (desktop + mobile).
 
 ### Fixed
+- **`Last.fm API error 6: Track not found` interrompait l'import** : à
+  l'étape 7 de la cascade de matching, `ScrobbleMatcher` appelle
+  `LastFmClient::trackGetInfo()` pour les scrobbles non matchés
+  localement. Quand Last.fm ne connaît pas le track (cas attendu —
+  morceau absent de leur catalogue), l'API renvoyait `error: 6` et
+  `LastFmClient::call()` le propageait en `RuntimeException`, qui
+  remontait jusqu'à crasher le run (`app:lastfm:import` /
+  `app:lastfm:rematch`) au premier scrobble inconnu de Last.fm.
+  Nouvelle exception typée `App\LastFm\LastFmApiException` qui porte
+  `errorCode` séparément ; `lookup()` (track.getInfo /
+  track.getCorrection) intercepte spécifiquement le code 6 et retourne
+  `LastFmTrackInfo::empty()` — la cascade continue normalement vers
+  l'éventuel fuzzy puis `unmatched`. Les autres codes (rate limit 29,
+  invalid key 10, service down 11/16, etc.) continuent de remonter
+  pour ne pas masquer une vraie panne. Closes #113.
 - **`UNIQUE constraint failed: lastfm_match_cache.source_artist_norm,
   lastfm_match_cache.source_title_norm` pendant `app:lastfm:import`** :
   l'import ne flushe pas entre deux scrobbles, donc lorsque la même

--- a/src/LastFm/LastFmApiException.php
+++ b/src/LastFm/LastFmApiException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * Thrown when the Last.fm API responds with an `error` field. Carries the
+ * numeric error code separately so callers can soft-handle expected codes
+ * (e.g. 6 « Track not found » during the matching cascade) while letting
+ * real failures (rate limiting, invalid key, service down) bubble up.
+ *
+ * Codes documented at https://www.last.fm/api/errorcodes — most relevant:
+ *   6  → Invalid parameters / track not found
+ *   8  → Operation failed
+ *   10 → Invalid API key
+ *   11 → Service offline
+ *   16 → Service temporarily unavailable
+ *   29 → Rate limit exceeded
+ */
+class LastFmApiException extends \RuntimeException
+{
+    public function __construct(
+        public readonly int $errorCode,
+        public readonly string $errorMessage,
+    ) {
+        parent::__construct(sprintf('Last.fm API error %d: %s', $errorCode, $errorMessage));
+    }
+}

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -234,14 +234,26 @@ class LastFmClient
      */
     private function lookup(string $method, string $apiKey, string $artist, string $title, string $bodyKey): LastFmTrackInfo
     {
-        $payload = $this->call([
-            'method' => $method,
-            'artist' => $artist,
-            'track' => $title,
-            'api_key' => $apiKey,
-            'autocorrect' => 1,
-            'format' => 'json',
-        ]);
+        try {
+            $payload = $this->call([
+                'method' => $method,
+                'artist' => $artist,
+                'track' => $title,
+                'api_key' => $apiKey,
+                'autocorrect' => 1,
+                'format' => 'json',
+            ]);
+        } catch (LastFmApiException $e) {
+            // Code 6 = « Track not found ». Expected during the matching
+            // cascade for tracks Last.fm doesn't know — let the caller
+            // continue with an empty result instead of crashing the whole
+            // import. Real failures (rate limit, invalid key, service
+            // down) keep bubbling up.
+            if ($e->errorCode === 6) {
+                return LastFmTrackInfo::empty();
+            }
+            throw $e;
+        }
 
         $node = $payload;
         foreach (explode('.', $bodyKey) as $segment) {
@@ -342,11 +354,10 @@ class LastFmClient
         }
 
         if (isset($body['error'])) {
-            throw new \RuntimeException(sprintf(
-                'Last.fm API error %s: %s',
-                $body['error'],
-                $body['message'] ?? 'unknown',
-            ));
+            throw new LastFmApiException(
+                (int) $body['error'],
+                (string) ($body['message'] ?? 'unknown'),
+            );
         }
 
         return $body;

--- a/tests/LastFm/LastFmClientTest.php
+++ b/tests/LastFm/LastFmClientTest.php
@@ -2,6 +2,7 @@
 
 namespace App\Tests\LastFm;
 
+use App\LastFm\LastFmApiException;
 use App\LastFm\LastFmClient;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -66,8 +67,11 @@ class LastFmClientTest extends TestCase
         $this->assertSame('mbid-1', $info->mbid);
     }
 
-    public function testTrackGetInfoErrorPropagatesAsRuntimeException(): void
+    public function testTrackGetInfoSwallowsTrackNotFoundError(): void
     {
+        // Last.fm error 6 = « Track not found ». Expected for any scrobble
+        // whose artist/title isn't in Last.fm's catalog — must NOT crash
+        // the import, just return an empty result so the cascade continues.
         $http = new MockHttpClient([
             new MockResponse(json_encode([
                 'error' => 6,
@@ -75,11 +79,59 @@ class LastFmClientTest extends TestCase
             ], JSON_THROW_ON_ERROR)),
         ]);
 
+        $info = (new LastFmClient($http, 0))->trackGetInfo('apikey', 'Unknown', 'Untrack');
+
+        $this->assertNull($info->mbid);
+        $this->assertNull($info->correctedArtist);
+        $this->assertNull($info->correctedTitle);
+        $this->assertFalse($info->hasMbid());
+        $this->assertFalse($info->hasCorrection());
+    }
+
+    public function testTrackGetInfoPropagatesNonTrackNotFoundErrors(): void
+    {
+        // Real failures (rate limit, invalid key, service down) must
+        // bubble up so the import surfaces them instead of silently
+        // hammering the API.
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                'error' => 29,
+                'message' => 'Rate limit exceeded',
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
         $client = new LastFmClient($http, 0);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/Last\.fm API error 6:/');
-        $client->trackGetInfo('apikey', 'Unknown', 'Untrack');
+        try {
+            $client->trackGetInfo('apikey', 'Some', 'Track');
+            $this->fail('Expected LastFmApiException to be thrown');
+        } catch (LastFmApiException $e) {
+            $this->assertSame(29, $e->errorCode);
+            $this->assertSame('Rate limit exceeded', $e->errorMessage);
+        }
+    }
+
+    public function testCallThrowsLastFmApiExceptionWithErrorCode(): void
+    {
+        // Indirect check via a method that goes through call() but is
+        // outside the lookup() try/catch — artistGetSimilar surfaces any
+        // error code untouched.
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                'error' => 10,
+                'message' => 'Invalid API key',
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $client = new LastFmClient($http, 0);
+
+        try {
+            $client->artistGetSimilar('badkey', 'Daft Punk');
+            $this->fail('Expected LastFmApiException to be thrown');
+        } catch (LastFmApiException $e) {
+            $this->assertSame(10, $e->errorCode);
+            $this->assertStringContainsString('Last.fm API error 10', $e->getMessage());
+        }
     }
 
     public function testTrackGetCorrectionReadsNestedCorrectionTrackNode(): void


### PR DESCRIPTION
## Summary

- L'étape 7 de la cascade `ScrobbleMatcher` (`trackGetInfo`) crashait l'import sur le 1er scrobble inconnu de Last.fm en propageant `error 6` en `RuntimeException`.
- Nouvelle `LastFmApiException` typée qui porte `errorCode` séparément, `lookup()` catch spécifiquement le code 6 et retourne `LastFmTrackInfo::empty()` pour laisser la cascade continuer.
- Les autres codes (rate limit 29, invalid key 10, service offline 11/16) continuent de remonter — on ne masque pas les vraies pannes.

Closes #113

## Test plan

- [x] `vendor/bin/phpunit tests/LastFm/LastFmClientTest.php` (9/9 OK, 26 assertions)
- [x] `vendor/bin/phpcs src/LastFm tests/LastFm` clean
- [x] `vendor/bin/phpstan analyse src/LastFm tests/LastFm` clean
- [x] Test ajouté `testTrackGetInfoSwallowsTrackNotFoundError` (error 6 → empty info, pas d'exception)
- [x] Test ajouté `testTrackGetInfoPropagatesNonTrackNotFoundErrors` (error 29 → exception conservée)
- [x] Test ajouté `testCallThrowsLastFmApiExceptionWithErrorCode` (couvre `call()` directement via un autre endpoint)
- [x] Test mis à jour : `testTrackGetInfoErrorPropagatesAsRuntimeException` → renommé en `testTrackGetInfoSwallowsTrackNotFoundError` (le comportement change pour code 6)
- [ ] Lancer un `app:lastfm:import` complet sur un user avec des scrobbles que Last.fm ne connaît pas pour confirmer que l'import termine et que les rows tombent en `unmatched`

## Notes

`composer ci` local a 8 erreurs phpstan dans `src/Docker/DockerCli.php` (`symfony/process` non installé dans le vendor lando) — elles existent déjà sur `main`, sans rapport avec ce fix. CI GitHub Actions réinstalle les vendors from scratch donc devrait être verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)