### PR TITLE
Fix Last.fm OAuth flow: remove pre-fetched token from auth URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,21 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   (desktop + mobile).
 
 ### Fixed
+- **OAuth Last.fm : la redirection finale n'aboutissait jamais** : la
+  page `/lastfm/connect` pré-appelait `auth.getToken` puis passait le
+  token obtenu **et** `cb` à `https://www.last.fm/api/auth/`. Or c'est
+  un mélange des deux flows incompatibles documentés par Last.fm —
+  desktop (token + pas de callback, l'utilisateur copie/colle) vs web
+  (pas de token côté URL, Last.fm en génère un et le pousse via `cb`).
+  En présence d'un `token` explicite, Last.fm bascule sur le flow
+  desktop et n'effectue **pas** la redirection vers `cb` : l'utilisateur
+  voit la page « access granted » mais reste bloqué chez Last.fm, et la
+  session reste marquée non active dans les Réglages. `connect` ne
+  pré-appelle plus `auth.getToken` ; `LastFmAuthService::buildAuthorizeUrl`
+  ne prend plus que `$callbackUrl`. Le token arrive bien dans le
+  callback et est échangé contre la session via `auth.getSession` comme
+  documenté.
+
 - **`--auto-stop` corrompait la DB SQLite Navidrome après un import lourd** :
   `DockerCli::stop()` envoyait un `docker stop -t 10` (timeout codé en
   dur 10s, hérité du défaut Docker). Pas assez pour que Navidrome

--- a/src/Controller/LastFmAuthController.php
+++ b/src/Controller/LastFmAuthController.php
@@ -16,18 +16,10 @@ class LastFmAuthController extends AbstractController
     }
 
     #[Route('/lastfm/connect', name: 'app_lastfm_connect', methods: ['GET'])]
-    public function connect(Request $request): Response
+    public function connect(): Response
     {
         if (!$this->authService->isConfigured()) {
             $this->addFlash('error', 'LASTFM_API_KEY et LASTFM_API_SECRET doivent être renseignés pour pouvoir se connecter à Last.fm.');
-
-            return $this->redirectToRoute('app_settings');
-        }
-
-        try {
-            $token = $this->authService->getRequestToken();
-        } catch (\Throwable $e) {
-            $this->addFlash('error', 'Impossible de demander un token Last.fm : ' . $e->getMessage());
 
             return $this->redirectToRoute('app_settings');
         }
@@ -38,7 +30,7 @@ class LastFmAuthController extends AbstractController
             \Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
         );
 
-        return $this->redirect($this->authService->buildAuthorizeUrl($token, $callbackUrl));
+        return $this->redirect($this->authService->buildAuthorizeUrl($callbackUrl));
     }
 
     #[Route('/lastfm/connect/callback', name: 'app_lastfm_connect_callback', methods: ['GET'])]

--- a/src/LastFm/LastFmAuthService.php
+++ b/src/LastFm/LastFmAuthService.php
@@ -54,40 +54,28 @@ class LastFmAuthService
     }
 
     /**
-     * Step 1: ask Last.fm for a fresh request token (lifetime 60 minutes).
+     * Build the URL the user must visit to grant access (web auth flow).
+     * Last.fm generates a fresh token server-side and appends it to the
+     * callback URL as `?token=…` after the user approves.
+     *
+     * Important : ne PAS pré-appeler `auth.getToken` puis passer le token
+     * ici — c'est le flow desktop. En présence de `cb`, Last.fm ignore
+     * un `token` fourni et n'effectue pas la redirection finale, ce qui
+     * laisse l'utilisateur bloqué sur la page « access granted » sans
+     * jamais revenir.
      */
-    public function getRequestToken(): string
-    {
-        $body = $this->call([
-            'method' => 'auth.getToken',
-            'api_key' => $this->apiKey,
-            'format' => 'json',
-        ]);
-        $token = (string) ($body['token'] ?? '');
-        if ($token === '') {
-            throw new \RuntimeException('Last.fm auth.getToken returned an empty token.');
-        }
-
-        return $token;
-    }
-
-    /**
-     * Step 2: build the URL the user must visit to grant access. After
-     * approving, Last.fm redirects to $callbackUrl (which must include the
-     * token in its query string — Last.fm does this automatically).
-     */
-    public function buildAuthorizeUrl(string $token, string $callbackUrl): string
+    public function buildAuthorizeUrl(string $callbackUrl): string
     {
         return self::AUTH_BASE . '?' . http_build_query([
             'api_key' => $this->apiKey,
-            'token' => $token,
             'cb' => $callbackUrl,
         ]);
     }
 
     /**
-     * Step 3: exchange the now-authorized token for a long-lived session
-     * key. Persists `sk` + the resolved username in `setting`.
+     * Exchange the token Last.fm appended to the callback URL for a
+     * long-lived session key. Persists `sk` + the resolved username in
+     * `setting`.
      */
     public function exchangeTokenForSession(string $token): void
     {

--- a/tests/LastFm/LastFmAuthServiceTest.php
+++ b/tests/LastFm/LastFmAuthServiceTest.php
@@ -13,27 +13,15 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 class LastFmAuthServiceTest extends TestCase
 {
-    public function testGetRequestTokenReturnsTokenFromApi(): void
-    {
-        $client = new MockHttpClient([
-            new MockResponse(json_encode(['token' => 'TOK123'], JSON_THROW_ON_ERROR), [
-                'response_headers' => ['content-type: application/json'],
-            ]),
-        ]);
-
-        $service = $this->makeService($client);
-        $this->assertSame('TOK123', $service->getRequestToken());
-    }
-
-    public function testBuildAuthorizeUrlIncludesTokenAndCallback(): void
+    public function testBuildAuthorizeUrlOmitsTokenAndIncludesCallback(): void
     {
         $service = $this->makeService(new MockHttpClient([]));
-        $url = $service->buildAuthorizeUrl('TOK123', 'https://app.test/cb');
+        $url = $service->buildAuthorizeUrl('https://app.test/cb');
 
         $this->assertStringStartsWith('https://www.last.fm/api/auth/?', $url);
         $this->assertStringContainsString('api_key=KEY', $url);
-        $this->assertStringContainsString('token=TOK123', $url);
         $this->assertStringContainsString('cb=' . urlencode('https://app.test/cb'), $url);
+        $this->assertStringNotContainsString('token=', $url);
     }
 
     public function testExchangeTokenForSessionPersistsKeyAndUser(): void


### PR DESCRIPTION
## Summary
Fixed a critical bug in the Last.fm OAuth flow where the authorization redirect was never completing. The issue was caused by mixing two incompatible Last.fm authentication flows (desktop and web) by passing both a pre-fetched token and a callback URL to the authorization endpoint.

## Key Changes
- **Removed `getRequestToken()` method** from `LastFmAuthService`: This method is only needed for the desktop flow, not the web flow with callbacks
- **Simplified `buildAuthorizeUrl()`**: Now takes only `$callbackUrl` parameter instead of both `$token` and `$callbackUrl`. Last.fm generates and manages the token server-side when a callback is provided
- **Updated `LastFmAuthController::connect()`**: Removed the pre-call to `getRequestToken()` and simplified the flow to directly redirect to the authorization URL
- **Updated tests**: Removed test for `getRequestToken()` and updated authorization URL test to verify the token is NOT included in the URL

## Implementation Details
The root cause was that Last.fm has two distinct OAuth flows:
1. **Desktop flow**: Client pre-fetches a token via `auth.getToken`, user approves it, and manually provides it back (no callback)
2. **Web flow**: Client provides only a callback URL; Last.fm generates a token server-side and redirects to the callback with `?token=...` appended

When both a token and callback (`cb`) were provided, Last.fm would switch to desktop mode and skip the final redirect, leaving users stuck on the "access granted" page without returning to the application.

The fix ensures we use the proper web flow by letting Last.fm handle token generation entirely.

https://claude.ai/code/session_01G827BV56r9tz4kjbWBfk72