### PR TITLE
docs(lastfm): recommander la CLI pour le traitement du buffer

### DIFF
--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -111,13 +111,33 @@
             </div>
         {% endif %}
 
+        <div class="bg-sky-50 border border-sky-300 text-sky-900 rounded p-3 mb-4 text-sm">
+            <div class="flex items-start gap-2">
+                <div class="text-base">💡</div>
+                <div class="flex-1">
+                    <p class="mb-2">
+                        <strong>Recommandé : lancer le traitement depuis le CLI</strong>
+                        plutôt que ce bouton. La requête HTTP peut être interrompue
+                        par un timeout reverse-proxy sur les gros buffers, alors que
+                        la commande tient sur des centaines de milliers de
+                        scrobbles. Avec <code>--auto-stop</code>, l'arrêt et le
+                        redémarrage de Navidrome sont orchestrés automatiquement.
+                    </p>
+                    <pre class="bg-white border border-sky-200 rounded px-2 py-1 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:process --auto-stop</code></pre>
+                    <p class="text-xs text-sky-800 mb-1">Avec Docker Compose :</p>
+                    <pre class="bg-white border border-sky-200 rounded px-2 py-1 text-xs overflow-x-auto"><code>docker compose exec -T navidrome-tools-web \
+    php bin/console app:lastfm:process --auto-stop</code></pre>
+                </div>
+            </div>
+        </div>
+
         <form method="post" action="{{ path('app_lastfm_process') }}"
               onsubmit="return confirm('Lancer le traitement des {{ buffer_count }} scrobbles bufferés ?');">
             <input type="hidden" name="_token" value="{{ csrf_token('lastfm_process') }}">
             <button type="submit"
                     {% if buffer_count == 0 %}disabled{% endif %}
                     class="px-4 py-2 rounded text-sm text-white {{ buffer_count == 0 ? 'bg-slate-400 cursor-not-allowed' : 'bg-emerald-600 hover:bg-emerald-700' }}">
-                ▶ Traiter le buffer
+                ▶ Traiter le buffer depuis l'UI
             </button>
         </form>
     </div>


### PR DESCRIPTION
## Contexte

La section 2 de `/lastfm/import` (« Traiter le buffer ») expose un
bouton qui POST sur `/lastfm/process` et bloque la requête HTTP le
temps du processing complet. Sur un gros buffer (10k+ scrobbles),
la requête peut être tuée par un timeout reverse-proxy avant la
fin — laissant le buffer partiellement drainé et l'audit
incomplet.

Côté CLI, la commande tient indéfiniment ; combinée à
`--auto-stop`, elle orchestre l'arrêt et le redémarrage de
Navidrome sans intervention.

## Changement

Ajout d'un bandeau **« Recommandé : lancer le traitement depuis le
CLI »** au-dessus du bouton, avec deux snippets prêts à coller :

- Invocation directe : `php bin/console app:lastfm:process --auto-stop`
- Invocation via Docker Compose :
  `docker compose exec -T navidrome-tools-web php bin/console app:lastfm:process --auto-stop`

Le bouton UI reste disponible (renommé en « Traiter le buffer
depuis l'UI ») pour les petits buffers et les tests rapides — il
n'y a pas de changement fonctionnel côté serveur.

## Test plan

- [x] `composer ci` (phpcs + phpstan + phpunit) — 348 tests / 908
      assertions, vert.
- [ ] Manuel : ouvrir `/lastfm/import` → vérifier que le bandeau
      sky/💡 apparaît au-dessus du bouton, avec les deux blocs
      `<pre>` lisibles et copiables.
- [ ] Manuel : copier-coller chacun des deux snippets dans un
      shell, vérifier qu'ils tournent.

https://claude.ai/code/session_013ssHTCCEph8Zev5kZwAZgH

---
_Generated by [Claude Code](https://claude.ai/code/session_013ssHTCCEph8Zev5kZwAZgH)_