### PR TITLE
feat(playlists): ajouter un morceau depuis la page détail (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   incomplètes ») n'étaient accessibles que sur desktop. Closes #115.
 
 ### Added
+- **Ajout de morceau dans une playlist depuis l'UI** : sur
+  `/playlists/{id}`, nouveau bloc « Ajouter un morceau » sous la table
+  des morceaux. Tape une requête (≥ 2 chars), Subsonic répond les
+  matchs (`search3.view` wrappé dans `SubsonicClient::search3()`),
+  cliquer « + Ajouter » l'ajoute via `updatePlaylist(songIdToAdd: …)`.
+  La requête est conservée dans l'URL après l'ajout pour permettre
+  d'enchaîner les ajouts sur le même résultat. Les morceaux déjà
+  présents sont filtrés des résultats. Closes #78 (partiellement —
+  reorder dans #117).
 - **Endpoint JSON `/api/status` + widget Homepage (gethomepage)** :
   nouveau controller `App\Controller\Api\StatusController` qui expose
   les métriques clés du tool en JSON. Sert deux usages avec un seul

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -41,6 +41,7 @@ class PlaylistController extends AbstractController
     #[Route('/playlists/{id}', name: 'app_playlists_show', methods: ['GET'], requirements: ['id' => '[^/]+'])]
     public function show(
         string $id,
+        Request $request,
         SubsonicClient $subsonic,
         NavidromeRepository $navidrome,
         PlaylistStatsService $stats,
@@ -61,11 +62,62 @@ class PlaylistController extends AbstractController
             ? $navidrome->filterMissingMediaFileIds($trackIds)
             : [];
 
+        // Optional search-to-add. Below 2 chars Subsonic returns way too
+        // much noise — and it spares an API call on the empty-form load.
+        $q = trim((string) $request->query->get('q', ''));
+        $searchResults = [];
+        if (mb_strlen($q) >= 2) {
+            try {
+                $existing = array_fill_keys($trackIds, true);
+                foreach ($subsonic->search3($q, 20)['songs'] as $song) {
+                    if ($song['id'] === '' || isset($existing[$song['id']])) {
+                        continue;
+                    }
+                    $searchResults[] = $song;
+                }
+            } catch (\Throwable $e) {
+                $this->addFlash('error', 'Recherche Subsonic impossible : ' . $e->getMessage());
+            }
+        }
+
         return $this->render('playlist_management/show.html.twig', [
             'playlist' => $playlist,
             'stats' => $stats->compute($playlist['tracks']),
             'missingIds' => array_fill_keys($missingIds, true),
+            'searchQuery' => $q,
+            'searchResults' => $searchResults,
         ]);
+    }
+
+    #[Route('/playlists/{id}/add-track', name: 'app_playlists_add_track', methods: ['POST'], requirements: ['id' => '[^/]+'])]
+    public function addTrack(string $id, Request $request, SubsonicClient $subsonic): Response
+    {
+        if (!$this->isCsrfTokenValid('add-track' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $songId = trim((string) $request->request->get('songId', ''));
+        if ($songId === '') {
+            $this->addFlash('error', 'Aucun morceau sélectionné.');
+            return $this->redirectToRoute('app_playlists_show', ['id' => $id]);
+        }
+
+        try {
+            $subsonic->updatePlaylist($id, songIdToAdd: [$songId]);
+            $this->addFlash('success', 'Morceau ajouté à la playlist.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        // Preserve the search query so the user can keep adding from the
+        // same result set without retyping.
+        $q = trim((string) $request->request->get('q', ''));
+        $params = ['id' => $id];
+        if ($q !== '') {
+            $params['q'] = $q;
+        }
+
+        return $this->redirectToRoute('app_playlists_show', $params);
     }
 
     #[Route('/playlists/{id}/rename', name: 'app_playlists_rename', methods: ['POST'], requirements: ['id' => '[^/]+'])]

--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -211,6 +211,43 @@ class SubsonicClient
     }
 
     /**
+     * Full-text search via Subsonic's `search3.view`. Returns the songs
+     * matching `$query` (artists / albums omitted to keep the payload
+     * small — the playlist add-track UI only needs songs). `$count`
+     * caps the result list ; Subsonic clamps it server-side too.
+     *
+     * @return array{songs: array<int, array{id: string, title: string, artist: string, album: string, duration: int}>}
+     */
+    public function search3(string $query, int $count = 20): array
+    {
+        $query = trim($query);
+        if ($query === '') {
+            return ['songs' => []];
+        }
+
+        $data = $this->call('search3', [
+            'query' => $query,
+            'songCount' => $count,
+            'artistCount' => 0,
+            'albumCount' => 0,
+        ]);
+
+        $songs = $data['searchResult3']['song'] ?? [];
+        $out = [];
+        foreach ($songs as $s) {
+            $out[] = [
+                'id' => (string) ($s['id'] ?? ''),
+                'title' => (string) ($s['title'] ?? ''),
+                'artist' => (string) ($s['artist'] ?? ''),
+                'album' => (string) ($s['album'] ?? ''),
+                'duration' => (int) ($s['duration'] ?? 0),
+            ];
+        }
+
+        return ['songs' => $out];
+    }
+
+    /**
      * Star one or more songs by Subsonic media_file id. No-op when the
      * list is empty. Subsonic accepts repeated `id=` parameters in the
      * same call; we batch by 50 to avoid blowing up the URL length.

--- a/templates/playlist_management/show.html.twig
+++ b/templates/playlist_management/show.html.twig
@@ -210,4 +210,56 @@
             </tbody>
         </table>
     {% endif %}
+
+    {# Search-to-add — Subsonic search3, filters out songs already in the playlist #}
+    <div class="mt-6 bg-white border border-slate-200 rounded p-3">
+        <h2 class="font-medium text-sm mb-2">Ajouter un morceau</h2>
+        <form method="get" action="{{ path('app_playlists_show', {id: playlist.id}) }}" class="flex items-center gap-2">
+            <input type="text" name="q" value="{{ searchQuery }}" placeholder="Titre, artiste, album…" minlength="2"
+                   class="border rounded px-2 py-1 text-sm flex-1 min-w-0">
+            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Rechercher</button>
+            {% if searchQuery is not empty %}
+                <a href="{{ path('app_playlists_show', {id: playlist.id}) }}" class="text-xs text-slate-500 hover:underline">Effacer</a>
+            {% endif %}
+        </form>
+
+        {% if searchQuery is not empty %}
+            {% if searchResults is empty %}
+                <p class="text-sm text-slate-500 mt-3">Aucun résultat (ou tous les morceaux trouvés sont déjà dans la playlist).</p>
+            {% else %}
+                <table class="w-full text-sm mt-3">
+                    <thead class="bg-slate-100 text-slate-600">
+                        <tr>
+                            <th class="px-3 py-2 text-left">Titre</th>
+                            <th class="px-3 py-2 text-left">Artiste</th>
+                            <th class="px-3 py-2 text-left">Album</th>
+                            <th class="px-3 py-2 text-right">Durée</th>
+                            <th class="px-3 py-2 text-right">Action</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for r in searchResults %}
+                            <tr class="border-t hover:bg-slate-50">
+                                <td class="px-3 py-2">{{ r.title }}</td>
+                                <td class="px-3 py-2 text-slate-600">{{ r.artist }}</td>
+                                <td class="px-3 py-2 text-slate-500 text-xs">{{ r.album }}</td>
+                                <td class="px-3 py-2 text-right text-xs text-slate-500">
+                                    {% set m = (r.duration // 60) %}{% set s = (r.duration % 60) %}
+                                    {{ m }}:{{ s|format('%02d') }}
+                                </td>
+                                <td class="px-3 py-2 text-right">
+                                    <form method="post" action="{{ path('app_playlists_add_track', {id: playlist.id}) }}" class="inline">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('add-track' ~ playlist.id) }}">
+                                        <input type="hidden" name="songId" value="{{ r.id }}">
+                                        <input type="hidden" name="q" value="{{ searchQuery }}">
+                                        <button type="submit" class="text-xs bg-emerald-100 hover:bg-emerald-200 text-emerald-800 px-2 py-1 rounded">+ Ajouter</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        {% endif %}
+    </div>
 {% endblock %}

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -411,6 +411,60 @@ class SubsonicClientTest extends TestCase
         $sub->updatePlaylist('', name: 'X');
     }
 
+    public function testSearch3ReturnsSongs(): void
+    {
+        $client = new MockHttpClient([
+            $this->ok([
+                'searchResult3' => [
+                    'song' => [
+                        ['id' => 'mf-1', 'title' => 'Take Me to Church', 'artist' => 'Hozier', 'album' => 'Hozier', 'duration' => 241],
+                        ['id' => 'mf-2', 'title' => 'Cherry Wine', 'artist' => 'Hozier', 'album' => 'Hozier', 'duration' => 240],
+                    ],
+                ],
+            ]),
+        ]);
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $res = $sub->search3('hozier');
+
+        $this->assertCount(2, $res['songs']);
+        $this->assertSame('mf-1', $res['songs'][0]['id']);
+        $this->assertSame('Take Me to Church', $res['songs'][0]['title']);
+        $this->assertSame(241, $res['songs'][0]['duration']);
+    }
+
+    public function testSearch3SkipsHttpWhenQueryIsBlank(): void
+    {
+        // Empty / whitespace queries don't even hit the wire — saves a
+        // pointless API call on every page load before the user types.
+        $sub = new SubsonicClient(new MockHttpClient(static function () {
+            throw new \RuntimeException('Should not perform HTTP for empty query.');
+        }), 'http://navi.test', 'admin', 'changeme');
+
+        $this->assertSame(['songs' => []], $sub->search3(''));
+        $this->assertSame(['songs' => []], $sub->search3('   '));
+    }
+
+    public function testSearch3PassesCountAsSongCount(): void
+    {
+        $captured = null;
+        $client = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return $this->ok(['searchResult3' => []]);
+        });
+
+        $sub = new SubsonicClient($client, 'http://navi.test', 'admin', 'changeme');
+        $sub->search3('led zep', 50);
+
+        $this->assertNotNull($captured);
+        $this->assertStringContainsString('/rest/search3.view?', $captured);
+        $this->assertStringContainsString('songCount=50', $captured);
+        // Artists / albums must be muted so the response stays small.
+        $this->assertStringContainsString('artistCount=0', $captured);
+        $this->assertStringContainsString('albumCount=0', $captured);
+    }
+
     /**
      * @param array<string, mixed> $payload
      */


### PR DESCRIPTION
## Summary

- Sur `/playlists/{id}`, nouveau bloc « Ajouter un morceau » sous la table : input texte (min. 2 chars), GET sur la même route avec `?q=…`. Le contrôleur appelle Subsonic `search3.view` et affiche les résultats filtrés des morceaux déjà présents.
- Bouton « + Ajouter » par résultat → POST `/playlists/{id}/add-track` → `updatePlaylist(songIdToAdd: [songId])`. La query est conservée dans l'URL après l'add pour enchaîner les ajouts.
- Nouvelle méthode `SubsonicClient::search3()` (wrap `search3.view`, songs uniquement, songCount par défaut 20).
- 3 tests unitaires sur `search3()` (`MockHttpClient`).

Closes partiellement **#78** — le **reorder** est splité dans la nouvelle issue **#117** (deux approches non-triviales : clear+rebuild non-atomique vs recreate qui change l'ID Subsonic).

## Contexte plus large : fin de l'epic #71

Avant d'attaquer ce ticket, vérification du code → **#72, #73, #77 étaient déjà livrés** sur main dans le commit `8a6b0ad` mais les issues n'avaient pas été fermées. Closes effectués sur GitHub (avec lien vers le commit) avant cette PR :
- #72 Liste `/playlists` ✓ closed
- #73 Détail `/playlists/{id}` ✓ closed
- #77 Bulk star/unstar ✓ closed

Cette PR + #117 (reorder) finissent l'epic #71.

## Test plan

- [x] `vendor/bin/phpunit` → 339 tests / 877 assertions OK
- [x] `vendor/bin/phpcs` → 176/176 clean
- [x] `vendor/bin/phpstan analyse src/Subsonic src/Controller tests/Subsonic` → no errors
- [x] `bin/console lint:twig templates/playlist_management` → OK
- [ ] **Test manuel sur Navidrome réel** (le Lando local n'a pas pu joindre l'instance Navidrome au moment du dev — 502) :
   - Aller sur `/playlists/{id}` quelconque
   - Section « Ajouter un morceau » visible sous la table
   - Taper « hozier » dans la search box → liste de résultats Subsonic, sans doublons avec la playlist
   - Cliquer « + Ajouter » sur un résultat → flash success, redirection avec `?q=hozier` préservé
   - Recharger la page → le morceau est dans la table

## Hors-scope

- **Reorder** des morceaux d'une playlist → suivi dans **#117**.
- **Bulk add** : pas demandé, mais `updatePlaylist(songIdToAdd: [...])` accepte déjà une liste — facile à brancher si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)