### PR TITLE
feat(backup): backup auto programmable de la DB locale + Navidrome (#95, #119)

### DIFF
--- a/.env
+++ b/.env
@@ -62,6 +62,13 @@ NAVIDROME_CONTAINER_NAME=
 RUN_HISTORY_RETENTION_DAYS=90
 ###< Run history retention ###
 
+###> Database backups (cf. .env.dist pour la doc complète) ###
+DB_BACKUP_SCHEDULE=
+DB_BACKUP_RETENTION_DAYS=30
+NAVIDROME_BACKUP_SCHEDULE=
+NAVIDROME_BACKUP_RETENTION_DAYS=30
+###< Database backups ###
+
 ###> Beets queue (file de chemins pour un tagger externe) ###
 # Chemin (côté container navidrome-tools) d'un fichier dans lequel l'app
 # appendit les chemins absolus des tracks à tagger via la page

--- a/.env.dist
+++ b/.env.dist
@@ -63,6 +63,25 @@ NAVIDROME_CONTAINER_NAME=
 RUN_HISTORY_RETENTION_DAYS=90
 ###< Run history retention ###
 
+###> Database backups ###
+# Snapshots both the tool's local DB (var/data.db) and optionally the
+# Navidrome library DB to var/backups/*.db.gz (gzipped VACUUM INTO).
+# Both schedules are independent ; leave empty to disable.
+#
+# DB_BACKUP_SCHEDULE — cron expr for `app:db:backup` (tool's local DB).
+# Cheap, safe to run while the app is up. Default off.
+DB_BACKUP_SCHEDULE=
+# DB_BACKUP_RETENTION_DAYS — auto-prune var/backups/data-*.db.gz files
+# older than N days at the end of each backup run. 0 = keep forever.
+DB_BACKUP_RETENTION_DAYS=30
+# NAVIDROME_BACKUP_SCHEDULE — cron expr for `app:navidrome:backup`
+# (Navidrome library DB). Requires Navidrome to be stopped during the
+# snapshot — when NAVIDROME_CONTAINER_NAME is set, the cron line uses
+# --auto-stop automatically. Default off.
+NAVIDROME_BACKUP_SCHEDULE=
+NAVIDROME_BACKUP_RETENTION_DAYS=30
+###< Database backups ###
+
 ###> Beets queue (optional — file de chemins pour tagger externe) ###
 # Path (inside the navidrome-tools container) of a file the app
 # appends absolute track paths to, via the /tagging/missing-mbid page.

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -43,6 +43,12 @@ services:
         # card + start/stop buttons (requires Docker socket mount).
         NAVIDROME_CONTAINER_NAME: ''
         RUN_HISTORY_RETENTION_DAYS: '90'
+        # Database backups — both schedules empty = disabled. Snapshots
+        # SQLite via VACUUM INTO + gzip into var/backups/.
+        DB_BACKUP_SCHEDULE: ''
+        DB_BACKUP_RETENTION_DAYS: '30'
+        NAVIDROME_BACKUP_SCHEDULE: ''
+        NAVIDROME_BACKUP_RETENTION_DAYS: '30'
         # File de chemins consommée par un beets externe (cron côté hôte
         # qui partage le même volume). Vide = bouton « pousser dans la
         # queue beets » masqué sur /tagging/missing-mbid.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   incomplètes ») n'étaient accessibles que sur desktop. Closes #115.
 
 ### Added
+- **Backup automatique programmable des DB SQLite** : deux nouvelles
+  commandes CLI plus une section dédiée sur `/settings`, partagent
+  toutes les deux le `App\Service\BackupService` (snapshot via
+  `VACUUM INTO` + gzip PHP zlib, sortie dans `var/backups/`).
+  - `app:db:backup` (#95) : backup de la **DB locale** du tool
+    (`var/data.db`). Cron via `DB_BACKUP_SCHEDULE`. Sûr à lancer
+    pendant que l'app tourne (Doctrine SQLite gère la concurrence).
+  - `app:navidrome:backup` (#119) : backup de la **DB Navidrome**
+    (`navidrome.db`). Comme `app:lastfm:import`, accepte `--auto-stop`
+    qui orchestre stop Navidrome → backup → restart Navidrome (try /
+    finally — restart toujours, même en cas d'erreur du backup) via
+    `NavidromeContainerManager::runWithNavidromeStopped()`. Sans
+    `--auto-stop`, pré-flight bloquant si Navidrome tourne (override
+    avec `--force`). Cron via `NAVIDROME_BACKUP_SCHEDULE` ; la ligne
+    cron générée par `app:cron:dump` ajoute automatiquement
+    `--auto-stop` quand `NAVIDROME_CONTAINER_NAME` est renseigné.
+  - Retention configurable via `DB_BACKUP_RETENTION_DAYS` (défaut 30)
+    et `NAVIDROME_BACKUP_RETENTION_DAYS` (défaut 30). 0 = ne purge
+    jamais. Purge appliquée à la fin de chaque run.
+  - Trace dans `RunHistory` (types `db-backup` et `navidrome-backup`,
+    metric `size_bytes` + `pruned`).
+  - UI sur `/settings` : section « Sauvegardes » qui liste les
+    fichiers (taille + date), permet de télécharger et de supprimer.
+    Bouton « Sauvegarder maintenant » pour la DB locale (sub-seconde) ;
+    pour Navidrome, instruction CLI affichée (le stop/restart est
+    incompatible avec une requête HTTP synchrone).
+  - **Restauration hors-scope de cette PR** (destructive, demande de
+    fermer toutes les connexions DB) — couverte ultérieurement par
+    `app:db:restore` (cf. #37) et procédure manuelle pour Navidrome.
+  Closes #95, closes #119.
 - **Ajout de morceau dans une playlist depuis l'UI** : sur
   `/playlists/{id}`, nouveau bloc « Ajouter un morceau » sous la table
   des morceaux. Tape une requête (≥ 2 chars), Subsonic répond les

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ pouvez les éditer puis les activer.
 | `COVERS_CACHE_PATH`  | non         | Cache disque des miniatures album/artiste. Défaut : `/app/var/covers` (volume Docker dédié dans le compose). |
 | `NAVIDROME_CONTAINER_NAME` | non   | Nom du conteneur Navidrome dans la même stack docker-compose. Quand renseigné, le dashboard affiche un statut UP/DOWN avec boutons Start/Stop, et les commandes d'import refusent de tourner si Navidrome est détecté UP (`--force` pour outrepasser). Requiert le mount `/var/run/docker.sock` (cf. `docker-compose.example.yml`). |
 | `HOMEPAGE_API_TOKEN` | non       | Bearer token pour le widget [Homepage](https://gethomepage.dev/widgets/services/customapi/) sur l'endpoint `/api/status`. Vide = mode enrichi désactivé (seul le mode healthcheck no-auth est servi). Voir la section [Widget Homepage](#widget-homepage-gethomepage). |
+| `DB_BACKUP_SCHEDULE` | non       | Cron expr pour `app:db:backup` (snapshot de la DB locale du tool). Vide = désactivé. Sortie dans `var/backups/data-*.db.gz`. Voir la section [Sauvegardes des DB](#sauvegardes-des-db). |
+| `DB_BACKUP_RETENTION_DAYS` | non (`30`) | Auto-purge des backups locaux plus anciens que N jours en fin de chaque run. 0 = ne purge jamais. |
+| `NAVIDROME_BACKUP_SCHEDULE` | non | Cron expr pour `app:navidrome:backup` (snapshot de la DB Navidrome avec stop/start du conteneur). Vide = désactivé. Sortie dans `var/backups/navidrome-*.db.gz`. La ligne cron générée utilise `--auto-stop` automatiquement quand `NAVIDROME_CONTAINER_NAME` est renseigné. |
+| `NAVIDROME_BACKUP_RETENTION_DAYS` | non (`30`) | Auto-purge des backups Navidrome plus anciens que N jours. 0 = ne purge jamais. |
 
 ### Mise à jour
 
@@ -672,6 +676,45 @@ Avec ce pattern, navidrome-tools ne touche **que** le fichier de
 queue (RW), `/music` reste `:ro`. Le push est tracé dans
 `/history` (type `beets-queue-push`) et le bandeau de la page
 affiche la taille courante de la queue.
+
+## Sauvegardes des DB
+
+Snapshots SQLite gzippés via `VACUUM INTO`, sortie dans
+`var/backups/`. Deux pendants :
+
+- **DB locale** (`data.db`) — `app:db:backup`. Sûr à lancer pendant
+  que l'app tourne. Programme via `DB_BACKUP_SCHEDULE`. Bouton
+  « Sauvegarder maintenant » sur `/settings`.
+- **DB Navidrome** (`navidrome.db`) — `app:navidrome:backup`.
+  Navidrome doit être arrêté pendant le snapshot ; deux modes :
+  - `--auto-stop` : orchestre stop Navidrome → backup → restart
+    (try / finally — restart toujours, même en cas d'erreur). Mode
+    recommandé pour le cron. Requiert `NAVIDROME_CONTAINER_NAME`
+    + le mount Docker socket.
+  - sans flag : pré-flight bloquant si Navidrome tourne. `--force`
+    pour outrepasser (à vos risques — copie possiblement corrompue).
+
+```bash
+bin/console app:db:backup
+bin/console app:navidrome:backup --auto-stop
+```
+
+Le cron supercronic intégré ajoute `--auto-stop` automatiquement
+sur la ligne `app:navidrome:backup` quand `NAVIDROME_CONTAINER_NAME`
+est renseigné.
+
+Retention configurable via `DB_BACKUP_RETENTION_DAYS` (défaut 30) et
+`NAVIDROME_BACKUP_RETENTION_DAYS` (défaut 30) — purge appliquée à la
+fin de chaque run. 0 = ne purge jamais.
+
+Page `/settings`, section « Sauvegardes » : liste des fichiers avec
+taille + date, télécharge ou supprime depuis l'UI.
+
+**Restauration** : la suppression d'`var/data.db` puis copie d'un
+backup décompressé à sa place suffit (faire avant le boot du
+conteneur, ou le redémarrer après). Pour Navidrome, même procédure
+en arrêtant Navidrome au préalable. Une commande `app:db:restore`
+viendra plus tard (#37).
 
 ## Historique des runs cron
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,10 @@ parameters:
     lidarr.monitor: '%env(LIDARR_MONITOR)%'
     navidrome.container_name: '%env(NAVIDROME_CONTAINER_NAME)%'
     app.homepage_api_token: '%env(HOMEPAGE_API_TOKEN)%'
+    app.db_backup_schedule: '%env(DB_BACKUP_SCHEDULE)%'
+    app.db_backup_retention_days: '%env(int:DB_BACKUP_RETENTION_DAYS)%'
+    app.navidrome_backup_schedule: '%env(NAVIDROME_BACKUP_SCHEDULE)%'
+    app.navidrome_backup_retention_days: '%env(int:NAVIDROME_BACKUP_RETENTION_DAYS)%'
 
 services:
     _defaults:
@@ -72,10 +76,21 @@ services:
             $statsRefreshSchedule: '%app.stats_refresh_schedule%'
             $loveSyncSchedule: '%lastfm.love_sync_schedule%'
             $rematchSchedule: '%lastfm.rematch_schedule%'
+            $dbBackupSchedule: '%app.db_backup_schedule%'
+            $navidromeBackupSchedule: '%app.navidrome_backup_schedule%'
 
     App\Command\PurgeHistoryCommand:
         arguments:
             $retentionDays: '%app.run_history_retention_days%'
+
+    App\Command\BackupDataDbCommand:
+        arguments:
+            $retentionDays: '%app.db_backup_retention_days%'
+
+    App\Command\BackupNavidromeDbCommand:
+        arguments:
+            $navidromeDbPath: '%navidrome.db_path%'
+            $retentionDays: '%app.navidrome_backup_retention_days%'
 
     App\Lidarr\LidarrConfig:
         arguments:
@@ -101,6 +116,10 @@ services:
     App\Controller\Api\StatusController:
         arguments:
             $apiToken: '%app.homepage_api_token%'
+
+    App\Controller\SettingsController:
+        arguments:
+            $dataBackupRetentionDays: '%app.db_backup_retention_days%'
 
     App\Controller\ForgottenArtistsController:
         arguments:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -30,6 +30,11 @@ services:
       # to also mount /var/run/docker.sock below.
       NAVIDROME_CONTAINER_NAME: ${NAVIDROME_CONTAINER_NAME:-}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
+      # Database backups — leave both schedules empty to disable.
+      DB_BACKUP_SCHEDULE: ${DB_BACKUP_SCHEDULE:-}
+      DB_BACKUP_RETENTION_DAYS: ${DB_BACKUP_RETENTION_DAYS:-30}
+      NAVIDROME_BACKUP_SCHEDULE: ${NAVIDROME_BACKUP_SCHEDULE:-}
+      NAVIDROME_BACKUP_RETENTION_DAYS: ${NAVIDROME_BACKUP_RETENTION_DAYS:-30}
       # File de chemins consommée par un beets externe (cron côté hôte
       # qui partage le même volume). Vide = bouton masqué sur
       # /tagging/missing-mbid.
@@ -88,6 +93,11 @@ services:
       LIDARR_MONITOR: ${LIDARR_MONITOR:-all}
       NAVIDROME_CONTAINER_NAME: ${NAVIDROME_CONTAINER_NAME:-}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
+      # Database backups — leave both schedules empty to disable.
+      DB_BACKUP_SCHEDULE: ${DB_BACKUP_SCHEDULE:-}
+      DB_BACKUP_RETENTION_DAYS: ${DB_BACKUP_RETENTION_DAYS:-30}
+      NAVIDROME_BACKUP_SCHEDULE: ${NAVIDROME_BACKUP_SCHEDULE:-}
+      NAVIDROME_BACKUP_RETENTION_DAYS: ${NAVIDROME_BACKUP_RETENTION_DAYS:-30}
       # File de chemins consommée par un beets externe (cron côté hôte
       # qui partage le même volume). Vide = bouton masqué sur
       # /tagging/missing-mbid.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,10 @@
         <env name="LIDARR_MONITOR" value="all"/>
         <env name="NAVIDROME_CONTAINER_NAME" value=""/>
         <env name="RUN_HISTORY_RETENTION_DAYS" value="90"/>
+        <env name="DB_BACKUP_SCHEDULE" value=""/>
+        <env name="DB_BACKUP_RETENTION_DAYS" value="30"/>
+        <env name="NAVIDROME_BACKUP_SCHEDULE" value=""/>
+        <env name="NAVIDROME_BACKUP_RETENTION_DAYS" value="30"/>
         <env name="BEETS_QUEUE_PATH" value=""/>
         <env name="LASTFM_API_KEY" value=""/>
         <env name="LASTFM_API_SECRET" value=""/>

--- a/src/Command/BackupDataDbCommand.php
+++ b/src/Command/BackupDataDbCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Service\BackupService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Snapshot the tool's local SQLite DB to var/backups/. Designed to run
+ * unattended via cron (`DB_BACKUP_SCHEDULE`) — Doctrine SQLite handles
+ * concurrent access so we don't need to stop the web container.
+ */
+#[AsCommand(
+    name: 'app:db:backup',
+    description: 'Snapshot the tool\'s local SQLite database to var/backups/.',
+)]
+class BackupDataDbCommand extends Command
+{
+    public function __construct(
+        private readonly BackupService $backupService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $projectDir,
+        private readonly int $retentionDays,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'retention-days',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override DB_BACKUP_RETENTION_DAYS for this run (0 = keep forever).',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $retention = $input->getOption('retention-days');
+        $retentionDays = $retention !== null ? max(0, (int) $retention) : $this->retentionDays;
+
+        $sourcePath = $this->projectDir . '/var/data.db';
+        $backupDir = $this->projectDir . '/var/backups';
+
+        try {
+            $result = $this->recorder->record(
+                type: RunHistory::TYPE_DB_BACKUP,
+                reference: 'data.db',
+                label: 'Backup DB locale',
+                action: function () use ($sourcePath, $backupDir, $retentionDays): array {
+                    $snapshot = $this->backupService->backupSqlite($sourcePath, $backupDir, 'data');
+                    $pruned = $this->backupService->pruneOlderThan($backupDir, 'data', $retentionDays);
+
+                    return $snapshot + ['pruned' => $pruned];
+                },
+                extractMetrics: static fn (array $r): array => [
+                    'size_bytes' => $r['size'],
+                    'pruned' => $r['pruned'],
+                    'path' => $r['path'],
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            'Backup OK : %s (%s, %d ancien(s) purgé(s))',
+            basename($result['path']),
+            $this->formatBytes($result['size']),
+            $result['pruned'],
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' o';
+        }
+        if ($bytes < 1024 * 1024) {
+            return number_format($bytes / 1024, 1, ',', ' ') . ' Kio';
+        }
+
+        return number_format($bytes / 1024 / 1024, 1, ',', ' ') . ' Mio';
+    }
+}

--- a/src/Command/BackupNavidromeDbCommand.php
+++ b/src/Command/BackupNavidromeDbCommand.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Command;
+
+use App\Docker\NavidromeContainerException;
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Service\BackupService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Snapshot the Navidrome library DB. Navidrome must be stopped during
+ * the VACUUM INTO so the SQLite file isn't being mutated mid-snapshot
+ * — we either rely on a manual pre-flight (default) or orchestrate the
+ * stop / backup / restart cycle ourselves with `--auto-stop`. Mirrors
+ * the pattern of `app:lastfm:import`.
+ */
+#[AsCommand(
+    name: 'app:navidrome:backup',
+    description: 'Snapshot the Navidrome library SQLite database to var/backups/.',
+)]
+class BackupNavidromeDbCommand extends Command
+{
+    public function __construct(
+        private readonly BackupService $backupService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly NavidromeContainerManager $container,
+        private readonly string $navidromeDbPath,
+        private readonly string $projectDir,
+        private readonly int $retentionDays,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'retention-days',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Override NAVIDROME_BACKUP_RETENTION_DAYS for this run (0 = keep forever).',
+            )
+            ->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Skip the Navidrome container pre-flight check. Use at your own risk: copying the DB while Navidrome runs can produce a corrupted snapshot.',
+            )
+            ->addOption(
+                'auto-stop',
+                null,
+                InputOption::VALUE_NONE,
+                'When NAVIDROME_CONTAINER_NAME is set, stop Navidrome before the backup and restart it afterwards (always, even on error). Recommended for unattended runs (cron).',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $retention = $input->getOption('retention-days');
+        $retentionDays = $retention !== null ? max(0, (int) $retention) : $this->retentionDays;
+        $force = (bool) $input->getOption('force');
+        $autoStop = (bool) $input->getOption('auto-stop');
+
+        if ($this->navidromeDbPath === '') {
+            $io->error('NAVIDROME_DB_PATH n\'est pas renseignée — impossible de localiser la DB Navidrome à sauvegarder.');
+
+            return Command::FAILURE;
+        }
+
+        if (!$autoStop) {
+            try {
+                $this->container->assertSafeToWrite($force);
+            } catch (NavidromeContainerException $e) {
+                $io->error($e->getMessage());
+
+                return Command::FAILURE;
+            }
+        }
+
+        $backupDir = $this->projectDir . '/var/backups';
+        $sourcePath = $this->navidromeDbPath;
+
+        $runBackup = fn () => $this->recorder->record(
+            type: RunHistory::TYPE_NAVIDROME_BACKUP,
+            reference: basename($sourcePath),
+            label: 'Backup DB Navidrome',
+            action: function () use ($sourcePath, $backupDir, $retentionDays): array {
+                $snapshot = $this->backupService->backupSqlite($sourcePath, $backupDir, 'navidrome');
+                $pruned = $this->backupService->pruneOlderThan($backupDir, 'navidrome', $retentionDays);
+
+                return $snapshot + ['pruned' => $pruned];
+            },
+            extractMetrics: static fn (array $r): array => [
+                'size_bytes' => $r['size'],
+                'pruned' => $r['pruned'],
+                'path' => $r['path'],
+            ],
+        );
+
+        try {
+            $result = $autoStop
+                ? $this->container->runWithNavidromeStopped($runBackup)
+                : $runBackup();
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            'Backup OK : %s (%s, %d ancien(s) purgé(s))',
+            basename($result['path']),
+            $this->formatBytes($result['size']),
+            $result['pruned'],
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' o';
+        }
+        if ($bytes < 1024 * 1024) {
+            return number_format($bytes / 1024, 1, ',', ' ') . ' Kio';
+        }
+
+        return number_format($bytes / 1024 / 1024, 1, ',', ' ') . ' Mio';
+    }
+}

--- a/src/Command/DumpCronCommand.php
+++ b/src/Command/DumpCronCommand.php
@@ -23,6 +23,8 @@ class DumpCronCommand extends Command
         private readonly string $statsRefreshSchedule,
         private readonly string $loveSyncSchedule = '',
         private readonly string $rematchSchedule = '',
+        private readonly string $dbBackupSchedule = '',
+        private readonly string $navidromeBackupSchedule = '',
     ) {
         parent::__construct();
     }
@@ -99,6 +101,43 @@ class DumpCronCommand extends Command
                 ));
             } catch (\Throwable $e) {
                 $output->writeln('# SKIP rematch: invalid LASTFM_REMATCH_SCHEDULE (' . $e->getMessage() . ')');
+            }
+        }
+
+        if ($this->dbBackupSchedule !== '') {
+            try {
+                new CronExpression($this->dbBackupSchedule);
+                $output->writeln('');
+                $output->writeln('# Backup of the tool\'s local DB (DB_BACKUP_SCHEDULE)');
+                $output->writeln(sprintf(
+                    '%s php %s app:db:backup',
+                    $this->dbBackupSchedule,
+                    $bin,
+                ));
+            } catch (\Throwable $e) {
+                $output->writeln('# SKIP db backup: invalid DB_BACKUP_SCHEDULE (' . $e->getMessage() . ')');
+            }
+        }
+
+        if ($this->navidromeBackupSchedule !== '') {
+            try {
+                new CronExpression($this->navidromeBackupSchedule);
+                $output->writeln('');
+                $output->writeln('# Backup of the Navidrome library DB (NAVIDROME_BACKUP_SCHEDULE)');
+                // Auto-stop only when the container management is wired —
+                // otherwise --auto-stop fails immediately with « not configured ».
+                // Without --auto-stop the pre-flight blocks the run if Navidrome
+                // is up, so the user has to either configure NAVIDROME_CONTAINER_NAME
+                // or stop Navidrome out-of-band.
+                $autoStopFlag = $this->containerConfig->isConfigured() ? ' --auto-stop' : '';
+                $output->writeln(sprintf(
+                    '%s php %s app:navidrome:backup%s',
+                    $this->navidromeBackupSchedule,
+                    $bin,
+                    $autoStopFlag,
+                ));
+            } catch (\Throwable $e) {
+                $output->writeln('# SKIP navidrome backup: invalid NAVIDROME_BACKUP_SCHEDULE (' . $e->getMessage() . ')');
             }
         }
 

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -2,15 +2,28 @@
 
 namespace App\Controller;
 
+use App\Entity\RunHistory;
 use App\LastFm\LastFmAuthService;
+use App\Service\BackupService;
+use App\Service\RunHistoryRecorder;
 use App\Service\SettingsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 
 class SettingsController extends AbstractController
 {
+    public function __construct(
+        private readonly BackupService $backupService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $projectDir,
+        private readonly int $dataBackupRetentionDays,
+    ) {
+    }
+
     #[Route('/settings', name: 'app_settings', methods: ['GET', 'POST'])]
     public function index(Request $request, SettingsService $settings, LastFmAuthService $lastfmAuth): Response
     {
@@ -29,11 +42,121 @@ class SettingsController extends AbstractController
             return $this->redirectToRoute('app_settings');
         }
 
+        $backupDir = $this->projectDir . '/var/backups';
+
         return $this->render('settings/index.html.twig', [
             'default_limit' => $settings->getDefaultLimit(),
             'default_template' => $settings->getDefaultNameTemplate(),
             'lastfm_auth_configured' => $lastfmAuth->isConfigured(),
             'lastfm_session_user' => $lastfmAuth->getStoredSessionUser(),
+            'data_backups' => $this->backupService->listBackups($backupDir, 'data'),
+            'navidrome_backups' => $this->backupService->listBackups($backupDir, 'navidrome'),
         ]);
+    }
+
+    #[Route('/settings/backups/data/run', name: 'app_settings_backup_run_data', methods: ['POST'])]
+    public function runDataBackup(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('backup-run-data', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $sourcePath = $this->projectDir . '/var/data.db';
+        $backupDir = $this->projectDir . '/var/backups';
+        $retention = $this->dataBackupRetentionDays;
+
+        try {
+            $result = $this->recorder->record(
+                type: RunHistory::TYPE_DB_BACKUP,
+                reference: 'data.db',
+                label: 'Backup DB locale (manuel)',
+                action: function () use ($sourcePath, $backupDir, $retention): array {
+                    $snapshot = $this->backupService->backupSqlite($sourcePath, $backupDir, 'data');
+                    $pruned = $this->backupService->pruneOlderThan($backupDir, 'data', $retention);
+                    return $snapshot + ['pruned' => $pruned];
+                },
+                extractMetrics: static fn (array $r): array => [
+                    'size_bytes' => $r['size'],
+                    'pruned' => $r['pruned'],
+                    'path' => $r['path'],
+                ],
+            );
+            $this->addFlash('success', sprintf(
+                'Sauvegarde créée : %s (%s).',
+                basename($result['path']),
+                $this->formatBytes($result['size']),
+            ));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur de sauvegarde : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_settings');
+    }
+
+    #[Route('/settings/backups/{type}/{name}/download', name: 'app_settings_backup_download', methods: ['GET'], requirements: ['type' => 'data|navidrome', 'name' => '[A-Za-z0-9._-]+'])]
+    public function downloadBackup(string $type, string $name): Response
+    {
+        $path = $this->resolveBackupPath($type, $name);
+        if ($path === null) {
+            throw $this->createNotFoundException();
+        }
+
+        $response = new BinaryFileResponse($path);
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $name,
+        );
+        $response->headers->set('Content-Type', 'application/gzip');
+
+        return $response;
+    }
+
+    #[Route('/settings/backups/{type}/{name}/delete', name: 'app_settings_backup_delete', methods: ['POST'], requirements: ['type' => 'data|navidrome', 'name' => '[A-Za-z0-9._-]+'])]
+    public function deleteBackup(string $type, string $name, Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('backup-delete' . $name, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $path = $this->resolveBackupPath($type, $name);
+        if ($path !== null && @unlink($path)) {
+            $this->addFlash('success', sprintf('Sauvegarde supprimée : %s', $name));
+        } else {
+            $this->addFlash('error', sprintf('Impossible de supprimer la sauvegarde : %s', $name));
+        }
+
+        return $this->redirectToRoute('app_settings');
+    }
+
+    /**
+     * Whitelisted file resolver — refuses any name that doesn't sit
+     * directly in `var/backups/` and doesn't match the prefix-based
+     * pattern emitted by {@see BackupService::backupSqlite()}. Stops
+     * a malicious actor from triggering arbitrary file reads via
+     * `name=../../etc/passwd` even though the route requirement
+     * already filters out slashes.
+     */
+    private function formatBytes(int $bytes): string
+    {
+        if ($bytes < 1024) {
+            return $bytes . ' o';
+        }
+        if ($bytes < 1024 * 1024) {
+            return number_format($bytes / 1024, 1, ',', ' ') . ' Kio';
+        }
+
+        return number_format($bytes / 1024 / 1024, 1, ',', ' ') . ' Mio';
+    }
+
+    private function resolveBackupPath(string $type, string $name): ?string
+    {
+        $backupDir = $this->projectDir . '/var/backups';
+        foreach ($this->backupService->listBackups($backupDir, $type) as $entry) {
+            if ($entry['name'] === $name) {
+                return $entry['path'];
+            }
+        }
+
+        return null;
     }
 }

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -20,6 +20,8 @@ class RunHistory
     public const TYPE_LASTFM_REMATCH = 'lastfm-rematch';
     public const TYPE_NAVIDROME_RESCAN = 'navidrome-rescan';
     public const TYPE_BEETS_QUEUE_PUSH = 'beets-queue-push';
+    public const TYPE_DB_BACKUP = 'db-backup';
+    public const TYPE_NAVIDROME_BACKUP = 'navidrome-backup';
 
     public const STATUS_SUCCESS = 'success';
     public const STATUS_ERROR = 'error';

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Snapshot SQLite databases to gzipped files. Used for both the tool's
+ * own DB (via {@see \App\Command\BackupDataDbCommand}) and the Navidrome
+ * library DB (via {@see \App\Command\BackupNavidromeDbCommand}, with
+ * stop/start of the Navidrome container around it).
+ *
+ * Uses `VACUUM INTO` rather than a raw file copy so the snapshot is :
+ *   - atomic (single SQL statement, no WAL races) ;
+ *   - defragmented (auto-compacted, smaller .db.gz on disk) ;
+ *   - portable (no .db-wal / .db-shm side files to worry about).
+ *
+ * The Alpine image ships neither the `gzip` CLI nor the `sqlite3` CLI,
+ * so we go through PHP zlib + PDO directly.
+ */
+class BackupService
+{
+    /**
+     * Take a gzipped snapshot of $sourcePath into $destinationDir, named
+     * `{$prefix}-{YYYY-MM-DD}-{HHMMSS}.db.gz`. Creates $destinationDir
+     * if missing. Returns `['path' => …, 'size' => bytes]` of the final
+     * gzipped file.
+     *
+     * @return array{path: string, size: int}
+     */
+    public function backupSqlite(string $sourcePath, string $destinationDir, string $prefix): array
+    {
+        if (!is_file($sourcePath)) {
+            throw new \RuntimeException(sprintf('Source SQLite database not found: %s', $sourcePath));
+        }
+        if (!is_readable($sourcePath)) {
+            throw new \RuntimeException(sprintf('Source SQLite database is not readable: %s', $sourcePath));
+        }
+
+        if (!is_dir($destinationDir) && !@mkdir($destinationDir, 0o755, true) && !is_dir($destinationDir)) {
+            throw new \RuntimeException(sprintf('Cannot create backup directory: %s', $destinationDir));
+        }
+
+        $stamp = (new \DateTimeImmutable())->format('Y-m-d-His');
+        $tempPath = rtrim($destinationDir, '/') . '/' . $prefix . '-' . $stamp . '.db';
+        $finalPath = $tempPath . '.gz';
+
+        if (file_exists($tempPath) || file_exists($finalPath)) {
+            throw new \RuntimeException(sprintf('Backup target already exists: %s', $finalPath));
+        }
+
+        // Open the source DB and run VACUUM INTO. The destination path is
+        // interpolated into the SQL (no parameter binding for VACUUM INTO),
+        // so we double single quotes to neutralise any apostrophe.
+        try {
+            $pdo = new \PDO('sqlite:' . $sourcePath, null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            $escaped = str_replace("'", "''", $tempPath);
+            $pdo->exec("VACUUM INTO '" . $escaped . "'");
+            $pdo = null;
+        } catch (\Throwable $e) {
+            // If VACUUM partially wrote the file before failing, clean up.
+            if (file_exists($tempPath)) {
+                @unlink($tempPath);
+            }
+            throw new \RuntimeException(sprintf(
+                'VACUUM INTO failed for %s: %s',
+                $sourcePath,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        try {
+            $this->gzipFile($tempPath, $finalPath);
+        } finally {
+            // The uncompressed snapshot has done its job — we only keep the gz.
+            @unlink($tempPath);
+        }
+
+        $size = (int) @filesize($finalPath);
+        if ($size === 0) {
+            throw new \RuntimeException(sprintf('Backup file is empty: %s', $finalPath));
+        }
+
+        return ['path' => $finalPath, 'size' => $size];
+    }
+
+    /**
+     * List `*.db.gz` files in $directory matching $prefix, newest first.
+     *
+     * @return list<array{path: string, name: string, size: int, mtime: int}>
+     */
+    public function listBackups(string $directory, string $prefix): array
+    {
+        if (!is_dir($directory)) {
+            return [];
+        }
+
+        $entries = [];
+        foreach (glob(rtrim($directory, '/') . '/' . $prefix . '-*.db.gz') ?: [] as $path) {
+            $entries[] = [
+                'path' => $path,
+                'name' => basename($path),
+                'size' => (int) @filesize($path),
+                'mtime' => (int) @filemtime($path),
+            ];
+        }
+
+        usort($entries, static fn (array $a, array $b) => $b['mtime'] <=> $a['mtime']);
+
+        return $entries;
+    }
+
+    /**
+     * Delete backups older than $retentionDays. Returns the number of
+     * files removed. A retention of 0 (or negative) is treated as
+     * « keep forever » — no-op.
+     */
+    public function pruneOlderThan(string $directory, string $prefix, int $retentionDays): int
+    {
+        if ($retentionDays <= 0) {
+            return 0;
+        }
+
+        $cutoff = (new \DateTimeImmutable())->modify('-' . $retentionDays . ' days')->getTimestamp();
+        $deleted = 0;
+        foreach ($this->listBackups($directory, $prefix) as $entry) {
+            if ($entry['mtime'] < $cutoff && @unlink($entry['path'])) {
+                $deleted++;
+            }
+        }
+
+        return $deleted;
+    }
+
+    private function gzipFile(string $source, string $destination): void
+    {
+        $in = @fopen($source, 'rb');
+        if ($in === false) {
+            throw new \RuntimeException(sprintf('Cannot read snapshot file: %s', $source));
+        }
+
+        $gz = @gzopen($destination, 'wb9');
+        if ($gz === false) {
+            fclose($in);
+            throw new \RuntimeException(sprintf('Cannot open gzip target for writing: %s', $destination));
+        }
+
+        try {
+            while (!feof($in)) {
+                $chunk = fread($in, 64 * 1024);
+                if ($chunk === false || $chunk === '') {
+                    break;
+                }
+                $written = gzwrite($gz, $chunk);
+                if ($written === 0 || $written === false) {
+                    throw new \RuntimeException(sprintf('Gzip write failed for %s', $destination));
+                }
+            }
+        } finally {
+            fclose($in);
+            gzclose($gz);
+        }
+    }
+}

--- a/templates/settings/index.html.twig
+++ b/templates/settings/index.html.twig
@@ -32,6 +32,107 @@
         </div>
     </form>
 
+    <div class="bg-white shadow rounded p-6 max-w-3xl mt-6 space-y-4">
+        <h2 class="text-lg font-semibold">Sauvegardes</h2>
+        <p class="text-sm text-slate-500">
+            Snapshots SQLite gzippés via <code>VACUUM INTO</code>, stockés dans <code>var/backups/</code>.
+            Programmables via <code>DB_BACKUP_SCHEDULE</code> et <code>NAVIDROME_BACKUP_SCHEDULE</code>.
+        </p>
+
+        {# Local DB section — synchronous "run now" button #}
+        <div>
+            <div class="flex items-center justify-between mb-2">
+                <h3 class="font-medium text-sm">DB locale (<code>data.db</code>)</h3>
+                <form method="post" action="{{ path('app_settings_backup_run_data') }}">
+                    <input type="hidden" name="_token" value="{{ csrf_token('backup-run-data') }}">
+                    <button type="submit" class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded">Sauvegarder maintenant</button>
+                </form>
+            </div>
+            {% if data_backups is empty %}
+                <p class="text-xs text-slate-500">Aucune sauvegarde pour le moment.</p>
+            {% else %}
+                <table class="w-full text-sm border border-slate-200 rounded">
+                    <thead class="bg-slate-100 text-slate-600 text-xs uppercase">
+                        <tr>
+                            <th class="px-3 py-2 text-left">Fichier</th>
+                            <th class="px-3 py-2 text-right">Taille</th>
+                            <th class="px-3 py-2 text-left">Date</th>
+                            <th class="px-3 py-2 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for b in data_backups %}
+                            <tr class="border-t hover:bg-slate-50">
+                                <td class="px-3 py-2 font-mono text-xs">{{ b.name }}</td>
+                                <td class="px-3 py-2 text-right text-xs text-slate-500">
+                                    {% if b.size < 1024 %}{{ b.size }} o
+                                    {% elseif b.size < 1048576 %}{{ (b.size / 1024)|number_format(1, ',', ' ') }} Kio
+                                    {% else %}{{ (b.size / 1048576)|number_format(1, ',', ' ') }} Mio{% endif %}
+                                </td>
+                                <td class="px-3 py-2 text-xs text-slate-500">{{ b.mtime|date('Y-m-d H:i') }}</td>
+                                <td class="px-3 py-2 text-right space-x-2">
+                                    <a href="{{ path('app_settings_backup_download', {type: 'data', name: b.name}) }}"
+                                       class="text-xs text-sky-700 hover:underline">Télécharger</a>
+                                    <form method="post" action="{{ path('app_settings_backup_delete', {type: 'data', name: b.name}) }}"
+                                          class="inline" onsubmit="return confirm('Supprimer définitivement {{ b.name }} ?');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('backup-delete' ~ b.name) }}">
+                                        <button type="submit" class="text-xs text-rose-600 hover:underline">Supprimer</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </div>
+
+        {# Navidrome DB section — no in-browser button (stop/start takes too long for an HTTP request) #}
+        <div>
+            <h3 class="font-medium text-sm mb-2">DB Navidrome (<code>navidrome.db</code>)</h3>
+            <p class="text-xs text-slate-500 mb-2">
+                À lancer en CLI ou via cron — l'opération arrête puis redémarre Navidrome,
+                trop long pour une requête HTTP synchrone :
+                <code class="text-slate-700">bin/console app:navidrome:backup --auto-stop</code>
+            </p>
+            {% if navidrome_backups is empty %}
+                <p class="text-xs text-slate-500">Aucune sauvegarde pour le moment.</p>
+            {% else %}
+                <table class="w-full text-sm border border-slate-200 rounded">
+                    <thead class="bg-slate-100 text-slate-600 text-xs uppercase">
+                        <tr>
+                            <th class="px-3 py-2 text-left">Fichier</th>
+                            <th class="px-3 py-2 text-right">Taille</th>
+                            <th class="px-3 py-2 text-left">Date</th>
+                            <th class="px-3 py-2 text-right">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for b in navidrome_backups %}
+                            <tr class="border-t hover:bg-slate-50">
+                                <td class="px-3 py-2 font-mono text-xs">{{ b.name }}</td>
+                                <td class="px-3 py-2 text-right text-xs text-slate-500">
+                                    {% if b.size < 1024 %}{{ b.size }} o
+                                    {% elseif b.size < 1048576 %}{{ (b.size / 1024)|number_format(1, ',', ' ') }} Kio
+                                    {% else %}{{ (b.size / 1048576)|number_format(1, ',', ' ') }} Mio{% endif %}
+                                </td>
+                                <td class="px-3 py-2 text-xs text-slate-500">{{ b.mtime|date('Y-m-d H:i') }}</td>
+                                <td class="px-3 py-2 text-right space-x-2">
+                                    <a href="{{ path('app_settings_backup_download', {type: 'navidrome', name: b.name}) }}"
+                                       class="text-xs text-sky-700 hover:underline">Télécharger</a>
+                                    <form method="post" action="{{ path('app_settings_backup_delete', {type: 'navidrome', name: b.name}) }}"
+                                          class="inline" onsubmit="return confirm('Supprimer définitivement {{ b.name }} ?');">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('backup-delete' ~ b.name) }}">
+                                        <button type="submit" class="text-xs text-rose-600 hover:underline">Supprimer</button>
+                                    </form>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </div>
+    </div>
+
     <div class="bg-white shadow rounded p-6 max-w-xl mt-6 space-y-3">
         <h2 class="text-lg font-semibold">Connexion Last.fm authentifiée</h2>
         {% if not lastfm_auth_configured %}

--- a/tests/Service/BackupServiceTest.php
+++ b/tests/Service/BackupServiceTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\BackupService;
+use PHPUnit\Framework\TestCase;
+
+class BackupServiceTest extends TestCase
+{
+    private string $tmpDir;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/backup-service-' . uniqid();
+        mkdir($this->tmpDir);
+    }
+
+    protected function tearDown(): void
+    {
+        // Recursively wipe the temp dir.
+        foreach (glob($this->tmpDir . '/*') ?: [] as $entry) {
+            if (is_dir($entry)) {
+                foreach (glob($entry . '/*') ?: [] as $f) {
+                    @unlink($f);
+                }
+                @rmdir($entry);
+            } else {
+                @unlink($entry);
+            }
+        }
+        @rmdir($this->tmpDir);
+    }
+
+    public function testBackupProducesValidGzippedSqliteFile(): void
+    {
+        $sourcePath = $this->tmpDir . '/source.db';
+        $this->createSampleDb($sourcePath);
+
+        $backupDir = $this->tmpDir . '/backups';
+        $service = new BackupService();
+        $result = $service->backupSqlite($sourcePath, $backupDir, 'data');
+
+        $this->assertFileExists($result['path']);
+        $this->assertGreaterThan(0, $result['size']);
+        $this->assertSame((int) filesize($result['path']), $result['size']);
+        $this->assertMatchesRegularExpression(
+            '~/data-\d{4}-\d{2}-\d{2}-\d{6}\.db\.gz$~',
+            $result['path'],
+        );
+
+        // Decompress and verify the resulting file is a real SQLite DB
+        // with the rows we inserted upstream.
+        $decompressed = $this->tmpDir . '/decompressed.db';
+        $this->gunzip($result['path'], $decompressed);
+
+        $pdo = new \PDO('sqlite:' . $decompressed);
+        $rows = $pdo->query('SELECT name FROM sample ORDER BY id')->fetchAll(\PDO::FETCH_COLUMN);
+        $this->assertSame(['alpha', 'beta'], $rows);
+
+        // The temporary uncompressed snapshot must be cleaned up.
+        $this->assertFileDoesNotExist(substr($result['path'], 0, -3));
+    }
+
+    public function testBackupCreatesDestinationDirIfMissing(): void
+    {
+        $sourcePath = $this->tmpDir . '/source.db';
+        $this->createSampleDb($sourcePath);
+
+        $backupDir = $this->tmpDir . '/nested/dir/backups';
+        $this->assertDirectoryDoesNotExist($backupDir);
+
+        $service = new BackupService();
+        $service->backupSqlite($sourcePath, $backupDir, 'data');
+
+        $this->assertDirectoryExists($backupDir);
+    }
+
+    public function testBackupRejectsMissingSource(): void
+    {
+        $service = new BackupService();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Source SQLite database not found/');
+        $service->backupSqlite($this->tmpDir . '/missing.db', $this->tmpDir, 'data');
+    }
+
+    public function testListBackupsSortsByMtimeDescAndIgnoresUnrelatedFiles(): void
+    {
+        $backupDir = $this->tmpDir . '/backups';
+        mkdir($backupDir);
+
+        $oldFile = $backupDir . '/data-2025-01-01-000000.db.gz';
+        $newFile = $backupDir . '/data-2026-05-03-120000.db.gz';
+        $other = $backupDir . '/navidrome-2026-05-03-120000.db.gz';
+        $stranger = $backupDir . '/random.txt';
+
+        file_put_contents($oldFile, "\x1f\x8b old");
+        file_put_contents($newFile, "\x1f\x8b new");
+        file_put_contents($other, "\x1f\x8b nav");
+        file_put_contents($stranger, 'noise');
+        // Touch mtimes explicitly so the test isn't time-of-day dependent.
+        touch($oldFile, 1_700_000_000);
+        touch($newFile, 1_750_000_000);
+        touch($other, 1_750_000_000);
+
+        $service = new BackupService();
+        $entries = $service->listBackups($backupDir, 'data');
+
+        $this->assertCount(2, $entries);
+        $this->assertSame(basename($newFile), $entries[0]['name']);
+        $this->assertSame(basename($oldFile), $entries[1]['name']);
+    }
+
+    public function testPruneOlderThanDeletesExpiredFilesOnly(): void
+    {
+        $backupDir = $this->tmpDir . '/backups';
+        mkdir($backupDir);
+
+        $old = $backupDir . '/data-2024-01-01-000000.db.gz';
+        $recent = $backupDir . '/data-2026-04-30-000000.db.gz';
+        $unrelated = $backupDir . '/navidrome-2024-01-01-000000.db.gz';
+
+        file_put_contents($old, 'x');
+        file_put_contents($recent, 'x');
+        file_put_contents($unrelated, 'x');
+        // 90 days ago = ~7_776_000s ; pin both old files to ~1 year ago.
+        touch($old, time() - 365 * 86400);
+        touch($unrelated, time() - 365 * 86400);
+        touch($recent, time() - 3 * 86400);
+
+        $service = new BackupService();
+        $deleted = $service->pruneOlderThan($backupDir, 'data', 30);
+
+        $this->assertSame(1, $deleted);
+        $this->assertFileDoesNotExist($old);
+        $this->assertFileExists($recent);
+        // pruneOlderThan must never touch files of a different prefix.
+        $this->assertFileExists($unrelated);
+    }
+
+    public function testPruneOlderThanWithZeroRetentionIsNoop(): void
+    {
+        $backupDir = $this->tmpDir . '/backups';
+        mkdir($backupDir);
+        $f = $backupDir . '/data-2020-01-01-000000.db.gz';
+        file_put_contents($f, 'x');
+        touch($f, 1);
+
+        $service = new BackupService();
+        $this->assertSame(0, $service->pruneOlderThan($backupDir, 'data', 0));
+        $this->assertFileExists($f);
+    }
+
+    private function createSampleDb(string $path): void
+    {
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo->exec('CREATE TABLE sample (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo->exec("INSERT INTO sample (name) VALUES ('alpha'), ('beta')");
+    }
+
+    private function gunzip(string $source, string $destination): void
+    {
+        $in = gzopen($source, 'rb');
+        $out = fopen($destination, 'wb');
+        while (!gzeof($in)) {
+            fwrite($out, gzread($in, 64 * 1024));
+        }
+        fclose($out);
+        gzclose($in);
+    }
+}


### PR DESCRIPTION
## Summary

Snapshots SQLite gzippés (VACUUM INTO + PHP zlib) dans `var/backups/`. Deux commandes parallèles partageant un `BackupService`, retention par prefix, trace `RunHistory`, UI dans `/settings`.

### DB locale (`data.db`) — closes #95

- **`app:db:backup`** — sûr à lancer pendant que l'app tourne (Doctrine SQLite gère la concurrence). Cron via `DB_BACKUP_SCHEDULE`.
- **Bouton « Sauvegarder maintenant »** sur `/settings` (sub-seconde, HTTP-safe).

### DB Navidrome (`navidrome.db`) — closes #119

- **`app:navidrome:backup`** avec `--auto-stop` qui orchestre stop Navidrome → backup → restart (try/finally — restart toujours, même en cas d'erreur du snapshot) via `NavidromeContainerManager::runWithNavidromeStopped()`. Sans `--auto-stop`, pré-flight bloquant ; `--force` pour outrepasser.
- Cron via `NAVIDROME_BACKUP_SCHEDULE` — la ligne générée par `app:cron:dump` ajoute automatiquement `--auto-stop` quand `NAVIDROME_CONTAINER_NAME` est renseigné (mirror de `app:lastfm:rematch`).
- **Pas de bouton run-now côté UI** — un stop/start prend 30-60s minimum, pas adapté à HTTP synchrone. Instruction CLI affichée sur `/settings` à la place.

### Retention

- `DB_BACKUP_RETENTION_DAYS` (défaut 30)
- `NAVIDROME_BACKUP_RETENTION_DAYS` (défaut 30)
- `0` = ne purge jamais. Purge appliquée en fin de chaque run.

### UI

Section « Sauvegardes » sur `/settings` : table par fichier (nom, taille, date), boutons Télécharger (BinaryFileResponse + attachment) et Supprimer (CSRF par-fichier).

### Hors-scope

- **Restauration** : destructive, demande de fermer les connexions DB. Documentée dans le README comme procédure manuelle. Une commande `app:db:restore` viendra avec #37.
- **Backup vers cloud** : à laisser à un script externe sur le volume monté (cohérent avec la position de #95 / #37).

## Test plan

- [x] `vendor/bin/phpunit` → **345 tests / 896 assertions** OK (6 nouveaux tests `BackupServiceTest`).
- [x] `vendor/bin/phpcs` → **180/180** clean.
- [x] `vendor/bin/phpstan analyse src/Service src/Command src/Controller src/Entity tests/Service` → no errors.
- [x] `bin/console lint:twig templates` → **33/33** OK.
- [x] **Test manuel CLI** sur Lando :
   - `bin/console app:db:backup` → 5,66 Mio → 1,3 Mio gzippés (×4 compression).
   - `bin/console app:navidrome:backup --force` → 131 Mio → 28,8 Mio gzippés.
   - `bin/console app:cron:dump` avec les schedules : lignes cron émises pour les deux commandes.
   - Décompression du `.db.gz` produit un fichier SQLite valide (`SQLite format 3` magic).
- [x] **Test manuel UI** sur Lando :
   - GET `/settings` → section « Sauvegardes » rendue avec table vide.
   - POST `/settings/backups/data/run` → flash success + fichier `data-YYYY-MM-DD-HHMMSS.db.gz` apparaît.
   - GET `/settings/backups/data/{name}/download` → renvoie le binaire gzip avec `Content-Disposition: attachment`.
- [ ] **Test manuel sur stack docker-compose réelle** (à valider en review) :
   - Activer `DB_BACKUP_SCHEDULE='*/5 * * * *'` → vérifier qu'un fichier apparaît toutes les 5 min.
   - Activer `NAVIDROME_BACKUP_SCHEDULE='0 4 * * *'` + `NAVIDROME_CONTAINER_NAME=navidrome` + mount Docker socket → vérifier la ligne cron générée et le cycle stop/backup/restart.
   - Permissions du volume `playlist-data` : le dossier `/app/var/backups` doit être writable par www-data (sur le Lando il a fallu `chown` parce que les CLI runs root l'avaient créé en root — bug de fixture, non-issue en prod où la commande tourne dans le même conteneur que l'app).

## Variables d'env ajoutées

| Variable | Défaut | Rôle |
|----------|--------|------|
| `DB_BACKUP_SCHEDULE` | (vide) | Cron expr `app:db:backup` |
| `DB_BACKUP_RETENTION_DAYS` | 30 | Retention data backups (0 = jamais) |
| `NAVIDROME_BACKUP_SCHEDULE` | (vide) | Cron expr `app:navidrome:backup` |
| `NAVIDROME_BACKUP_RETENTION_DAYS` | 30 | Retention navidrome backups (0 = jamais) |

Déclarées dans les 5 endroits canoniques + `config/services.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)