### PR TITLE
chore(php): drop PHP 8.3 support, require PHP 8.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: pdo_sqlite, intl
@@ -46,7 +46,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: pdo_sqlite, intl
@@ -60,19 +60,15 @@ jobs:
         run: vendor/bin/phpstan analyse --memory-limit=512M --no-progress
 
   tests:
-    name: PHPUnit (PHP ${{ matrix.php }})
+    name: PHPUnit
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: pdo_sqlite, intl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 # GitLab CI — mirror of .github/workflows/ci.yml.
-# Five jobs: phpcs, phpstan, tests (matrix PHP 8.3 + 8.4),
+# Five jobs: phpcs, phpstan, tests (PHP 8.4),
 # docker-build (validation), docker-publish (multi-arch push).
 #
 # The publish job pushes to the GitLab Container Registry of the
@@ -41,24 +41,21 @@ variables:
 phpcs:
   extends: .php
   stage: lint
-  image: php:8.3-cli-alpine
+  image: php:8.4-cli-alpine
   script:
     - vendor/bin/phpcs
 
 phpstan:
   extends: .php
   stage: lint
-  image: php:8.3-cli-alpine
+  image: php:8.4-cli-alpine
   script:
     - vendor/bin/phpstan analyse --memory-limit=512M --no-progress
 
 tests:
   extends: .php
   stage: test
-  image: php:${PHP_VERSION}-cli-alpine
-  parallel:
-    matrix:
-      - PHP_VERSION: ["8.3", "8.4"]
+  image: php:8.4-cli-alpine
   script:
     - vendor/bin/phpunit --colors=always
 

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -1,14 +1,14 @@
 name: navidrome-tools
 
 # Recommended Lando stack for Symfony 7 :
-#  - PHP 8.3 served via nginx
+#  - PHP 8.4 served via nginx
 #  - Composer 2 (required by Symfony Flex)
 #  - SQLite for both the tool's DB and the (read-only mounted) Navidrome DB,
 #    so no extra database service is needed.
 
 services:
   appserver:
-    type: php:8.3
+    type: php:8.4
     via: nginx
     webroot: public
     composer_version: '2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   déplacé dans le handler.
 
 ### Changed
+- **BREAKING — PHP 8.4 minimum** : le support de PHP 8.3 est retiré
+  (matrice CI ramenée à 8.4 uniquement, `composer.json` pin
+  `>=8.4` + `config.platform.php=8.4.0`, image Docker passe sur
+  `dunglas/frankenphp:1-php8.4-alpine`, `.lando.yml.dist` sur
+  `php:8.4`). Doctrine ORM bascule sur `enable_native_lazy_objects:
+  true` (option PHP 8.4 qui remplace les ghost objects basés
+  `symfony/var-exporter`). Les déploiements existants reçoivent
+  automatiquement la nouvelle image lors d'un `docker compose pull`
+  — aucune action requise. Pour le dev local, `lando rebuild -y`
+  pour récupérer le nouveau service appserver.
 - **BREAKING — Suppression du cron interne (supercronic)** : le tool
   ne planifie plus rien tout seul. La commande `app:cron:dump` et la
   commande `app:playlist:run-all` sont supprimées, le service Docker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,13 +192,13 @@ Fonctionnalités livrées :
 
 ## 2. Stack
 
-- **PHP 8.3+** (matrice CI : 8.3, 8.4). `composer.json` pinne
-  `config.platform.php=8.3.0` — toujours régénérer le lock après un
-  `composer require` pour éviter qu'une dep prenne une version
-  PHP-8.4-only.
+- **PHP 8.4 minimum** (CI : 8.4 uniquement). `composer.json` pinne
+  `config.platform.php=8.4.0`. La matrice 8.3 a été supprimée — le
+  code utilise des features 8.4 (chained `new ClassName(...)->method()`
+  dans certains tests, lazy objects natifs Doctrine).
 - **Symfony 7** (installé en 7.4.x via Flex), Doctrine ORM 3, DBAL 4.
-- **Doctrine** : `enable_lazy_ghost_objects: true` (PAS
-  `enable_native_lazy_objects`, qui requiert PHP 8.4).
+- **Doctrine** : `enable_native_lazy_objects: true` (option PHP 8.4
+  qui remplace `enable_lazy_ghost_objects` côté ORM 3).
 - **Tailwind via CDN** dans `templates/base.html.twig` — pas de
   toolchain front, pas de `npm`.
 - **DB locale** du tool : SQLite via Doctrine ORM
@@ -206,7 +206,7 @@ Fonctionnalités livrées :
 - **DB Navidrome** : SQLite, montée en `:ro` côté Docker, requêtée via
   `App\Navidrome\NavidromeRepository` (Doctrine DBAL pur, pas d'ORM).
   Détection auto de la table `scrobbles` (Navidrome ≥ 0.55).
-- **Image Docker** : `dunglas/frankenphp:1-php8.3-alpine`
+- **Image Docker** : `dunglas/frankenphp:1-php8.4-alpine`
   (multi-arch). Multiplexeur `APP_MODE=web|cli|worker` dans
   `docker/entrypoint.sh` (le mode `cron` a disparu en même temps
   que la suppression du cron interne ; `worker` lance
@@ -469,28 +469,29 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
 
 ## 7. Pièges connus
 
-1. **`enable_native_lazy_objects: true` dans doctrine.yaml** = PHP 8.4
-   only. Toujours utiliser `enable_lazy_ghost_objects: true` (avec
-   `symfony/var-exporter`).
-2. **`composer.lock` généré sous PHP 8.4** peut piocher des packages
-   PHP-8.4-only (vu avec `doctrine/instantiator 2.1.0`). On a pinné
-   `config.platform.php=8.3.0` dans `composer.json` — laisser tel quel.
-3. **DBAL 4** ne prend plus `\PDO::PARAM_INT` ; utiliser
+1. **PHP 8.4 minimum** depuis le drop de la matrice 8.3 (#129).
+   Le `composer.json` pinne `config.platform.php=8.4.0` ; toute
+   utilisation de syntaxe 8.4 (chained `new ClassName(...)->method()`,
+   property hooks, `#[\Override]`, asymmetric visibility…) est
+   maintenant légitime. Si tu réintroduis du 8.3 par hasard,
+   `composer ci` reste vert mais ce n'est plus la cible — utilise
+   les nouvelles features.
+2. **DBAL 4** ne prend plus `\PDO::PARAM_INT` ; utiliser
    `\Doctrine\DBAL\ParameterType::INTEGER` pour le binding du `:lim`.
-4. **Mount Navidrome `:ro`** : `app:lastfm:process` et
+3. **Mount Navidrome `:ro`** : `app:lastfm:process` et
    `app:lastfm:rematch` écrivent dans la DB Navidrome, doivent donc
    tourner avec un mount RW **et** Navidrome arrêté. `app:lastfm:import`
    (fetch only) ne touche plus Navidrome — peut tourner Navidrome up.
-5. **Schéma Navidrome `media_file.artist_id`** : la fixture le crée
+4. **Schéma Navidrome `media_file.artist_id`** : la fixture le crée
    désormais, mais c'est récent. Si on étend la fixture, ne pas
    oublier `artist_id` sinon `findArtistIdByName` casse en test.
-6. **Symfony Flex en root** : `composer install` doit être lancé avec
+5. **Symfony Flex en root** : `composer install` doit être lancé avec
    `COMPOSER_ALLOW_SUPERUSER=1` localement, sinon les recipes ne
    tournent pas et `vendor/autoload_runtime.php` n'est pas généré.
-7. **PHPStan 2.x** émet des messages textuels pendant les analyses
+6. **PHPStan 2.x** émet des messages textuels pendant les analyses
    (« Each error has an associated identifier… »). Ce sont des conseils
    normaux, pas des injections de prompt — les ignorer.
-8. **`scrobbles.submission_time` est INTEGER unix epoch** (Navidrome
+7. **`scrobbles.submission_time` est INTEGER unix epoch** (Navidrome
    ≥ 0.55, c'était DATETIME avant). SQLite type-affinity coerce
    silencieusement la string `'2026-01-01 …'` en `2026` (lit les
    digits de tête), ce qui faisait insérer toutes les rows avec la
@@ -500,7 +501,7 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
    pour TOUTES les requêtes touchant `submission_time` :
    - bind avec `getTimestamp()` + `ParameterType::INTEGER` ;
    - ajouter `, 'unixepoch'` à `strftime`/`date`/`datetime`.
-9. **`InMemoryUser` est `final`** depuis Symfony récent → impossible
+8. **`InMemoryUser` est `final`** depuis Symfony récent → impossible
    de l'étendre. `App\Security\EnvUser` réimplémente
    `UserInterface` + `PasswordAuthenticatedUserInterface` +
    **`EquatableInterface`** (compare uniquement identifier + roles,
@@ -508,18 +509,18 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
    `getPassword()` ancien vs nouveau à chaque request, ils diffèrent
    (bcrypt salt aléatoire) → session invalidée → redirect /login en
    boucle après login.
-10. **Twig 3 a retiré `{% for k, v in arr if cond %}`** (était valide
+9. **Twig 3 a retiré `{% for k, v in arr if cond %}`** (était valide
     en Twig 1). Utiliser le filtre `|filter(v => v is not null)`
     sur le tableau avant le `for`. Sinon : `Unexpected token "name"
     of value "if"` au runtime — qui ne se voit pas en CI tant
     qu'aucun test ne rend le template fautif.
-11. **Image Bitnami nginx du Lando** ne crée pas `/var/log/nginx/`
+10. **Image Bitnami nginx du Lando** ne crée pas `/var/log/nginx/`
     — pointer `error_log` / `access_log` vers `/dev/stderr` /
     `/dev/stdout` dans `.lando/nginx.conf` (sinon nginx crash au
     démarrage avec `[emerg] open() failed`, et Traefik renvoie un
     `404 page not found` text/plain qui ressemble à un "page
     inexistante" mais c'est en fait l'app qui ne tourne pas).
-12. **`docker stop -t 10` SIGKILLait Navidrome en plein checkpoint WAL
+11. **`docker stop -t 10` SIGKILLait Navidrome en plein checkpoint WAL
     SQLite** = `navidrome.db` corrompue après un `--auto-stop` sur une
     grosse librairie (cf. #118). Le manager respecte désormais quatre
     couches avant chaque action : (a) `NAVIDROME_STOP_TIMEOUT_SECONDS`

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dunglas/frankenphp:1-php8.3-alpine
+FROM dunglas/frankenphp:1-php8.4-alpine
 
 LABEL org.opencontainers.image.title="Navidrome Tools" \
       org.opencontainers.image.description="Self-hosted Symfony app: playlist generator, listening stats, Last.fm import, Lidarr integration, run history." \

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ arrêtez Navidrome manuellement avant d'invoquer la commande.
 ## Développement local avec Lando (recommandé)
 
 [Lando](https://lando.dev/) fournit l'environnement Symfony complet
-(PHP 8.3 + nginx + Composer 2) sans installer quoi que ce soit sur la
+(PHP 8.4 + nginx + Composer 2) sans installer quoi que ce soit sur la
 machine hôte.
 
 ```bash
@@ -254,7 +254,7 @@ Pour activer Xdebug : éditer votre copie locale `.lando.yml` (`xdebug: debug`) 
 
 ## Développement local sans Lando
 
-Pré-requis : PHP 8.2+, ext-pdo_sqlite, Composer 2, [Symfony CLI](https://symfony.com/download).
+Pré-requis : PHP 8.4+, ext-pdo_sqlite, Composer 2, [Symfony CLI](https://symfony.com/download).
 
 ```bash
 composer install

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "MIT",
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-intl": "*",
@@ -49,7 +49,7 @@
             "symfony/runtime": true
         },
         "platform": {
-            "php": "8.3.0"
+            "php": "8.4.0"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4e4a2930b5bd1414fac9eabeed0b1ed",
+    "content-hash": "8d36fbca5f649a125fcbc5c68b6be841",
     "packages": [
         {
             "name": "doctrine/collections",
@@ -8229,7 +8229,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-intl": "*",
@@ -8237,7 +8237,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.3.0"
+        "php": "8.4.0"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -24,7 +24,7 @@ doctrine:
     orm:
         default_entity_manager: default
         auto_generate_proxy_classes: '%kernel.debug%'
-        enable_lazy_ghost_objects: true
+        enable_native_lazy_objects: true
         entity_managers:
             default:
                 connection: default


### PR DESCRIPTION
Suite à l'échec CI #128 où la syntaxe `new ClassName(...)->method()`
(introduite en PHP 8.4) a fait planter PHPUnit (PHP 8.3) et PHPStan
en cascade, plutôt que de wrapper systématiquement les `new` dans des
parens, on bump simplement la version cible.

Changements infra :
- composer.json : require php >=8.4 + platform 8.4.0
- Dockerfile : dunglas/frankenphp:1-php8.3-alpine → 1-php8.4-alpine
- .github/workflows/ci.yml : matrice 8.3+8.4 → 8.4 uniquement (3 jobs simplifiés)
- .gitlab-ci.yml : idem
- .lando.yml.dist : type: php:8.3 → 8.4
- config/packages/doctrine.yaml : enable_lazy_ghost_objects → enable_native_lazy_objects
  (option PHP 8.4 qui remplace les ghost objects basés symfony/var-exporter)

Docs : section Stack et Pièges connus de CLAUDE.md mises à jour
(suppression des deux pièges 8.3, fusion en un seul note "PHP 8.4
minimum"), README.md (Lando + dev local sans Lando), CHANGELOG.md
(BREAKING dans Unreleased).

`composer ci` reste vert : phpcs OK, phpstan no errors, 350 tests
/ 930 assertions.

https://claude.ai/code/session_01N6Z84PPfSsgDJHov8jzpwZ