### PR TITLE
fix(test): wrap new DateTimeImmutable() in parens for PHP 8.3 parser

### DIFF
--- a/tests/MessageHandler/RunLastFmFetchHandlerTest.php
+++ b/tests/MessageHandler/RunLastFmFetchHandlerTest.php
@@ -101,7 +101,7 @@ class RunLastFmFetchHandlerTest extends TestCase
                 title: 'Track ' . $i,
                 album: 'Album',
                 mbid: null,
-                playedAt: new \DateTimeImmutable('2026-04-01 10:00:00', new \DateTimeZone('UTC'))
+                playedAt: (new \DateTimeImmutable('2026-04-01 10:00:00', new \DateTimeZone('UTC')))
                     ->modify('+' . $i . ' minute'),
             );
         }


### PR DESCRIPTION
La syntaxe `new ClassName(...)->method()` (chained method on new sans
parens) est une nouveauté de PHP 8.4. Sur PHP 8.3 elle plante avec
« Internal error: syntax error, unexpected token "->", expecting ")" »,
ce qui faisait sauter en cascade PHPUnit (PHP 8.3) et PHPStan dans la
CI du #128 alors que tout passait en local sur PHP 8.4.

Wrap dans des parens explicites pour rester compatible 8.3.

https://claude.ai/code/session_01N6Z84PPfSsgDJHov8jzpwZ