### PR TITLE
feat(lastfm): afficher la plage de dates des batches dans app:lastfm:import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   incomplètes ») n'étaient accessibles que sur desktop. Closes #115.
 
 ### Added
+- **Plage de dates dans la progression de `app:lastfm:import`** :
+  chaque ligne de progression (toutes les 50 scrobbles) affiche
+  désormais la fenêtre `played_at` du batch en cours
+  (`batch=YYYY-MM-DD HH:MM → YYYY-MM-DD HH:MM`), pour suivre où
+  l'import en est dans l'historique. La signature du callback
+  `LastFmFetcher::fetch(progress:)` reçoit deux nouveaux paramètres
+  `?\DateTimeImmutable` (premier / dernier `playedAt` du batch).
+
 - **Compteurs Last.fm sur le dashboard** : deux nouvelles cards
   santé affichent le nombre de scrobbles en attente dans le buffer
   Last.fm (lien direct vers `/lastfm/import` pour les traiter) et

--- a/src/Command/ImportLastFmCommand.php
+++ b/src/Command/ImportLastFmCommand.php
@@ -119,12 +119,21 @@ class ImportLastFmCommand extends Command
                     dateMax: $dateMax,
                     maxScrobbles: $maxScrobblesInt,
                     dryRun: $dryRun,
-                    progress: function (int $f, int $b, int $a) use ($io): void {
+                    progress: function (int $f, int $b, int $a, ?\DateTimeImmutable $batchFirst, ?\DateTimeImmutable $batchLast) use ($io): void {
+                        $range = '';
+                        if ($batchFirst !== null && $batchLast !== null) {
+                            $from = min($batchFirst, $batchLast);
+                            $to = max($batchFirst, $batchLast);
+                            $range = $from == $to
+                                ? sprintf('  batch=%s', $from->format('Y-m-d H:i'))
+                                : sprintf('  batch=%s → %s', $from->format('Y-m-d H:i'), $to->format('Y-m-d H:i'));
+                        }
                         $io->writeln(sprintf(
-                            '  fetched=%d  buffered=%d  already_buffered=%d',
+                            '  fetched=%d  buffered=%d  already_buffered=%d%s',
                             $f,
                             $b,
                             $a,
+                            $range,
                         ));
                     },
                 ),

--- a/src/LastFm/LastFmFetcher.php
+++ b/src/LastFm/LastFmFetcher.php
@@ -25,7 +25,7 @@ class LastFmFetcher
     }
 
     /**
-     * @param callable(int $fetched, int $buffered, int $alreadyBuffered): void $progress
+     * @param callable(int $fetched, int $buffered, int $alreadyBuffered, ?\DateTimeImmutable $batchFirstPlayedAt, ?\DateTimeImmutable $batchLastPlayedAt): void $progress
      */
     public function fetch(
         string $apiKey,
@@ -39,6 +39,8 @@ class LastFmFetcher
         $report = new FetchReport();
         $utc = new \DateTimeZone('UTC');
         $now = (new \DateTimeImmutable('now'))->setTimezone($utc)->format('Y-m-d H:i:s');
+        $batchFirstPlayedAt = null;
+        $batchLastPlayedAt = null;
 
         foreach ($this->client->streamRecentTracks($apiKey, $lastFmUser, $dateMin, $dateMax) as $scrobble) {
             if ($maxScrobbles !== null && $report->fetched >= $maxScrobbles) {
@@ -46,11 +48,22 @@ class LastFmFetcher
             }
             $report->fetched++;
 
+            $scrobblePlayedAt = $scrobble->playedAt->setTimezone($utc);
+            if ($batchFirstPlayedAt === null) {
+                $batchFirstPlayedAt = $scrobblePlayedAt;
+            }
+            $batchLastPlayedAt = $scrobblePlayedAt;
+
             if ($dryRun) {
+                if ($progress !== null && $report->fetched % 50 === 0) {
+                    $progress($report->fetched, $report->buffered, $report->alreadyBuffered, $batchFirstPlayedAt, $batchLastPlayedAt);
+                    $batchFirstPlayedAt = null;
+                    $batchLastPlayedAt = null;
+                }
                 continue;
             }
 
-            $playedAt = $scrobble->playedAt->setTimezone($utc)->format('Y-m-d H:i:s');
+            $playedAt = $scrobblePlayedAt->format('Y-m-d H:i:s');
             $album = $scrobble->album !== '' ? $scrobble->album : null;
 
             // INSERT OR IGNORE leans on the SQLite unique constraint to drop
@@ -78,12 +91,14 @@ class LastFmFetcher
             }
 
             if ($progress !== null && $report->fetched % 50 === 0) {
-                $progress($report->fetched, $report->buffered, $report->alreadyBuffered);
+                $progress($report->fetched, $report->buffered, $report->alreadyBuffered, $batchFirstPlayedAt, $batchLastPlayedAt);
+                $batchFirstPlayedAt = null;
+                $batchLastPlayedAt = null;
             }
         }
 
         if ($progress !== null) {
-            $progress($report->fetched, $report->buffered, $report->alreadyBuffered);
+            $progress($report->fetched, $report->buffered, $report->alreadyBuffered, $batchFirstPlayedAt, $batchLastPlayedAt);
         }
 
         return $report;


### PR DESCRIPTION
Pendant un import historique, voir uniquement le compteur cumulé
fetched/buffered ne dit pas où on en est dans l'historique. La progression
affiche désormais la fenêtre played_at du batch en cours, ce qui permet
de suivre l'avancement dans le temps (utile pour estimer la suite).

https://claude.ai/code/session_01TL1YAuYfH3qeCvi3KA53GM