### PR TITLE
feat(stats): page /stats/tops avec fenêtre libre + création de playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **Page `/stats/tops` — tops fenêtre libre** : nouvelle page dédiée
+  qui affiche, sur une fenêtre `[from, to]` arbitraire (sélecteur
+  date-picker, filtre optionnel par client Subsonic), le top
+  **50 artistes / 100 albums / 500 morceaux** depuis les scrobbles
+  Navidrome. Les snapshots sont mis en cache dans la nouvelle table
+  `top_snapshot` (clé unique `(window_from, window_to, client)`,
+  bornes en epoch arrondies au jour côté contrôleur pour réutiliser
+  les calculs entre clics). Bouton **« + Créer playlist Navidrome »**
+  sur le top morceaux : crée la playlist via l'API Subsonic à partir
+  des N premiers IDs (1 ≤ N ≤ 500, nom personnalisable). Listing des
+  10 dernières fenêtres calculées en bas de page pour rappel rapide.
+  Nouvelle commande `app:stats:tops:compute --from=… --to=…
+  [--client=…]` (wrappée par `RunHistoryRecorder`, type `stats-tops`)
+  pour planifier le calcul depuis le crontab. Lien ajouté dans
+  `_navbar.html.twig` (sous-menu Statistiques → « Tops fenêtre
+  libre »).
 - **Lancement des jobs Last.fm depuis l'UI sans timeout HTTP** : les
   4 long-runners (`fetch`, `process`, `rematch`, `sync-loved`) sont
   maintenant exécutés via Symfony Messenger (transport Doctrine,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,18 @@ Fonctionnalités livrées :
   jsdelivr dans le block `stylesheets`.
 - **Page `/stats/heatmap`** : deux heatmaps HTML/CSS (jour×heure 90j,
   année×jour façon GitHub contribs avec sélecteur d'année).
+- **Page `/stats/tops`** : tops sur fenêtre `[from, to]` arbitraire
+  (date-picker + filtre client), top **50 artistes / 100 albums /
+  500 morceaux** depuis `scrobbles`. Cache dans la table
+  `top_snapshot` keyed par `(window_from, window_to, client)` —
+  les bornes sont arrondies au jour côté contrôleur
+  (`TopsService::normalizeWindow()`) pour réutiliser un snapshot
+  entre clics. Bouton « + Créer playlist Navidrome » sur le top
+  morceaux (Subsonic `createPlaylist` avec les N premiers IDs,
+  N borné à 500). Refresh manuel via le bouton ou via
+  `app:stats:tops:compute --from=… --to=… [--client=…]` (wrappé
+  par `RunHistoryRecorder`, type `stats-tops`). À planifier dans
+  le crontab unix si besoin.
 - **Page `/wrapped/{year}`** : rétrospective annuelle, cachée dans
   `stats_snapshot` (key `wrapped-<year>`). `WrappedService::compute()`
   agrège tout : top 25 artistes, top 50 morceaux, new artists, streak

--- a/README.md
+++ b/README.md
@@ -274,6 +274,10 @@ Cinq pages stats accessibles via le menu déroulant **Statistiques** :
 |----------------------|------------------------------------------------------------------------------|
 | `/stats`             | Vue d'ensemble par période (7d/30d/last-month/last-year/all-time), cachée    |
 |                      | dans `stats_snapshot`, refresh manuel + cron `STATS_REFRESH_SCHEDULE`.       |
+| `/stats/tops`        | Tops sur fenêtre `[from, to]` arbitraire : 50 artistes / 100 albums /        |
+|                      | 500 morceaux, filtre par client. Cache dans `top_snapshot` (clé              |
+|                      | (from, to, client)). Bouton « + Créer playlist Navidrome » sur le top        |
+|                      | morceaux. Refresh manuel ou via `app:stats:tops:compute`.                    |
 | `/stats/compare`     | Comparaison côte à côte de deux périodes : top artistes / morceaux fusionnés |
 |                      | avec deltas et badges (nouveau / disparu / ↑N / ↓N / =).                     |
 | `/stats/charts`      | Trois graphiques Chart.js : écoutes par mois, top 5 artistes au fil du       |

--- a/migrations/Version20260504300000.php
+++ b/migrations/Version20260504300000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260504300000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add top_snapshot table caching top artists/albums/tracks per (window_from, window_to, client).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE top_snapshot (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                window_from INTEGER NOT NULL,
+                window_to INTEGER NOT NULL,
+                client VARCHAR(64) DEFAULT NULL,
+                data CLOB NOT NULL,
+                computed_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX top_snapshot_window_uniq ON top_snapshot (window_from, window_to, client)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE top_snapshot');
+    }
+}

--- a/src/Command/ComputeStatsTopsCommand.php
+++ b/src/Command/ComputeStatsTopsCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Entity\TopSnapshot;
+use App\Service\RunHistoryRecorder;
+use App\Service\TopsService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:stats:tops:compute',
+    description: 'Compute / refresh a top-snapshot (artists / albums / tracks) for an arbitrary date window.',
+)]
+class ComputeStatsTopsCommand extends Command
+{
+    public function __construct(
+        private readonly TopsService $tops,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Window start (Y-m-d). Defaults to 30 days ago.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Window end (Y-m-d, inclusive). Defaults to today.')
+            ->addOption('client', null, InputOption::VALUE_REQUIRED, 'Filter by Subsonic client (optional).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $now = new \DateTimeImmutable('now');
+        $fromOpt = $input->getOption('from');
+        $toOpt = $input->getOption('to');
+        $client = $input->getOption('client');
+        $clientFilter = ($client !== null && $client !== '') ? (string) $client : null;
+
+        try {
+            $from = $fromOpt !== null ? new \DateTimeImmutable((string) $fromOpt) : $now->modify('-30 days');
+            $to = $toOpt !== null ? new \DateTimeImmutable((string) $toOpt) : $now;
+        } catch (\Throwable $e) {
+            $io->error('Invalid date: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        [$normFrom, $normTo] = TopsService::normalizeWindow($from, $to);
+        $reference = sprintf('%s..%s', $normFrom->format('Y-m-d'), $normTo->format('Y-m-d'));
+        if ($clientFilter !== null) {
+            $reference .= '|' . $clientFilter;
+        }
+
+        try {
+            $snapshot = $this->recorder->record(
+                type: RunHistory::TYPE_STATS_TOPS,
+                reference: $reference,
+                label: 'Tops — ' . $reference,
+                action: fn () => $this->tops->compute($from, $to, $clientFilter),
+                extractMetrics: static fn (TopSnapshot $s) => [
+                    'total_plays' => $s->getData()['total_plays'] ?? 0,
+                    'distinct_tracks' => $s->getData()['distinct_tracks'] ?? 0,
+                    'top_artists' => count($s->getData()['top_artists'] ?? []),
+                    'top_albums' => count($s->getData()['top_albums'] ?? []),
+                    'top_tracks' => count($s->getData()['top_tracks'] ?? []),
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            'Tops computed for %s: %d plays, %d distinct tracks, %d artists / %d albums / %d tracks.',
+            $reference,
+            $snapshot->getData()['total_plays'] ?? 0,
+            $snapshot->getData()['distinct_tracks'] ?? 0,
+            count($snapshot->getData()['top_artists'] ?? []),
+            count($snapshot->getData()['top_albums'] ?? []),
+            count($snapshot->getData()['top_tracks'] ?? []),
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -47,6 +47,7 @@ class HistoryController extends AbstractController
             'types' => [
                 RunHistory::TYPE_PLAYLIST => 'Playlist',
                 RunHistory::TYPE_STATS => 'Stats',
+                RunHistory::TYPE_STATS_TOPS => 'Tops fenêtre libre',
                 RunHistory::TYPE_LASTFM_FETCH => 'Fetch Last.fm',
                 RunHistory::TYPE_LASTFM_PROCESS => 'Process buffer Last.fm',
                 RunHistory::TYPE_LASTFM_IMPORT => 'Import Last.fm (legacy)',

--- a/src/Controller/TopsController.php
+++ b/src/Controller/TopsController.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Controller;
+
+use App\Navidrome\NavidromeRepository;
+use App\Service\TopsService;
+use App\Subsonic\SubsonicClient;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class TopsController extends AbstractController
+{
+    #[Route('/stats/tops', name: 'app_stats_tops', methods: ['GET'])]
+    public function index(Request $request, TopsService $tops, NavidromeRepository $navidrome): Response
+    {
+        [$from, $to] = $this->resolveWindow($request);
+        $clients = $navidrome->isAvailable() ? $navidrome->listScrobbleClients() : [];
+        $client = (string) $request->query->get('client', '');
+        if ($client !== '' && !in_array($client, $clients, true)) {
+            $client = '';
+        }
+        $clientFilter = $client !== '' ? $client : null;
+
+        $snapshot = $tops->getCached($from, $to, $clientFilter);
+
+        return $this->render('stats/tops.html.twig', [
+            'from' => $from,
+            'to' => $to,
+            'client' => $client,
+            'clients' => $clients,
+            'snapshot' => $snapshot,
+            'recent' => $tops->recentSnapshots(10),
+            'limits' => [
+                'artists' => TopsService::TOP_ARTISTS_LIMIT,
+                'albums' => TopsService::TOP_ALBUMS_LIMIT,
+                'tracks' => TopsService::TOP_TRACKS_LIMIT,
+            ],
+        ]);
+    }
+
+    #[Route('/stats/tops/refresh', name: 'app_stats_tops_refresh', methods: ['POST'])]
+    public function refresh(Request $request, TopsService $tops, NavidromeRepository $navidrome): Response
+    {
+        [$from, $to] = $this->resolveWindow($request);
+        $client = (string) $request->request->get('client', '');
+        $clients = $navidrome->isAvailable() ? $navidrome->listScrobbleClients() : [];
+        if ($client !== '' && !in_array($client, $clients, true)) {
+            $client = '';
+        }
+        $clientFilter = $client !== '' ? $client : null;
+
+        if (!$this->isCsrfTokenValid($this->csrfId($from, $to, $clientFilter), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        try {
+            $tops->compute($from, $to, $clientFilter);
+            $this->addFlash('success', sprintf(
+                'Tops calculés pour la fenêtre %s → %s%s.',
+                $from->format('Y-m-d'),
+                $to->format('Y-m-d'),
+                $clientFilter !== null ? ' (client : ' . $clientFilter . ')' : '',
+            ));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_stats_tops', $this->queryParams($from, $to, $client));
+    }
+
+    #[Route('/stats/tops/playlist', name: 'app_stats_tops_playlist', methods: ['POST'])]
+    public function createPlaylist(Request $request, TopsService $tops, SubsonicClient $subsonic): Response
+    {
+        [$from, $to] = $this->resolveWindow($request);
+        $client = (string) $request->request->get('client', '');
+        $clientFilter = $client !== '' ? $client : null;
+
+        if (!$this->isCsrfTokenValid($this->csrfId($from, $to, $clientFilter), (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $snapshot = $tops->getCached($from, $to, $clientFilter);
+        if ($snapshot === null) {
+            $this->addFlash('error', 'Aucun snapshot pour cette fenêtre. Calcule-le d\'abord.');
+
+            return $this->redirectToRoute('app_stats_tops', $this->queryParams($from, $to, $client));
+        }
+
+        $count = (int) $request->request->get('count', 50);
+        $count = max(1, min($count, TopsService::TOP_TRACKS_LIMIT));
+
+        $name = trim((string) $request->request->get('name', ''));
+        if ($name === '') {
+            $name = sprintf('Top %d morceaux %s → %s', $count, $from->format('Y-m-d'), $to->format('Y-m-d'));
+        }
+
+        $tracks = array_slice($snapshot->getData()['top_tracks'] ?? [], 0, $count);
+        $songIds = array_values(array_filter(
+            array_map(static fn (array $t) => (string) ($t['id'] ?? ''), $tracks),
+            static fn (string $id) => $id !== '',
+        ));
+        if ($songIds === []) {
+            $this->addFlash('error', 'Aucun morceau dans ce snapshot.');
+
+            return $this->redirectToRoute('app_stats_tops', $this->queryParams($from, $to, $client));
+        }
+
+        try {
+            $subsonic->createPlaylist($name, $songIds);
+            $this->addFlash('success', sprintf('Playlist « %s » créée (%d morceaux).', $name, count($songIds)));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur Subsonic : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_stats_tops', $this->queryParams($from, $to, $client));
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function resolveWindow(Request $request): array
+    {
+        $bag = $request->isMethod('POST') ? $request->request : $request->query;
+        $fromStr = (string) $bag->get('from', '');
+        $toStr = (string) $bag->get('to', '');
+
+        $now = new \DateTimeImmutable('now');
+        $from = $fromStr !== '' ? $this->parseDate($fromStr) : null;
+        $to = $toStr !== '' ? $this->parseDate($toStr) : null;
+
+        if ($from === null) {
+            $from = $now->modify('-30 days');
+        }
+        if ($to === null) {
+            $to = $now;
+        }
+        if ($to < $from) {
+            $to = $from;
+        }
+
+        return TopsService::normalizeWindow($from, $to);
+    }
+
+    private function parseDate(string $value): ?\DateTimeImmutable
+    {
+        try {
+            return new \DateTimeImmutable($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function queryParams(\DateTimeImmutable $from, \DateTimeImmutable $to, string $client): array
+    {
+        $params = [
+            'from' => $from->format('Y-m-d'),
+            'to' => $to->modify('-1 day')->format('Y-m-d'),
+        ];
+        if ($client !== '') {
+            $params['client'] = $client;
+        }
+
+        return $params;
+    }
+
+    private function csrfId(\DateTimeImmutable $from, \DateTimeImmutable $to, ?string $client): string
+    {
+        return sprintf('tops_%d_%d_%s', $from->getTimestamp(), $to->getTimestamp(), $client ?? '');
+    }
+}

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -15,6 +15,7 @@ class RunHistory
 {
     public const TYPE_PLAYLIST = 'playlist';
     public const TYPE_STATS = 'stats';
+    public const TYPE_STATS_TOPS = 'stats-tops';
     public const TYPE_LASTFM_IMPORT = 'lastfm-import';
     public const TYPE_LASTFM_FETCH = 'lastfm-fetch';
     public const TYPE_LASTFM_PROCESS = 'lastfm-process';

--- a/src/Entity/TopSnapshot.php
+++ b/src/Entity/TopSnapshot.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\TopSnapshotRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: TopSnapshotRepository::class)]
+#[ORM\Table(name: 'top_snapshot')]
+#[ORM\UniqueConstraint(name: 'top_snapshot_window_uniq', columns: ['window_from', 'window_to', 'client'])]
+class TopSnapshot
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $windowFrom;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $windowTo;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $client = null;
+
+    /**
+     * JSON payload :
+     *   total_plays, distinct_tracks,
+     *   top_artists [{artist, plays}],
+     *   top_albums  [{album, album_artist, plays, track_count, sample_track_id}],
+     *   top_tracks  [{id, title, artist, album, plays}]
+     *
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: Types::JSON)]
+    private array $data = [
+        'total_plays' => 0,
+        'distinct_tracks' => 0,
+        'top_artists' => [],
+        'top_albums' => [],
+        'top_tracks' => [],
+    ];
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $computedAt;
+
+    public function __construct(\DateTimeImmutable $windowFrom, \DateTimeImmutable $windowTo, ?string $client = null)
+    {
+        $this->windowFrom = $windowFrom->getTimestamp();
+        $this->windowTo = $windowTo->getTimestamp();
+        $this->client = ($client !== null && $client !== '') ? $client : null;
+        $this->computedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getWindowFrom(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('@' . $this->windowFrom))
+            ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+    }
+
+    public function getWindowTo(): \DateTimeImmutable
+    {
+        return (new \DateTimeImmutable('@' . $this->windowTo))
+            ->setTimezone(new \DateTimeZone(date_default_timezone_get()));
+    }
+
+    public function getWindowFromTimestamp(): int
+    {
+        return $this->windowFrom;
+    }
+
+    public function getWindowToTimestamp(): int
+    {
+        return $this->windowTo;
+    }
+
+    public function getClient(): ?string
+    {
+        return $this->client;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+        $this->computedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function getComputedAt(): \DateTimeImmutable
+    {
+        return $this->computedAt;
+    }
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -598,6 +598,65 @@ class NavidromeRepository
     }
 
     /**
+     * Top albums by aggregated plays in [from, to). Pass null/null for all-time.
+     * `sample_track_id` is the most-played media_file in the album, used for
+     * cover art on the UI.
+     *
+     * @return list<array{album: string, album_artist: string, plays: int, track_count: int, sample_track_id: string}>
+     */
+    public function getTopAlbums(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+
+        $sql = 'SELECT mf.album AS album,
+                       COALESCE(NULLIF(mf.album_artist, ""), mf.artist) AS album_artist,
+                       COUNT(*) AS plays,
+                       COUNT(DISTINCT mf.id) AS track_count,
+                       (SELECT s2.media_file_id
+                        FROM scrobbles s2
+                        JOIN media_file mf2 ON mf2.id = s2.media_file_id
+                        WHERE s2.user_id = :uid
+                          AND mf2.album = mf.album
+                          AND COALESCE(NULLIF(mf2.album_artist, ""), mf2.artist) = COALESCE(NULLIF(mf.album_artist, ""), mf.artist)
+                        GROUP BY s2.media_file_id
+                        ORDER BY COUNT(*) DESC, s2.media_file_id ASC
+                        LIMIT 1) AS sample_track_id
+                FROM scrobbles s
+                JOIN media_file mf ON mf.id = s.media_file_id
+                WHERE s.user_id = :uid
+                  AND mf.album != ""';
+        $params = ['uid' => $userId, 'lim' => $limit];
+        $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+        if ($from !== null && $to !== null) {
+            $sql .= ' AND s.submission_time >= :f AND s.submission_time < :t';
+            $params['f'] = $from->getTimestamp();
+            $params['t'] = $to->getTimestamp();
+            $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        }
+        if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+            $sql .= ' AND s.client = :client';
+            $params['client'] = $client;
+        }
+        $sql .= ' GROUP BY mf.album, COALESCE(NULLIF(mf.album_artist, ""), mf.artist)
+                  ORDER BY plays DESC, album ASC LIMIT :lim';
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r) => [
+            'album' => (string) $r['album'],
+            'album_artist' => (string) $r['album_artist'],
+            'plays' => (int) $r['plays'],
+            'track_count' => (int) $r['track_count'],
+            'sample_track_id' => (string) ($r['sample_track_id'] ?? ''),
+        ], $rows);
+    }
+
+    /**
      * Plays per month over the last $monthsBack months. Optionally filtered
      * to a single artist. Months without scrobbles are returned with plays=0.
      *

--- a/src/Repository/TopSnapshotRepository.php
+++ b/src/Repository/TopSnapshotRepository.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\TopSnapshot;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TopSnapshot>
+ */
+class TopSnapshotRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TopSnapshot::class);
+    }
+
+    public function findOneByWindow(\DateTimeImmutable $from, \DateTimeImmutable $to, ?string $client = null): ?TopSnapshot
+    {
+        return $this->findOneBy([
+            'windowFrom' => $from->getTimestamp(),
+            'windowTo' => $to->getTimestamp(),
+            'client' => ($client !== null && $client !== '') ? $client : null,
+        ]);
+    }
+
+    /**
+     * @return TopSnapshot[]
+     */
+    public function findRecent(int $limit = 10): array
+    {
+        return $this->createQueryBuilder('t')
+            ->orderBy('t.computedAt', 'DESC')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult();
+    }
+}

--- a/src/Service/TopsService.php
+++ b/src/Service/TopsService.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\TopSnapshot;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\TopSnapshotRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+class TopsService
+{
+    public const TOP_ARTISTS_LIMIT = 50;
+    public const TOP_ALBUMS_LIMIT = 100;
+    public const TOP_TRACKS_LIMIT = 500;
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly TopSnapshotRepository $repository,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Round (from, to) to day boundaries so a date-picker hitting different
+     * times within the same day reuses the same cache row.
+     *
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    public static function normalizeWindow(\DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $from = $from->setTime(0, 0, 0);
+        $to = $to->setTime(0, 0, 0)->modify('+1 day');
+        if ($to <= $from) {
+            $to = $from->modify('+1 day');
+        }
+
+        return [$from, $to];
+    }
+
+    public function getCached(\DateTimeImmutable $from, \DateTimeImmutable $to, ?string $client = null): ?TopSnapshot
+    {
+        [$from, $to] = self::normalizeWindow($from, $to);
+
+        return $this->repository->findOneByWindow($from, $to, $client);
+    }
+
+    public function compute(\DateTimeImmutable $from, \DateTimeImmutable $to, ?string $client = null): TopSnapshot
+    {
+        [$from, $to] = self::normalizeWindow($from, $to);
+        $clientFilter = ($client !== null && $client !== '') ? $client : null;
+
+        $data = [
+            'total_plays' => $this->navidrome->getTotalPlays($from, $to, $clientFilter),
+            'distinct_tracks' => $this->navidrome->getDistinctTracksPlayed($from, $to, $clientFilter),
+            'top_artists' => $this->navidrome->getTopArtists($from, $to, self::TOP_ARTISTS_LIMIT, $clientFilter),
+            'top_albums' => $this->navidrome->getTopAlbums($from, $to, self::TOP_ALBUMS_LIMIT, $clientFilter),
+            'top_tracks' => $this->navidrome->getTopTracksWithDetails($from, $to, self::TOP_TRACKS_LIMIT, $clientFilter),
+        ];
+
+        $snapshot = $this->repository->findOneByWindow($from, $to, $clientFilter)
+            ?? new TopSnapshot($from, $to, $clientFilter);
+        $snapshot->setData($data);
+
+        if ($snapshot->getId() === null) {
+            $this->em->persist($snapshot);
+        }
+        $this->em->flush();
+
+        return $snapshot;
+    }
+
+    public function invalidate(\DateTimeImmutable $from, \DateTimeImmutable $to, ?string $client = null): void
+    {
+        [$from, $to] = self::normalizeWindow($from, $to);
+        $existing = $this->repository->findOneByWindow($from, $to, $client);
+        if ($existing !== null) {
+            $this->em->remove($existing);
+            $this->em->flush();
+        }
+    }
+
+    /**
+     * @return TopSnapshot[]
+     */
+    public function recentSnapshots(int $limit = 10): array
+    {
+        return $this->repository->findRecent($limit);
+    }
+}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -18,6 +18,7 @@
     { type: 'dropdown', label: 'Statistiques', width: 'w-64', groups: [
         { heading: 'Vue & analyse', items: [
             { label: 'Vue d\'ensemble', route: 'app_stats' },
+            { label: 'Tops fenêtre libre', route: 'app_stats_tops' },
             { label: 'Comparer 2 périodes', route: 'app_stats_compare' },
             { label: 'Graphiques', route: 'app_stats_charts' },
             { label: 'Heatmap', route: 'app_stats_heatmap' },

--- a/templates/stats/tops.html.twig
+++ b/templates/stats/tops.html.twig
@@ -1,0 +1,253 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Tops fenêtre libre{% endblock %}
+
+{% block body %}
+    <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
+        <span class="text-slate-500">Voir aussi :</span>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
+    </div>
+
+    <h1 class="text-2xl font-semibold mb-2">Tops sur fenêtre libre</h1>
+    <p class="text-sm text-slate-500 mb-6">
+        Top {{ limits.artists }} artistes, top {{ limits.albums }} albums et top {{ limits.tracks }} morceaux
+        sur la fenêtre [from, to] inclusive.
+        Les snapshots sont cachés par paire de dates.
+    </p>
+
+    {% set fromStr = from|date('Y-m-d') %}
+    {% set toStr = to|date('Y-m-d')|date_modify('-1 day')|date('Y-m-d') %}
+
+    <div class="bg-white shadow rounded p-4 mb-6">
+        <form method="get" action="{{ path('app_stats_tops') }}" class="flex flex-wrap items-end gap-3">
+            <div>
+                <label class="block text-xs text-slate-500 mb-1" for="from">Du</label>
+                <input type="date" id="from" name="from" value="{{ fromStr }}"
+                       class="border rounded px-2 py-1 text-sm">
+            </div>
+            <div>
+                <label class="block text-xs text-slate-500 mb-1" for="to">Au</label>
+                <input type="date" id="to" name="to" value="{{ toStr }}"
+                       class="border rounded px-2 py-1 text-sm">
+            </div>
+            {% if clients is not empty %}
+                <div>
+                    <label class="block text-xs text-slate-500 mb-1" for="client">Client</label>
+                    <select name="client" id="client" class="border rounded px-2 py-1 text-sm">
+                        <option value="">Tous</option>
+                        {% for c in clients %}
+                            <option value="{{ c }}" {{ c == client ? 'selected' : '' }}>{{ c }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+            {% endif %}
+            <button type="submit" class="bg-slate-800 hover:bg-slate-900 text-white px-3 py-1.5 rounded text-sm">
+                Voir
+            </button>
+        </form>
+    </div>
+
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div class="text-sm">
+            Fenêtre :
+            <strong>{{ fromStr }}</strong> → <strong>{{ toStr }}</strong>
+            {% if client %}<span class="text-slate-500">— client : {{ client }}</span>{% endif %}
+        </div>
+
+        <form method="post" action="{{ path('app_stats_tops_refresh') }}">
+            <input type="hidden" name="from" value="{{ fromStr }}">
+            <input type="hidden" name="to" value="{{ toStr }}">
+            {% if client %}<input type="hidden" name="client" value="{{ client }}">{% endif %}
+            <input type="hidden" name="_token" value="{{ csrf_token('tops_' ~ from.timestamp ~ '_' ~ to.timestamp ~ '_' ~ (client ?? '')) }}">
+            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+                ↻ {{ snapshot ? 'Recalculer' : 'Calculer' }}
+            </button>
+        </form>
+    </div>
+
+    {% if snapshot is null %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+            Aucune donnée en cache pour cette fenêtre. Cliquez sur <strong>Calculer</strong>.
+        </div>
+    {% else %}
+        <p class="text-xs text-slate-500 mb-4">
+            Calculé le <strong>{{ snapshot.computedAt|date('Y-m-d H:i:s') }}</strong>
+        </p>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+            <div class="bg-white shadow rounded p-5">
+                <div class="text-xs uppercase text-slate-500">Total d'écoutes</div>
+                <div class="text-3xl font-semibold mt-1">{{ snapshot.data.total_plays|number_format(0, '.', ' ') }}</div>
+            </div>
+            <div class="bg-white shadow rounded p-5">
+                <div class="text-xs uppercase text-slate-500">Morceaux distincts écoutés</div>
+                <div class="text-3xl font-semibold mt-1">{{ snapshot.data.distinct_tracks|number_format(0, '.', ' ') }}</div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+            {# ---------- Top artists ---------- #}
+            <div class="bg-white shadow rounded overflow-hidden">
+                <div class="px-4 py-3 border-b bg-slate-50">
+                    <h2 class="font-semibold text-sm">Top {{ limits.artists }} artistes</h2>
+                </div>
+                {% if snapshot.data.top_artists is empty %}
+                    <div class="p-4 text-sm text-slate-500">Aucune donnée.</div>
+                {% else %}
+                    <div class="max-h-[600px] overflow-y-auto">
+                        <table class="w-full text-sm">
+                            <thead class="bg-slate-100 text-slate-600 text-left text-xs sticky top-0">
+                            <tr>
+                                <th class="px-3 py-2 w-10">#</th>
+                                <th class="px-3 py-2">Artiste</th>
+                                <th class="px-3 py-2 w-20 text-right">Plays</th>
+                            </tr>
+                            </thead>
+                            <tbody class="divide-y">
+                            {% for row in snapshot.data.top_artists %}
+                                <tr>
+                                    <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
+                                    <td class="px-3 py-1.5 font-medium">{{ row.artist }}</td>
+                                    <td class="px-3 py-1.5 text-right">{{ row.plays|number_format(0, '.', ' ') }}</td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+
+            {# ---------- Top albums ---------- #}
+            <div class="bg-white shadow rounded overflow-hidden">
+                <div class="px-4 py-3 border-b bg-slate-50">
+                    <h2 class="font-semibold text-sm">Top {{ limits.albums }} albums</h2>
+                </div>
+                {% if snapshot.data.top_albums is empty %}
+                    <div class="p-4 text-sm text-slate-500">Aucune donnée.</div>
+                {% else %}
+                    <div class="max-h-[600px] overflow-y-auto">
+                        <table class="w-full text-sm">
+                            <thead class="bg-slate-100 text-slate-600 text-left text-xs sticky top-0">
+                            <tr>
+                                <th class="px-3 py-2 w-10">#</th>
+                                <th class="px-3 py-2">Album</th>
+                                <th class="px-3 py-2 w-20 text-right">Plays</th>
+                            </tr>
+                            </thead>
+                            <tbody class="divide-y">
+                            {% for row in snapshot.data.top_albums %}
+                                <tr>
+                                    <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
+                                    <td class="px-3 py-1.5">
+                                        <div class="font-medium">{{ row.album }}</div>
+                                        <div class="text-xs text-slate-500">{{ row.album_artist }}</div>
+                                    </td>
+                                    <td class="px-3 py-1.5 text-right">{{ row.plays|number_format(0, '.', ' ') }}</td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+
+            {# ---------- Top tracks + create-playlist action ---------- #}
+            <div class="bg-white shadow rounded overflow-hidden">
+                <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between gap-2">
+                    <h2 class="font-semibold text-sm">Top {{ limits.tracks }} morceaux</h2>
+                </div>
+
+                {% if snapshot.data.top_tracks is not empty %}
+                    <form method="post" action="{{ path('app_stats_tops_playlist') }}"
+                          class="px-4 py-3 border-b bg-emerald-50 flex flex-wrap items-end gap-2 text-xs">
+                        <input type="hidden" name="from" value="{{ fromStr }}">
+                        <input type="hidden" name="to" value="{{ toStr }}">
+                        {% if client %}<input type="hidden" name="client" value="{{ client }}">{% endif %}
+                        <input type="hidden" name="_token" value="{{ csrf_token('tops_' ~ from.timestamp ~ '_' ~ to.timestamp ~ '_' ~ (client ?? '')) }}">
+                        <div class="flex flex-col">
+                            <label for="count" class="text-slate-600 mb-1">Nb morceaux</label>
+                            <input type="number" id="count" name="count" min="1" max="{{ limits.tracks }}" value="50"
+                                   class="border rounded px-2 py-1 w-24">
+                        </div>
+                        <div class="flex flex-col flex-1 min-w-[180px]">
+                            <label for="name" class="text-slate-600 mb-1">Nom (optionnel)</label>
+                            <input type="text" id="name" name="name"
+                                   placeholder="Top X morceaux {{ fromStr }} → {{ toStr }}"
+                                   class="border rounded px-2 py-1">
+                        </div>
+                        <button type="submit"
+                                class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded">
+                            + Créer playlist Navidrome
+                        </button>
+                    </form>
+                {% endif %}
+
+                {% if snapshot.data.top_tracks is empty %}
+                    <div class="p-4 text-sm text-slate-500">Aucune donnée.</div>
+                {% else %}
+                    <div class="max-h-[600px] overflow-y-auto">
+                        <table class="w-full text-sm">
+                            <thead class="bg-slate-100 text-slate-600 text-left text-xs sticky top-0">
+                            <tr>
+                                <th class="px-3 py-2 w-10">#</th>
+                                <th class="px-3 py-2">Titre</th>
+                                <th class="px-3 py-2 w-20 text-right">Plays</th>
+                            </tr>
+                            </thead>
+                            <tbody class="divide-y">
+                            {% for row in snapshot.data.top_tracks %}
+                                <tr>
+                                    <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
+                                    <td class="px-3 py-1.5">
+                                        <div class="font-medium">{{ row.title }}</div>
+                                        <div class="text-xs text-slate-500">
+                                            {{ row.artist }}{% if row.album %} — {{ row.album }}{% endif %}
+                                        </div>
+                                    </td>
+                                    <td class="px-3 py-1.5 text-right">{{ row.plays|number_format(0, '.', ' ') }}</td>
+                                </tr>
+                            {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                {% endif %}
+            </div>
+        </div>
+    {% endif %}
+
+    {% if recent is not empty %}
+        <div class="bg-white shadow rounded overflow-hidden">
+            <div class="px-4 py-3 border-b bg-slate-50">
+                <h2 class="font-semibold text-sm">Dernières fenêtres calculées</h2>
+            </div>
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2">Fenêtre</th>
+                    <th class="px-3 py-2">Client</th>
+                    <th class="px-3 py-2">Calculé le</th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for snap in recent %}
+                    {% set rFrom = snap.windowFrom|date('Y-m-d') %}
+                    {% set rTo = snap.windowTo|date_modify('-1 day')|date('Y-m-d') %}
+                    {% set rArgs = { from: rFrom, to: rTo } %}
+                    {% if snap.client %}{% set rArgs = rArgs|merge({ client: snap.client }) %}{% endif %}
+                    <tr>
+                        <td class="px-3 py-1.5">
+                            <a class="text-blue-700 hover:underline" href="{{ path('app_stats_tops', rArgs) }}">
+                                {{ rFrom }} → {{ rTo }}
+                            </a>
+                        </td>
+                        <td class="px-3 py-1.5 text-slate-500">{{ snap.client ?? '—' }}</td>
+                        <td class="px-3 py-1.5 text-slate-500">{{ snap.computedAt|date('Y-m-d H:i') }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Navidrome/NavidromeRepositoryStatsTest.php
+++ b/tests/Navidrome/NavidromeRepositoryStatsTest.php
@@ -302,6 +302,79 @@ class NavidromeRepositoryStatsTest extends TestCase
         $this->assertSame(3, $tracks[1]['plays']);
     }
 
+    public function testGetTopAlbumsAggregatesPlaysAndTrackCount(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        // Album "Discovery" — Daft Punk: 2 tracks, 7 total plays.
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-d1', 'One More Time', 'Daft Punk', 180, 'Discovery');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-d2', 'Aerodynamic', 'Daft Punk', 180, 'Discovery');
+        // Album "Selected Ambient" — Aphex Twin: 1 track, 4 plays.
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a1', 'Xtal', 'Aphex Twin', 180, 'Selected Ambient');
+        // Empty-album track must be ignored.
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-e1', 'Loose', 'Random', 180, '');
+
+        for ($i = 0; $i < 4; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-d1', date('Y-m-d H:i:s', strtotime("-{$i} day - 1 hour")));
+        }
+        for ($i = 0; $i < 3; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-d2', date('Y-m-d H:i:s', strtotime("-{$i} day - 2 hour")));
+        }
+        for ($i = 0; $i < 4; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-a1', date('Y-m-d H:i:s', strtotime("-{$i} day - 3 hour")));
+        }
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-e1', date('Y-m-d H:i:s', strtotime('-1 hour')));
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $albums = $repo->getTopAlbums(null, null, 10);
+
+        $this->assertCount(2, $albums, 'empty album skipped');
+        $this->assertSame('Discovery', $albums[0]['album']);
+        $this->assertSame('Daft Punk', $albums[0]['album_artist']);
+        $this->assertSame(7, $albums[0]['plays']);
+        $this->assertSame(2, $albums[0]['track_count']);
+        $this->assertSame('mf-d1', $albums[0]['sample_track_id'], 'most-played track in album');
+
+        $this->assertSame('Selected Ambient', $albums[1]['album']);
+        $this->assertSame(4, $albums[1]['plays']);
+        $this->assertSame(1, $albums[1]['track_count']);
+        $this->assertSame('mf-a1', $albums[1]['sample_track_id']);
+    }
+
+    public function testGetTopAlbumsRespectsWindowAndClient(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track A', 'Artist X', 180, 'Album X');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Track B', 'Artist Y', 180, 'Album Y');
+
+        // Outside window
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2024-01-01 10:00:00', 'Symfonium');
+        // Inside window, two clients
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-06-01 10:00:00', 'Symfonium');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2025-06-02 10:00:00', 'Symfonium');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2', '2025-06-03 10:00:00', 'DSub');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $from = new \DateTimeImmutable('2025-01-01 00:00:00');
+        $to = new \DateTimeImmutable('2026-01-01 00:00:00');
+
+        $all = $repo->getTopAlbums($from, $to, 10);
+        $this->assertCount(2, $all);
+        $this->assertSame('Album X', $all[0]['album']);
+        $this->assertSame(2, $all[0]['plays']);
+
+        $symf = $repo->getTopAlbums($from, $to, 10, 'Symfonium');
+        $this->assertCount(1, $symf);
+        $this->assertSame('Album X', $symf[0]['album']);
+        $this->assertSame(2, $symf[0]['plays']);
+    }
+
+    public function testGetTopAlbumsReturnsEmptyWhenScrobblesMissing(): void
+    {
+        NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: false);
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $this->assertSame([], $repo->getTopAlbums(null, null, 10));
+    }
+
     public function testTopArtistsTimelineExposesArtistIdForCovers(): void
     {
         $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);

--- a/tests/Service/TopsServiceTest.php
+++ b/tests/Service/TopsServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\TopSnapshot;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\TopSnapshotRepository;
+use App\Service\TopsService;
+use App\Tests\Navidrome\NavidromeFixtureFactory;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class TopsServiceTest extends TestCase
+{
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/navidrome-tops-' . uniqid() . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testNormalizeWindowRoundsToDayBoundaries(): void
+    {
+        $from = new \DateTimeImmutable('2026-01-15 14:32:00');
+        $to = new \DateTimeImmutable('2026-01-20 09:00:00');
+
+        [$nFrom, $nTo] = TopsService::normalizeWindow($from, $to);
+
+        $this->assertSame('2026-01-15 00:00:00', $nFrom->format('Y-m-d H:i:s'));
+        // to is rounded to start-of-next-day so [from, to) covers the 20th inclusive.
+        $this->assertSame('2026-01-21 00:00:00', $nTo->format('Y-m-d H:i:s'));
+    }
+
+    public function testNormalizeWindowEnforcesAtLeastOneDay(): void
+    {
+        $same = new \DateTimeImmutable('2026-01-15 09:00:00');
+        [$from, $to] = TopsService::normalizeWindow($same, $same);
+
+        $this->assertSame('2026-01-15 00:00:00', $from->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-01-16 00:00:00', $to->format('Y-m-d H:i:s'));
+    }
+
+    public function testComputePopulatesAllSections(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track A', 'Artist X', 180, 'Album X');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Track B', 'Artist X', 180, 'Album X');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'Track C', 'Artist Y', 180, 'Album Y');
+
+        for ($i = 0; $i < 4; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2026-01-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT) . ' 10:00:00');
+        }
+        for ($i = 0; $i < 2; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2', '2026-01-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT) . ' 11:00:00');
+        }
+        for ($i = 0; $i < 3; $i++) {
+            NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-3', '2026-01-' . str_pad((string) ($i + 1), 2, '0', STR_PAD_LEFT) . ' 12:00:00');
+        }
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persisted = [];
+        $em->method('persist')->willReturnCallback(function (object $e) use (&$persisted): void {
+            $persisted[] = $e;
+        });
+        $em->method('flush');
+
+        $repo = $this->createMock(TopSnapshotRepository::class);
+        $repo->method('findOneByWindow')->willReturn(null);
+
+        $navidrome = new NavidromeRepository($this->dbPath, 'admin');
+        $service = new TopsService($navidrome, $repo, $em);
+
+        $from = new \DateTimeImmutable('2026-01-01 00:00:00');
+        $to = new \DateTimeImmutable('2026-01-31 00:00:00');
+        $snapshot = $service->compute($from, $to);
+
+        $this->assertCount(1, $persisted, 'snapshot persisted on first compute');
+        $this->assertInstanceOf(TopSnapshot::class, $persisted[0]);
+
+        $data = $snapshot->getData();
+        $this->assertSame(9, $data['total_plays']);
+        $this->assertSame(3, $data['distinct_tracks']);
+        $this->assertCount(2, $data['top_artists']);
+        $this->assertSame('Artist X', $data['top_artists'][0]['artist']);
+        $this->assertSame(6, $data['top_artists'][0]['plays']);
+
+        $this->assertCount(2, $data['top_albums']);
+        $this->assertSame('Album X', $data['top_albums'][0]['album']);
+        $this->assertSame(6, $data['top_albums'][0]['plays']);
+        $this->assertSame(2, $data['top_albums'][0]['track_count']);
+
+        $this->assertCount(3, $data['top_tracks']);
+        $this->assertSame('mf-1', $data['top_tracks'][0]['id']);
+        $this->assertSame(4, $data['top_tracks'][0]['plays']);
+    }
+
+    public function testComputeUpdatesExistingSnapshotWithoutPersisting(): void
+    {
+        NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persistCount = 0;
+        $em->method('persist')->willReturnCallback(function () use (&$persistCount): void {
+            $persistCount++;
+        });
+        $em->method('flush');
+
+        $existing = new TopSnapshot(
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-02-01 00:00:00'),
+            null,
+        );
+        $repo = $this->createMock(TopSnapshotRepository::class);
+        $repo->method('findOneByWindow')->willReturn($existing);
+        // Force an id so the service does NOT persist it as new.
+        $reflect = new \ReflectionProperty(TopSnapshot::class, 'id');
+        $reflect->setValue($existing, 42);
+
+        $navidrome = new NavidromeRepository($this->dbPath, 'admin');
+        $service = new TopsService($navidrome, $repo, $em);
+
+        $service->compute(
+            new \DateTimeImmutable('2026-01-01 00:00:00'),
+            new \DateTimeImmutable('2026-01-31 00:00:00'),
+        );
+
+        $this->assertSame(0, $persistCount, 'existing snapshot must not be re-persisted');
+    }
+}


### PR DESCRIPTION
Nouvelle page dédiée affichant le top 50 artistes / 100 albums / 500 morceaux sur une fenêtre [from, to] arbitraire et un filtre client optionnel. Les snapshots sont cachés dans une nouvelle table top_snapshot keyée par (window_from, window_to, client) — bornes en epoch arrondies au jour côté contrôleur pour réutiliser un snapshot entre clics. Bouton « + Créer playlist Navidrome » sur le top morceaux qui appelle Subsonic createPlaylist avec les N premiers IDs (1≤N≤500, nom personnalisable). Commande app:stats:tops:compute pour planifier le calcul depuis le crontab (type RunHistory stats-tops). Lien dans la navbar.

https://claude.ai/code/session_01N1boRd1M8egKv8HCMWFf2h