### PR TITLE
Add dark mode support to favicon with prefers-color-scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Changed
+- **Favicon** : adapte automatiquement sa couleur au thème système
+  (`prefers-color-scheme`). La note reste sombre (`#0f172a`) en mode
+  clair et passe en blanc cassé (`#f8fafc`) en mode dark, pour rester
+  lisible sur les onglets sombres de Firefox/Chrome.
+
 ### Added
 - **Page `/stats/tops` — tops fenêtre libre** : nouvelle page dédiée
   qui affiche, sur une fenêtre `[from, to]` arbitraire (sélecteur

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,4 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32" fill="#0f172a">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="32" height="32">
+  <style>
+    path { fill: #0f172a; }
+    @media (prefers-color-scheme: dark) {
+      path { fill: #f8fafc; }
+    }
+  </style>
   <path d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3h-6z"/>
 </svg>


### PR DESCRIPTION
## Summary
Updated the favicon to automatically adapt its color based on the system's color scheme preference, improving visibility across different browser tab themes.

## Changes
- **Favicon styling**: Moved fill color from inline SVG attribute to a `<style>` block with media query support
  - Light mode (default): Dark color (`#0f172a`) for visibility on light backgrounds
  - Dark mode: Light off-white color (`#f8fafc`) for visibility on dark backgrounds
  - Uses `@media (prefers-color-scheme: dark)` for automatic theme detection

## Implementation Details
The favicon now respects the user's system color scheme preference, ensuring it remains readable on both light and dark browser tab backgrounds (particularly important for Firefox and Chrome which use dark tabs in dark mode). The change uses standard CSS media queries with no JavaScript required.

https://claude.ai/code/session_017X6WF5s52Y29VKEBSwrZ4A