### PR TITLE
fix(docker): empêcher la corruption SQLite Navidrome lors de --auto-stop

### DIFF
--- a/.env
+++ b/.env
@@ -56,6 +56,21 @@ LIDARR_MONITOR=all
 # bypass). Requires the host Docker socket to be mounted into this
 # container — see docker-compose.example.yml.
 NAVIDROME_CONTAINER_NAME=
+# Seconds Docker waits for Navidrome to gracefully shutdown after SIGTERM
+# before sending SIGKILL. The default 60s gives SQLite plenty of time to
+# checkpoint its WAL on a large library — keeping Docker's own 10s default
+# would risk a SIGKILL mid-flush and corrupt navidrome.db (see #118).
+NAVIDROME_STOP_TIMEOUT_SECONDS=60
+# Extra ceiling (in seconds) we then poll `docker inspect` after stop, in
+# case Navidrome stalls during shutdown. We refuse to write to the DB
+# while inspect still reports Running=true — corruption-safer than
+# trusting `docker stop`'s exit code alone.
+NAVIDROME_STOP_WAIT_CEILING_SECONDS=30
+# Number of `<navidrome.db>.backup-<ts>` snapshots to keep. The
+# --auto-stop pipeline copies the DB (+ wal/shm siblings) before any
+# write, so a `cp` is enough to roll back. Older backups beyond this
+# count are auto-pruned. 0 = keep all.
+NAVIDROME_DB_BACKUP_RETENTION=3
 ###< Navidrome container management ###
 
 ###> Run history retention ###

--- a/.env.dist
+++ b/.env.dist
@@ -57,6 +57,21 @@ LIDARR_MONITOR=all
 # bypass). Requires the host Docker socket to be mounted into this
 # container — see docker-compose.example.yml.
 NAVIDROME_CONTAINER_NAME=
+# Seconds Docker waits for Navidrome to gracefully shutdown after SIGTERM
+# before sending SIGKILL. The default 60s gives SQLite plenty of time to
+# checkpoint its WAL on a large library — keeping Docker's own 10s default
+# would risk a SIGKILL mid-flush and corrupt navidrome.db (see #118).
+NAVIDROME_STOP_TIMEOUT_SECONDS=60
+# Extra ceiling (in seconds) we then poll `docker inspect` after stop, in
+# case Navidrome stalls during shutdown. We refuse to write to the DB
+# while inspect still reports Running=true — corruption-safer than
+# trusting `docker stop`'s exit code alone.
+NAVIDROME_STOP_WAIT_CEILING_SECONDS=30
+# Number of `<navidrome.db>.backup-<ts>` snapshots to keep. The
+# --auto-stop pipeline copies the DB (+ wal/shm siblings) before any
+# write, so a `cp` is enough to roll back. Older backups beyond this
+# count are auto-pruned. 0 = keep all.
+NAVIDROME_DB_BACKUP_RETENTION=3
 ###< Navidrome container management ###
 
 ###> Run history retention ###

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -42,6 +42,17 @@ services:
         # Set to your Navidrome container name to enable the dashboard
         # card + start/stop buttons (requires Docker socket mount).
         NAVIDROME_CONTAINER_NAME: ''
+        # Graceful shutdown window for `docker stop` before SIGKILL — must
+        # comfortably outlast Navidrome's WAL checkpoint to avoid SQLite
+        # corruption on --auto-stop runs.
+        NAVIDROME_STOP_TIMEOUT_SECONDS: '60'
+        # After docker stop returns, we still poll docker inspect for up to
+        # this long until Running=false, before letting any write touch
+        # the DB. Belt and braces.
+        NAVIDROME_STOP_WAIT_CEILING_SECONDS: '30'
+        # How many <db>.backup-<ts> snapshots to keep — backups are taken
+        # automatically before any --auto-stop write so a `cp` rolls back.
+        NAVIDROME_DB_BACKUP_RETENTION: '3'
         RUN_HISTORY_RETENTION_DAYS: '90'
         # File de chemins consommée par un beets externe (cron côté hôte
         # qui partage le même volume). Vide = bouton « pousser dans la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,30 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   (desktop + mobile).
 
 ### Fixed
+- **`--auto-stop` corrompait la DB SQLite Navidrome après un import lourd** :
+  `DockerCli::stop()` envoyait un `docker stop -t 10` (timeout codé en
+  dur 10s, hérité du défaut Docker). Pas assez pour que Navidrome
+  termine son checkpoint WAL sur une grosse librairie après une rafale
+  d'écritures (~13k scrobbles insérés en un run) — Docker basculait sur
+  SIGKILL en plein flush, laissant un `.db-wal` mi-écrit. Le pipeline
+  enchaînait ensuite directement avec `$action()` (l'`import`) sans
+  poller `docker inspect` pour confirmer l'arrêt, ouvrait la DB en
+  écriture et la corrompait.
+
+  Défense en profondeur dans `NavidromeContainerManager::runWithNavidromeStopped()` :
+  1. timeout `docker stop` configurable via `NAVIDROME_STOP_TIMEOUT_SECONDS`
+     (défaut 60s, contre 10s avant) ;
+  2. polling de `docker inspect` jusqu'à `Running:false` (ceiling
+     `NAVIDROME_STOP_WAIT_CEILING_SECONDS`, défaut 30s) — on n'écrira
+     jamais sur la DB tant que `inspect` voit Navidrome vivant ;
+  3. snapshot de la DB SQLite (+ siblings `-wal` / `-shm`) vers
+     `<dbPath>.backup-<unix_ts>` avant l'action — rollback trivial
+     en `cp`. Rétention configurable via `NAVIDROME_DB_BACKUP_RETENTION`
+     (défaut 3) ;
+  4. `PRAGMA quick_check` avant l'action — si la DB est déjà brisée
+     (résidu d'un crash antérieur), on abandonne sans aggraver et
+     l'utilisateur reçoit un message explicite. Implémenté par le
+     nouveau service `App\Navidrome\NavidromeDbBackup`. Closes #118.
 - **`Last.fm API error 6: Track not found` interrompait l'import** : à
   l'étape 7 de la cascade de matching, `ScrobbleMatcher` appelle
   `LastFmClient::trackGetInfo()` pour les scrobbles non matchés

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,20 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
     démarrage avec `[emerg] open() failed`, et Traefik renvoie un
     `404 page not found` text/plain qui ressemble à un "page
     inexistante" mais c'est en fait l'app qui ne tourne pas).
+12. **`docker stop -t 10` SIGKILLait Navidrome en plein checkpoint WAL
+    SQLite** = `navidrome.db` corrompue après un `--auto-stop` sur une
+    grosse librairie (cf. #118). Le manager respecte désormais quatre
+    couches avant chaque action : (a) `NAVIDROME_STOP_TIMEOUT_SECONDS`
+    (défaut 60s, cf. `DockerCli::stop()`) ; (b) polling de `docker
+    inspect` jusqu'à `Running:false` (`waitUntilStopped`) — on n'écrit
+    JAMAIS pendant que Navidrome tourne, même si `docker stop` a rendu
+    la main avec exit 0 ; (c) snapshot
+    `<dbPath>.backup-<unix_ts>` via `App\Navidrome\NavidromeDbBackup`,
+    rétention `NAVIDROME_DB_BACKUP_RETENTION` ; (d) `PRAGMA quick_check`
+    avant l'action — si la DB est déjà brisée on bloque l'écriture
+    pour ne pas aggraver. Si tu réintroduis un appel à `runProcess`
+    pour stop/start ailleurs, **passe par `NavidromeContainerManager`**
+    sinon tu by-passes les 4 garde-fous.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ pouvez les éditer puis les activer.
 | `CRON_REGEN_INTERVAL`| non (`300`) | Intervalle en secondes entre 2 régénérations du crontab (mode cron).     |
 | `COVERS_CACHE_PATH`  | non         | Cache disque des miniatures album/artiste. Défaut : `/app/var/covers` (volume Docker dédié dans le compose). |
 | `NAVIDROME_CONTAINER_NAME` | non   | Nom du conteneur Navidrome dans la même stack docker-compose. Quand renseigné, le dashboard affiche un statut UP/DOWN avec boutons Start/Stop, et les commandes d'import refusent de tourner si Navidrome est détecté UP (`--force` pour outrepasser). Requiert le mount `/var/run/docker.sock` (cf. `docker-compose.example.yml`). |
+| `NAVIDROME_STOP_TIMEOUT_SECONDS` | non (`60`) | Fenêtre de shutdown gracieux passée à `docker stop -t` lorsqu'on arrête Navidrome via `--auto-stop`. Doit confortablement excéder le checkpoint WAL SQLite — le défaut Docker (10s) suffit pour un Navidrome inactif mais peut SIGKILL en plein flush sur une grosse librairie après un import lourd, et corrompre `navidrome.db` (cf. #118). |
+| `NAVIDROME_STOP_WAIT_CEILING_SECONDS` | non (`30`) | Après `docker stop`, on poll encore `docker inspect` jusqu'à ce que `Running=false`, plafonné à cette durée. On refuse d'écrire dans la DB tant qu'`inspect` voit Navidrome vivant — ceinture-bretelles contre un SIGTERM handler qui traîne. |
+| `NAVIDROME_DB_BACKUP_RETENTION` | non (`3`) | Nombre de snapshots `<navidrome.db>.backup-<unix_ts>` conservés. Avant chaque action `--auto-stop`, le tool copie automatiquement la DB SQLite (et ses siblings `-wal` / `-shm`) — un simple `cp` rétablit l'état précédent. `0` = pas de purge. |
 | `HOMEPAGE_API_TOKEN` | non       | Bearer token pour le widget [Homepage](https://gethomepage.dev/widgets/services/customapi/) sur l'endpoint `/api/status`. Vide = mode enrichi désactivé (seul le mode healthcheck no-auth est servi). Voir la section [Widget Homepage](#widget-homepage-gethomepage). |
 
 ### Mise à jour
@@ -406,6 +409,23 @@ la variable d'environnement `LASTFM_API_KEY`. De même, le username peut
 - Sous Lando : `lando symfony app:lastfm:import myuser --api-key=...`
   fonctionne directement (la DB Navidrome bind-mountée est en RW par
   défaut).
+
+> **Backup automatique avant chaque écriture.** Quand vous lancez
+> `app:lastfm:import --auto-stop` ou `app:lastfm:rematch --auto-stop`,
+> le tool snapshote `navidrome.db` (+ siblings `-wal`/`-shm`) en
+> `<dbPath>.backup-<unix_ts>` **avant** d'écrire. Rétention configurable
+> via `NAVIDROME_DB_BACKUP_RETENTION` (défaut 3 snapshots). Si quoi que
+> ce soit tourne mal et que Navidrome refuse de redémarrer, restauration
+> en une commande :
+>
+> ```bash
+> # Lister les backups disponibles (du plus ancien au plus récent)
+> ls -lh /srv/navidrome/data/navidrome.db.backup-*
+>
+> # Rollback : remplacer la DB par le dernier backup connu sain
+> cp /srv/navidrome/data/navidrome.db.backup-<unix_ts> /srv/navidrome/data/navidrome.db
+> docker compose start navidrome
+> ```
 
 ### Exemples
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,9 @@ parameters:
     lidarr.metadata_profile_id: '%env(int:LIDARR_METADATA_PROFILE_ID)%'
     lidarr.monitor: '%env(LIDARR_MONITOR)%'
     navidrome.container_name: '%env(NAVIDROME_CONTAINER_NAME)%'
+    navidrome.container_stop_timeout: '%env(int:NAVIDROME_STOP_TIMEOUT_SECONDS)%'
+    navidrome.container_stop_wait_ceiling: '%env(int:NAVIDROME_STOP_WAIT_CEILING_SECONDS)%'
+    navidrome.db_backup_retention: '%env(int:NAVIDROME_DB_BACKUP_RETENTION)%'
     app.homepage_api_token: '%env(HOMEPAGE_API_TOKEN)%'
 
 services:
@@ -89,6 +92,13 @@ services:
     App\Docker\NavidromeContainerConfig:
         arguments:
             $containerName: '%navidrome.container_name%'
+            $stopTimeoutSeconds: '%navidrome.container_stop_timeout%'
+            $stopWaitCeilingSeconds: '%navidrome.container_stop_wait_ceiling%'
+
+    App\Navidrome\NavidromeDbBackup:
+        arguments:
+            $dbPath: '%navidrome.db_path%'
+            $retention: '%navidrome.db_backup_retention%'
 
     App\Controller\LastFmImportController:
         arguments:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -29,6 +29,17 @@ services:
       # `container_name: navidrome` in your compose file). Don't forget
       # to also mount /var/run/docker.sock below.
       NAVIDROME_CONTAINER_NAME: ${NAVIDROME_CONTAINER_NAME:-}
+      # Graceful shutdown window (s) for `docker stop` before SIGKILL —
+      # too short = WAL not checkpointed = corrupt navidrome.db on
+      # --auto-stop. 60s is comfortable for a 100k-track library.
+      NAVIDROME_STOP_TIMEOUT_SECONDS: ${NAVIDROME_STOP_TIMEOUT_SECONDS:-60}
+      # Extra ceiling polling docker inspect after stop, refusing to
+      # write while Running=true. Belt-and-braces against a stalled
+      # SIGTERM handler.
+      NAVIDROME_STOP_WAIT_CEILING_SECONDS: ${NAVIDROME_STOP_WAIT_CEILING_SECONDS:-30}
+      # Number of <db>.backup-<ts> snapshots retained — taken auto
+      # before any --auto-stop write so a `cp` rolls back trivially.
+      NAVIDROME_DB_BACKUP_RETENTION: ${NAVIDROME_DB_BACKUP_RETENTION:-3}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
       # File de chemins consommée par un beets externe (cron côté hôte
       # qui partage le même volume). Vide = bouton masqué sur
@@ -87,6 +98,9 @@ services:
       LIDARR_METADATA_PROFILE_ID: ${LIDARR_METADATA_PROFILE_ID:-1}
       LIDARR_MONITOR: ${LIDARR_MONITOR:-all}
       NAVIDROME_CONTAINER_NAME: ${NAVIDROME_CONTAINER_NAME:-}
+      NAVIDROME_STOP_TIMEOUT_SECONDS: ${NAVIDROME_STOP_TIMEOUT_SECONDS:-60}
+      NAVIDROME_STOP_WAIT_CEILING_SECONDS: ${NAVIDROME_STOP_WAIT_CEILING_SECONDS:-30}
+      NAVIDROME_DB_BACKUP_RETENTION: ${NAVIDROME_DB_BACKUP_RETENTION:-3}
       RUN_HISTORY_RETENTION_DAYS: ${RUN_HISTORY_RETENTION_DAYS:-90}
       # File de chemins consommée par un beets externe (cron côté hôte
       # qui partage le même volume). Vide = bouton masqué sur

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,6 +27,9 @@
         <env name="LIDARR_METADATA_PROFILE_ID" value="1"/>
         <env name="LIDARR_MONITOR" value="all"/>
         <env name="NAVIDROME_CONTAINER_NAME" value=""/>
+        <env name="NAVIDROME_STOP_TIMEOUT_SECONDS" value="60"/>
+        <env name="NAVIDROME_STOP_WAIT_CEILING_SECONDS" value="30"/>
+        <env name="NAVIDROME_DB_BACKUP_RETENTION" value="3"/>
         <env name="RUN_HISTORY_RETENTION_DAYS" value="90"/>
         <env name="BEETS_QUEUE_PATH" value=""/>
         <env name="LASTFM_API_KEY" value=""/>

--- a/src/Docker/NavidromeContainerConfig.php
+++ b/src/Docker/NavidromeContainerConfig.php
@@ -6,6 +6,8 @@ final class NavidromeContainerConfig
 {
     public function __construct(
         public readonly string $containerName,
+        public readonly int $stopTimeoutSeconds = 60,
+        public readonly int $stopWaitCeilingSeconds = 30,
     ) {
     }
 

--- a/src/Docker/NavidromeContainerManager.php
+++ b/src/Docker/NavidromeContainerManager.php
@@ -2,11 +2,14 @@
 
 namespace App\Docker;
 
+use App\Navidrome\NavidromeDbBackup;
+
 class NavidromeContainerManager
 {
     public function __construct(
         private readonly DockerCli $cli,
         private readonly NavidromeContainerConfig $config,
+        private readonly NavidromeDbBackup $backup,
     ) {
     }
 
@@ -52,7 +55,7 @@ class NavidromeContainerManager
         if (!$this->config->isConfigured()) {
             throw new NavidromeContainerException('NAVIDROME_CONTAINER_NAME n\'est pas renseignée.');
         }
-        $this->cli->stop($this->config->containerName);
+        $this->cli->stop($this->config->containerName, $this->config->stopTimeoutSeconds);
     }
 
     /**
@@ -96,10 +99,26 @@ class NavidromeContainerManager
      * we stopped it ourselves. Restart happens in a finally-equivalent
      * block, so an action that throws still leaves Navidrome running.
      *
-     * - Feature disabled (`NAVIDROME_CONTAINER_NAME` empty) → run as-is.
-     * - Status `Stopped` / `NotFound` → run as-is, don't try to restart
-     *   something we didn't stop.
-     * - Status `Running` → stop, run, restart (always).
+     * Defense in depth before $action() touches the DB:
+     *  1. `docker stop -t <NAVIDROME_STOP_TIMEOUT_SECONDS>` — long enough
+     *     for Navidrome's SQLite WAL to checkpoint cleanly (default 60s,
+     *     vs Docker's 10s default which used to SIGKILL mid-flush and
+     *     leave a half-written WAL — the corruption pattern from #118).
+     *  2. Poll `docker inspect` until Running=false — we never trust
+     *     `docker stop` returning success alone.
+     *  3. Snapshot the SQLite file (and its `-wal`/`-shm` siblings) to
+     *     `<dbPath>.backup-<ts>` so any future write that goes wrong is
+     *     recoverable with a single `cp`. Last 3 by default (configurable).
+     *  4. `PRAGMA quick_check` — if the DB is already broken (e.g. from
+     *     a previous bad shutdown) we abort before writing into it and
+     *     making it worse.
+     *
+     * - Feature disabled (`NAVIDROME_CONTAINER_NAME` empty) → run as-is,
+     *   skip all the above (we don't know the DB lifecycle).
+     * - Status `Stopped` / `NotFound` → still backup + quickCheck before
+     *   the action (same risk profile), but don't restart something we
+     *   didn't stop.
+     * - Status `Running` → stop, wait, backup, check, run, restart (always).
      * - Status `Unknown` → throw, since we can't safely orchestrate
      *   stop/start without confirming current state.
      *
@@ -124,35 +143,44 @@ class NavidromeContainerManager
             ));
         }
 
-        if ($status !== ContainerStatus::Running) {
-            return $action();
+        $weStoppedIt = false;
+        if ($status === ContainerStatus::Running) {
+            $this->stop();
+            $weStoppedIt = true;
+            $this->waitUntilStopped($this->config->stopWaitCeilingSeconds);
         }
 
-        $this->stop();
+        // Backup + quick_check apply whether we stopped Navidrome ourselves
+        // or it was already down — either way we're about to mutate the
+        // file and we want a rollback artefact + a sanity check first.
+        $this->backup->backup();
 
         $actionException = null;
         $result = null;
         try {
+            $this->backup->quickCheck();
             $result = $action();
         } catch (\Throwable $e) {
             $actionException = $e;
         }
 
-        try {
-            $this->start();
-        } catch (\Throwable $startException) {
-            if ($actionException !== null) {
-                throw new NavidromeContainerException(
-                    sprintf(
-                        '%s — et le redémarrage du conteneur Navidrome a aussi échoué : %s',
-                        $actionException->getMessage(),
-                        $startException->getMessage(),
-                    ),
-                    0,
-                    $actionException,
-                );
+        if ($weStoppedIt) {
+            try {
+                $this->start();
+            } catch (\Throwable $startException) {
+                if ($actionException !== null) {
+                    throw new NavidromeContainerException(
+                        sprintf(
+                            '%s — et le redémarrage du conteneur Navidrome a aussi échoué : %s',
+                            $actionException->getMessage(),
+                            $startException->getMessage(),
+                        ),
+                        0,
+                        $actionException,
+                    );
+                }
+                throw $startException;
             }
-            throw $startException;
         }
 
         if ($actionException !== null) {
@@ -160,5 +188,44 @@ class NavidromeContainerManager
         }
 
         return $result;
+    }
+
+    /**
+     * Block until `docker inspect` reports Running=false, or the ceiling
+     * (in seconds) is reached. The first probe runs immediately so a
+     * cleanly-stopped container exits without a sleep ; subsequent probes
+     * are spaced 500ms apart. Throws on ceiling so the caller never
+     * proceeds to write while Navidrome is still alive.
+     */
+    private function waitUntilStopped(int $maxSeconds): void
+    {
+        $deadline = microtime(true) + max(1, $maxSeconds);
+
+        while (true) {
+            try {
+                $state = $this->cli->inspectState($this->config->containerName);
+            } catch (NavidromeContainerException $e) {
+                throw new NavidromeContainerException(sprintf(
+                    'Impossible de confirmer l\'arrêt du conteneur Navidrome « %s » : %s. Abandon avant écriture pour éviter la corruption.',
+                    $this->config->containerName,
+                    $e->getMessage(),
+                ), 0, $e);
+            }
+
+            // null = container vanished (compose down) ; Running:false = stopped.
+            if ($state === null || ($state['Running'] ?? null) !== true) {
+                return;
+            }
+
+            if (microtime(true) >= $deadline) {
+                throw new NavidromeContainerException(sprintf(
+                    'Le conteneur Navidrome « %s » est toujours en cours %ds après `docker stop`. Abandon avant écriture pour éviter la corruption SQLite.',
+                    $this->config->containerName,
+                    $maxSeconds,
+                ));
+            }
+
+            usleep(500_000);
+        }
     }
 }

--- a/src/Navidrome/NavidromeDbBackup.php
+++ b/src/Navidrome/NavidromeDbBackup.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Navidrome;
+
+/**
+ * Safety net around the Navidrome SQLite file. Two responsibilities:
+ *
+ *  1. {@see backup()} copies `<dbPath>` (and its `-wal` / `-shm` siblings
+ *     when present) to `<dbPath>.backup-<unix_ts>` just before any
+ *     write-mutating operation (`app:lastfm:import --auto-stop`, etc.).
+ *     Old backups beyond `$retention` are pruned.
+ *  2. {@see quickCheck()} opens the file SQLite read-only and runs
+ *     `PRAGMA quick_check` — a lightweight structural sanity test that
+ *     catches a half-flushed WAL or a SIGKILL-truncated header *before*
+ *     we open the DB for writes (which would aggravate the corruption).
+ *
+ * Only used by `NavidromeContainerManager::runWithNavidromeStopped()` so
+ * far. Not a Doctrine connection: stays out of the DBAL UDF setup
+ * (`np_normalize`) so it can run on a potentially broken file without
+ * dragging the whole repository's machinery in.
+ */
+class NavidromeDbBackup
+{
+    public function __construct(
+        private readonly string $dbPath,
+        private readonly int $retention = 3,
+    ) {
+    }
+
+    /**
+     * Returns the path of the backup just created, or null when the source
+     * file does not exist (Navidrome never started, fresh install — the
+     * caller can decide to skip rather than fail).
+     */
+    public function backup(): ?string
+    {
+        if (!is_file($this->dbPath)) {
+            return null;
+        }
+
+        $timestamp = (new \DateTimeImmutable())->format('YmdHis');
+        $target = $this->dbPath . '.backup-' . $timestamp;
+
+        $this->copyAtomic($this->dbPath, $target);
+        // Copy WAL/SHM siblings so the restore replicates the *exact* state
+        // SQLite was in. Missing siblings = clean DB, nothing to copy.
+        foreach (['-wal', '-shm'] as $suffix) {
+            $sibling = $this->dbPath . $suffix;
+            if (is_file($sibling)) {
+                $this->copyAtomic($sibling, $target . $suffix);
+            }
+        }
+
+        $this->prune();
+
+        return $target;
+    }
+
+    /**
+     * Throws when the SQLite file fails the structural sanity test.
+     * No-op when the file is missing (treated as « nothing to check »).
+     */
+    public function quickCheck(): void
+    {
+        if (!is_file($this->dbPath)) {
+            return;
+        }
+
+        try {
+            $pdo = new \PDO('sqlite:' . $this->dbPath, null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            // Read-only intent: SQLite still mounts the WAL on open and
+            // recovers any clean-but-unmerged frames, which is desirable
+            // here (this is also how we « heal » a soft-stop residue).
+            $stmt = $pdo->query('PRAGMA quick_check');
+            $result = $stmt !== false ? $stmt->fetchColumn() : false;
+        } catch (\PDOException $e) {
+            throw new \RuntimeException(sprintf(
+                'La base SQLite Navidrome (%s) est illisible : %s. Restaurez un backup avant toute écriture.',
+                $this->dbPath,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        if ($result !== 'ok') {
+            throw new \RuntimeException(sprintf(
+                'PRAGMA quick_check a échoué sur %s : « %s ». La DB est corrompue, on bloque l\'écriture pour ne pas aggraver. Restaurez un backup.',
+                $this->dbPath,
+                is_string($result) ? $result : 'résultat inattendu',
+            ));
+        }
+    }
+
+    /**
+     * @return list<string> backup paths sorted from oldest to newest
+     */
+    public function listBackups(): array
+    {
+        $matches = glob($this->dbPath . '.backup-*') ?: [];
+        // Drop the -wal / -shm siblings — we only want the main backup files
+        // for retention bookkeeping.
+        $main = array_values(array_filter(
+            $matches,
+            static fn (string $p): bool => preg_match('/\.backup-\d+$/', $p) === 1,
+        ));
+        sort($main);
+
+        return $main;
+    }
+
+    private function prune(): void
+    {
+        if ($this->retention <= 0) {
+            return;
+        }
+
+        $backups = $this->listBackups();
+        $excess = count($backups) - $this->retention;
+        if ($excess <= 0) {
+            return;
+        }
+
+        foreach (array_slice($backups, 0, $excess) as $stale) {
+            @unlink($stale);
+            @unlink($stale . '-wal');
+            @unlink($stale . '-shm');
+        }
+    }
+
+    private function copyAtomic(string $source, string $target): void
+    {
+        $tmp = $target . '.tmp';
+        if (!@copy($source, $tmp)) {
+            throw new \RuntimeException(sprintf('Backup impossible : copie %s → %s a échoué.', $source, $tmp));
+        }
+        if (!@rename($tmp, $target)) {
+            @unlink($tmp);
+            throw new \RuntimeException(sprintf('Backup impossible : rename %s → %s a échoué.', $tmp, $target));
+        }
+    }
+}

--- a/tests/Docker/FakeDockerCli.php
+++ b/tests/Docker/FakeDockerCli.php
@@ -25,6 +25,23 @@ final class FakeDockerCli extends DockerCli
     public bool $stopShouldFail = false;
 
     /**
+     * Last `timeoutSeconds` value passed to {@see stop()} — lets tests
+     * assert that the container manager is forwarding the configured
+     * graceful-shutdown window to `docker stop -t`.
+     */
+    public ?int $lastStopTimeout = null;
+
+    /**
+     * When non-null, simulates a slow-shutdown container : `stop()` does
+     * not flip `Running` to false immediately. Instead, the next N calls
+     * to `inspectState()` keep returning Running=true (counter
+     * decremented each call), and the (N+1)th call flips it. Useful to
+     * exercise the polling loop in `runWithNavidromeStopped()`. Set to
+     * a very large number to simulate a Navidrome that never stops.
+     */
+    private ?int $inspectsRemainingBeforeStopped = null;
+
+    /**
      * @param array<string, mixed>|null $state
      */
     public function __construct(
@@ -38,6 +55,15 @@ final class FakeDockerCli extends DockerCli
     {
         if ($this->throwOnInspect !== null) {
             throw new NavidromeContainerException($this->throwOnInspect);
+        }
+
+        if ($this->inspectsRemainingBeforeStopped !== null && $this->state !== null) {
+            if ($this->inspectsRemainingBeforeStopped > 0) {
+                $this->inspectsRemainingBeforeStopped--;
+            } else {
+                $this->state['Running'] = false;
+                $this->inspectsRemainingBeforeStopped = null;
+            }
         }
 
         return $this->state;
@@ -59,11 +85,22 @@ final class FakeDockerCli extends DockerCli
     {
         $this->lastAction = ['stop', $containerName];
         $this->actions[] = ['stop', $containerName];
+        $this->lastStopTimeout = $timeoutSeconds;
         if ($this->stopShouldFail) {
             throw new NavidromeContainerException('docker stop a échoué (simulé).');
+        }
+        if ($this->inspectsRemainingBeforeStopped !== null) {
+            // Slow-shutdown mode: leave Running=true and let inspectState()
+            // count down. Don't flip here.
+            return;
         }
         if ($this->state !== null) {
             $this->state['Running'] = false;
         }
+    }
+
+    public function simulateSlowShutdown(int $inspectsBeforeStopped): void
+    {
+        $this->inspectsRemainingBeforeStopped = $inspectsBeforeStopped;
     }
 }

--- a/tests/Docker/NavidromeContainerManagerTest.php
+++ b/tests/Docker/NavidromeContainerManagerTest.php
@@ -7,13 +7,36 @@ use App\Docker\DockerCli;
 use App\Docker\NavidromeContainerConfig;
 use App\Docker\NavidromeContainerException;
 use App\Docker\NavidromeContainerManager;
+use App\Navidrome\NavidromeDbBackup;
 use PHPUnit\Framework\TestCase;
 
 class NavidromeContainerManagerTest extends TestCase
 {
+    /** @var list<string> Files (and their wal/shm siblings) to clean up after each test */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            foreach (['', '-wal', '-shm'] as $suffix) {
+                @unlink($path . $suffix);
+            }
+            foreach (glob($path . '.backup-*') ?: [] as $backup) {
+                @unlink($backup);
+                @unlink($backup . '-wal');
+                @unlink($backup . '-shm');
+            }
+        }
+        $this->createdPaths = [];
+    }
+
     public function testStatusDisabledWhenContainerNameEmpty(): void
     {
-        $manager = new NavidromeContainerManager(new DockerCli(), new NavidromeContainerConfig(''));
+        $manager = new NavidromeContainerManager(
+            new DockerCli(),
+            new NavidromeContainerConfig(''),
+            $this->makeNoopBackup(),
+        );
         $this->assertSame(ContainerStatus::Disabled, $manager->getStatus());
     }
 
@@ -50,7 +73,11 @@ class NavidromeContainerManagerTest extends TestCase
 
     public function testAssertSafeToWritePassesWhenDisabled(): void
     {
-        $manager = new NavidromeContainerManager(new DockerCli(), new NavidromeContainerConfig(''));
+        $manager = new NavidromeContainerManager(
+            new DockerCli(),
+            new NavidromeContainerConfig(''),
+            $this->makeNoopBackup(),
+        );
         $manager->assertSafeToWrite();
         $this->addToAssertionCount(1);
     }
@@ -81,7 +108,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testStartCallsCliWithContainerName(): void
     {
         $cli = new FakeDockerCli(state: ['Running' => false]);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $manager->start();
         $this->assertSame(['start', 'navidrome'], $cli->lastAction);
     }
@@ -89,14 +116,30 @@ class NavidromeContainerManagerTest extends TestCase
     public function testStopCallsCliWithContainerName(): void
     {
         $cli = new FakeDockerCli(state: ['Running' => true]);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $manager->stop();
         $this->assertSame(['stop', 'navidrome'], $cli->lastAction);
     }
 
+    public function testStopForwardsConfiguredTimeoutToDockerCli(): void
+    {
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome', stopTimeoutSeconds: 75),
+            $this->makeNoopBackup(),
+        );
+        $manager->stop();
+        $this->assertSame(75, $cli->lastStopTimeout);
+    }
+
     public function testStartThrowsWhenNotConfigured(): void
     {
-        $manager = new NavidromeContainerManager(new DockerCli(), new NavidromeContainerConfig(''));
+        $manager = new NavidromeContainerManager(
+            new DockerCli(),
+            new NavidromeContainerConfig(''),
+            $this->makeNoopBackup(),
+        );
         $this->expectException(NavidromeContainerException::class);
         $manager->start();
     }
@@ -104,7 +147,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedSkipsOrchestrationWhenDisabled(): void
     {
         $cli = new FakeDockerCli();
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig(''));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig(''), $this->makeNoopBackup());
         $result = $manager->runWithNavidromeStopped(fn () => 42);
         $this->assertSame(42, $result);
         $this->assertSame([], $cli->actions);
@@ -113,7 +156,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedSkipsOrchestrationWhenAlreadyStopped(): void
     {
         $cli = new FakeDockerCli(state: ['Running' => false]);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $result = $manager->runWithNavidromeStopped(fn () => 'ok');
         $this->assertSame('ok', $result);
         $this->assertSame([], $cli->actions);
@@ -122,7 +165,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedSkipsOrchestrationWhenNotFound(): void
     {
         $cli = new FakeDockerCli(state: null);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $manager->runWithNavidromeStopped(fn () => null);
         $this->assertSame([], $cli->actions);
     }
@@ -130,7 +173,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedThrowsWhenStatusUnknown(): void
     {
         $cli = new FakeDockerCli(throwOnInspect: 'cannot connect');
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $this->expectException(NavidromeContainerException::class);
         $this->expectExceptionMessageMatches('/ind[ée]termin[ée]/u');
         $manager->runWithNavidromeStopped(fn () => 'never');
@@ -139,7 +182,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedStopsRunsAndRestartsWhenRunning(): void
     {
         $cli = new FakeDockerCli(state: ['Running' => true]);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
         $calls = [];
         $result = $manager->runWithNavidromeStopped(function () use (&$calls): string {
             $calls[] = 'action';
@@ -157,7 +200,7 @@ class NavidromeContainerManagerTest extends TestCase
     public function testRunWithStoppedRestartsEvenWhenActionThrows(): void
     {
         $cli = new FakeDockerCli(state: ['Running' => true]);
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
 
         $thrown = null;
         try {
@@ -180,7 +223,7 @@ class NavidromeContainerManagerTest extends TestCase
     {
         $cli = new FakeDockerCli(state: ['Running' => true]);
         $cli->startShouldFail = true;
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
 
         $thrown = null;
         try {
@@ -201,11 +244,119 @@ class NavidromeContainerManagerTest extends TestCase
     {
         $cli = new FakeDockerCli(state: ['Running' => true]);
         $cli->startShouldFail = true;
-        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'));
+        $manager = new NavidromeContainerManager($cli, new NavidromeContainerConfig('navidrome'), $this->makeNoopBackup());
 
         $this->expectException(NavidromeContainerException::class);
         $this->expectExceptionMessageMatches('/docker start/');
         $manager->runWithNavidromeStopped(fn () => 'ok');
+    }
+
+    public function testRunWithStoppedPollsBeforeRunningAction(): void
+    {
+        // Simulate a Navidrome that takes 2 inspect cycles to actually
+        // shutdown after `docker stop` returns. The action MUST NOT fire
+        // until inspect reports Running:false.
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $cli->simulateSlowShutdown(2);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome', stopWaitCeilingSeconds: 5),
+            $this->makeNoopBackup(),
+        );
+
+        $calls = [];
+        $result = $manager->runWithNavidromeStopped(function () use ($cli, &$calls) {
+            $calls[] = 'action';
+            // By the time the action runs, inspect must already see stopped.
+            $state = $cli->inspectState('navidrome');
+            $this->assertNotNull($state);
+            $this->assertFalse($state['Running']);
+
+            return 'ok';
+        });
+        $this->assertSame('ok', $result);
+        $this->assertSame(['action'], $calls);
+    }
+
+    public function testRunWithStoppedAbortsWhenContainerStillRunningAfterCeiling(): void
+    {
+        // Ceiling of 1s; simulate a container that needs 100 inspect cycles
+        // to flip — way more than the polling will do in 1 second. Action
+        // must NEVER run, no start(), exception explains the reason.
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $cli->simulateSlowShutdown(100);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome', stopWaitCeilingSeconds: 1),
+            $this->makeNoopBackup(),
+        );
+
+        $actionRan = false;
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function () use (&$actionRan): void {
+                $actionRan = true;
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertFalse($actionRan, 'Action must NOT run while Navidrome is still alive.');
+        $this->assertInstanceOf(NavidromeContainerException::class, $thrown);
+        $this->assertMatchesRegularExpression('/toujours en cours/', $thrown->getMessage());
+        // No start: we never confirmed stop, leaving Navidrome running is
+        // safer than re-issuing start to a still-running container.
+        $this->assertSame([['stop', 'navidrome']], $cli->actions);
+    }
+
+    public function testRunWithStoppedTakesBackupBeforeAction(): void
+    {
+        $dbPath = $this->makeRealSqliteDb();
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $backupExistedDuringAction = false;
+        $manager->runWithNavidromeStopped(function () use ($dbPath, &$backupExistedDuringAction): void {
+            $backupExistedDuringAction = (glob($dbPath . '.backup-*') ?: []) !== [];
+        });
+
+        $this->assertTrue($backupExistedDuringAction, 'Backup must exist before action runs.');
+    }
+
+    public function testRunWithStoppedAbortsActionWhenIntegrityCheckFails(): void
+    {
+        // Tampered file: SQLite header replaced with garbage. quickCheck
+        // must throw, action must NOT run, but Navidrome must be restarted
+        // so the user gets back to a working dashboard.
+        $dbPath = sys_get_temp_dir() . '/nv-corrupt-' . bin2hex(random_bytes(4)) . '.db';
+        file_put_contents($dbPath, str_repeat("\x00", 4096));
+        $this->createdPaths[] = $dbPath;
+
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $actionRan = false;
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function () use (&$actionRan): void {
+                $actionRan = true;
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertFalse($actionRan);
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        // start() was still called to bring Navidrome back up.
+        $this->assertContains(['start', 'navidrome'], $cli->actions);
     }
 
     /**
@@ -216,6 +367,27 @@ class NavidromeContainerManagerTest extends TestCase
         return new NavidromeContainerManager(
             new FakeDockerCli($state, $throwOnInspect),
             new NavidromeContainerConfig('navidrome'),
+            $this->makeNoopBackup(),
         );
+    }
+
+    private function makeNoopBackup(): NavidromeDbBackup
+    {
+        // Pointing at a path that does not exist makes both backup() and
+        // quickCheck() into no-ops — perfect for tests that only care
+        // about start/stop orchestration.
+        return new NavidromeDbBackup('/tmp/does-not-exist-' . bin2hex(random_bytes(4)) . '.db');
+    }
+
+    private function makeRealSqliteDb(): string
+    {
+        $path = sys_get_temp_dir() . '/nv-mgr-test-' . bin2hex(random_bytes(4)) . '.db';
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+        $pdo->exec("INSERT INTO t (v) VALUES ('one'), ('two')");
+        unset($pdo);
+        $this->createdPaths[] = $path;
+
+        return $path;
     }
 }

--- a/tests/Navidrome/NavidromeDbBackupTest.php
+++ b/tests/Navidrome/NavidromeDbBackupTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeDbBackup;
+use PHPUnit\Framework\TestCase;
+
+class NavidromeDbBackupTest extends TestCase
+{
+    /** @var list<string> */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            foreach (['', '-wal', '-shm'] as $suffix) {
+                @unlink($path . $suffix);
+            }
+            foreach (glob($path . '.backup-*') ?: [] as $backup) {
+                @unlink($backup);
+                @unlink($backup . '-wal');
+                @unlink($backup . '-shm');
+            }
+        }
+        $this->createdPaths = [];
+    }
+
+    public function testBackupReturnsNullWhenSourceFileMissing(): void
+    {
+        $backup = new NavidromeDbBackup('/tmp/no-such-file-' . bin2hex(random_bytes(4)) . '.db');
+        $this->assertNull($backup->backup());
+    }
+
+    public function testBackupCopiesSqliteFile(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        $target = $backup->backup();
+        $this->assertNotNull($target);
+        $this->assertFileExists($target);
+        $this->assertMatchesRegularExpression('/\.backup-\d{14}$/', $target);
+        $this->assertSame(file_get_contents($dbPath), file_get_contents($target));
+    }
+
+    public function testBackupCopiesWalAndShmSiblingsWhenPresent(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        // Fake WAL/SHM siblings — we only check copy, not validity.
+        file_put_contents($dbPath . '-wal', 'fake wal payload');
+        file_put_contents($dbPath . '-shm', 'fake shm payload');
+
+        $target = (new NavidromeDbBackup($dbPath))->backup();
+
+        $this->assertNotNull($target);
+        $this->assertFileExists($target . '-wal');
+        $this->assertFileExists($target . '-shm');
+        $this->assertSame('fake wal payload', file_get_contents($target . '-wal'));
+        $this->assertSame('fake shm payload', file_get_contents($target . '-shm'));
+    }
+
+    public function testRetentionPrunesOldestBackups(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+
+        // Plant 4 forged old backups with chronologically-sortable stamps.
+        // Doing it this way (vs calling backup() multiple times) lets us
+        // skirt the per-second timestamp granularity of `backup()`.
+        foreach (['20200101000001', '20200101000002', '20200101000003', '20200101000004'] as $stamp) {
+            file_put_contents($dbPath . '.backup-' . $stamp, 'old');
+        }
+
+        $backup = new NavidromeDbBackup($dbPath, retention: 2);
+        $latest = $backup->backup();
+        $this->assertNotNull($latest);
+
+        $remaining = $backup->listBackups();
+        $this->assertCount(2, $remaining, 'retention=2 must keep only the 2 most recent backups');
+        $this->assertContains($latest, $remaining);
+        // The most recent forged backup is the 2nd kept one.
+        $this->assertContains($dbPath . '.backup-20200101000004', $remaining);
+        // The 3 oldest forged backups must all be gone.
+        $this->assertFileDoesNotExist($dbPath . '.backup-20200101000001');
+        $this->assertFileDoesNotExist($dbPath . '.backup-20200101000002');
+        $this->assertFileDoesNotExist($dbPath . '.backup-20200101000003');
+    }
+
+    public function testRetentionZeroKeepsEverything(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+
+        // Plant 5 forged old backups, retention=0 must leave them all.
+        foreach (range(1, 5) as $i) {
+            file_put_contents($dbPath . '.backup-2020010100000' . $i, 'old');
+        }
+
+        $backup = new NavidromeDbBackup($dbPath, retention: 0);
+        $latest = $backup->backup();
+        $this->assertNotNull($latest);
+        $this->assertGreaterThanOrEqual(6, count($backup->listBackups()));
+    }
+
+    public function testQuickCheckPassesOnHealthyDb(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        (new NavidromeDbBackup($dbPath))->quickCheck();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testQuickCheckIsNoopWhenFileMissing(): void
+    {
+        $backup = new NavidromeDbBackup('/tmp/no-such-file-' . bin2hex(random_bytes(4)) . '.db');
+        $backup->quickCheck();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testQuickCheckThrowsOnGarbageFile(): void
+    {
+        $path = sys_get_temp_dir() . '/nv-bk-bad-' . bin2hex(random_bytes(4)) . '.db';
+        file_put_contents($path, str_repeat("\xFF", 4096));
+        $this->createdPaths[] = $path;
+
+        $this->expectException(\RuntimeException::class);
+        (new NavidromeDbBackup($path))->quickCheck();
+    }
+
+    public function testQuickCheckThrowsOnTruncatedSqliteHeader(): void
+    {
+        // Real SQLite file truncated to 50 bytes — invalid header that
+        // SQLite refuses to open. Models the « SIGKILL pendant fsync »
+        // case that motivated this whole machinery.
+        $dbPath = $this->makeSqliteDb();
+        $truncated = sys_get_temp_dir() . '/nv-bk-trunc-' . bin2hex(random_bytes(4)) . '.db';
+        file_put_contents($truncated, substr((string) file_get_contents($dbPath), 0, 50));
+        $this->createdPaths[] = $truncated;
+
+        $this->expectException(\RuntimeException::class);
+        (new NavidromeDbBackup($truncated))->quickCheck();
+    }
+
+    private function makeSqliteDb(): string
+    {
+        $path = sys_get_temp_dir() . '/nv-bk-test-' . bin2hex(random_bytes(4)) . '.db';
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+        $pdo->exec("INSERT INTO t (v) VALUES ('one'), ('two')");
+        unset($pdo);
+        $this->createdPaths[] = $path;
+
+        return $path;
+    }
+}


### PR DESCRIPTION
`docker stop -t 10` (timeout codé en dur dans `DockerCli::stop()`)
SIGKILLait Navidrome en plein checkpoint WAL SQLite après une rafale
d'écritures (~13k scrobbles insérés en un import), laissant un
`.db-wal` mi-flushé. Le pipeline enchaînait ensuite directement avec
l'`$action()` sans poller `docker inspect` — l'import ouvrait alors la
DB en écriture sur un état incohérent et la corrompait.

Défense en profondeur dans `NavidromeContainerManager::runWithNavidromeStopped()` :

1. Timeout `docker stop` configurable, défaut 60s (vs 10s avant) via
   `NAVIDROME_STOP_TIMEOUT_SECONDS` — plein temps pour le checkpoint.
2. Polling `docker inspect` jusqu'à `Running:false` (`waitUntilStopped()`),
   ceiling configurable via `NAVIDROME_STOP_WAIT_CEILING_SECONDS`
   (défaut 30s). On n'écrit jamais pendant que Navidrome tourne, même
   si `docker stop` a rendu la main avec exit 0.
3. Snapshot `<dbPath>.backup-<unix_ts>` (+ siblings `-wal`/`-shm`) avant
   l'action via le nouveau service `App\Navidrome\NavidromeDbBackup`.
   Rétention `NAVIDROME_DB_BACKUP_RETENTION` (défaut 3). Rollback en
   un `cp`.
4. `PRAGMA quick_check` avant l'action — si la DB est déjà brisée
   (résidu d'un crash antérieur), on abandonne au lieu d'aggraver, et
   l'utilisateur reçoit un message explicite. Bonus : ouvrir la DB
   read-only force le replay du WAL clean si pertinent.

Tests : 14 nouveaux cas couvrant timeout forwardé, polling effectif,
abandon sur ceiling, backup pris avant l'action, quick_check OK/KO,
rétention et `quickCheck` sur DB tronquée. Total 353 tests, 914 assertions.

Closes #118

https://claude.ai/code/session_01KV7114jUx7JsQguBKrqs7s