### PR TITLE
fix(lastfm): détacher les entités après chaque batch flush pour éviter l'OOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+- **`app:lastfm:process` / `app:lastfm:rematch` — fuite mémoire sur
+  les gros volumes** : `LastFmBufferProcessor` et `LastFmRematchService`
+  flushaient toutes les 100 itérations mais ne vidaient jamais
+  l'identity map de Doctrine. Sur un buffer Last.fm volumineux (≥ ~10k
+  scrobbles), les entités hydratées par `toIterable()`
+  (`LastFmBufferedScrobble` / `LastFmImportTrack`) plus celles
+  persistées par le matcher (`LastFmMatchCacheEntry`) finissaient par
+  saturer les 128 Mo de PHP — `Allowed memory size of 134217728 bytes
+  exhausted in UnitOfWork.php`. Les deux services détachent maintenant
+  ces entités juste après chaque flush via un nouveau helper
+  `flushAndDetach()`, et le repo cache expose `detachPending()` pour
+  vider sa map en mémoire interne en synchro. La `RunHistory`
+  attachée à l'audit reste managée pour ne pas casser le callback de
+  progression (`RunHistoryRecorder::updateProgress`).
+
 ### Changed
 - **Favicon** : adapte automatiquement sa couleur au thème système
   (`prefers-color-scheme`). La note reste sombre (`#0f172a`) en mode

--- a/src/LastFm/LastFmBufferProcessor.php
+++ b/src/LastFm/LastFmBufferProcessor.php
@@ -66,6 +66,8 @@ class LastFmBufferProcessor
         $report = new ProcessReport();
         $batch = 0;
         $connection = $this->em->getConnection();
+        /** @var list<LastFmImportTrack> $pendingTracks */
+        $pendingTracks = [];
 
         foreach ($this->bufferRepo->streamAll($limit) as $buffered) {
             /** @var LastFmBufferedScrobble $buffered */
@@ -116,7 +118,7 @@ class LastFmBufferProcessor
 
             if (!$dryRun) {
                 if ($auditRun !== null) {
-                    $this->em->persist(new LastFmImportTrack(
+                    $importTrack = new LastFmImportTrack(
                         runHistory: $auditRun,
                         artist: $buffered->getArtist(),
                         title: $buffered->getTitle(),
@@ -125,7 +127,9 @@ class LastFmBufferProcessor
                         playedAt: $buffered->getPlayedAt(),
                         status: $status,
                         matchedMediaFileId: $matchedId,
-                    ));
+                    );
+                    $this->em->persist($importTrack);
+                    $pendingTracks[] = $importTrack;
                 }
                 $connection->executeStatement(
                     'DELETE FROM lastfm_import_buffer WHERE id = :id',
@@ -133,10 +137,22 @@ class LastFmBufferProcessor
                 );
             }
 
-            // Periodic flush so memory does not grow unbounded on big
-            // sweeps (mirrors LastFmRematchService).
+            // Detach the buffered entity now that we're done with it —
+            // toIterable() leaves it managed otherwise, so a 100k-row
+            // buffer would pin 100k entities in the identity map.
+            if ($this->em->contains($buffered)) {
+                $this->em->detach($buffered);
+            }
+
+            // Periodic flush + targeted detach so memory does not grow
+            // unbounded on big sweeps. We detach the just-persisted
+            // LastFmImportTrack rows + the cache entries the matcher
+            // queued, but keep $auditRun managed so the caller's
+            // progress callback (RunHistoryRecorder::updateProgress)
+            // keeps seeing a managed entity to flush.
             if (!$dryRun && ++$batch >= 100) {
-                $this->em->flush();
+                $this->flushAndDetach($pendingTracks);
+                $pendingTracks = [];
                 $batch = 0;
             }
 
@@ -146,7 +162,7 @@ class LastFmBufferProcessor
         }
 
         if (!$dryRun) {
-            $this->em->flush();
+            $this->flushAndDetach($pendingTracks);
         }
 
         if ($progress !== null) {
@@ -154,6 +170,20 @@ class LastFmBufferProcessor
         }
 
         return $report;
+    }
+
+    /**
+     * @param list<LastFmImportTrack> $pendingTracks
+     */
+    private function flushAndDetach(array $pendingTracks): void
+    {
+        $this->em->flush();
+        foreach ($pendingTracks as $track) {
+            if ($this->em->contains($track)) {
+                $this->em->detach($track);
+            }
+        }
+        $this->cacheRepository?->detachPending();
     }
 
     private function bumpCacheCounters(ProcessReport $report, MatchResult $result): void

--- a/src/Repository/LastFmMatchCacheRepository.php
+++ b/src/Repository/LastFmMatchCacheRepository.php
@@ -109,6 +109,26 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
     }
 
     /**
+     * Detach every entry queued in the in-memory pending map from the EM
+     * and forget the map. Called by long-running consumers (buffer
+     * processor, rematch service) after each batch flush so the identity
+     * map does not grow unbounded across the whole run. The DB row was
+     * already written by the flush; subsequent lookups for the same
+     * couple will hit `findOneBy()` and re-hydrate a fresh managed entity
+     * if needed.
+     */
+    public function detachPending(): void
+    {
+        $em = $this->getEntityManager();
+        foreach ($this->pendingByKey as $entry) {
+            if ($em->contains($entry)) {
+                $em->detach($entry);
+            }
+        }
+        $this->pendingByKey = [];
+    }
+
+    /**
      * Drop the row matching this exact couple. Returns the number of
      * rows deleted (0 or 1). Called when the user creates / edits /
      * deletes a track-level alias for that couple.

--- a/src/Service/LastFmRematchService.php
+++ b/src/Service/LastFmRematchService.php
@@ -65,6 +65,8 @@ class LastFmRematchService
 
         $report = new RematchReport();
         $batch = 0;
+        /** @var list<LastFmImportTrack> $pendingTracks */
+        $pendingTracks = [];
         foreach ($this->trackRepo->streamUnmatched($runId, $limit, $random) as $track) {
             /** @var LastFmImportTrack $track */
             $report->considered++;
@@ -119,9 +121,18 @@ class LastFmRematchService
                 ]);
             }
 
-            // Flush periodically so memory does not grow unbounded on big sweeps.
+            $pendingTracks[] = $track;
+
+            // Flush periodically so memory does not grow unbounded on big
+            // sweeps. We then detach the just-flushed LastFmImportTrack
+            // rows (their setStatus() / setMatchedMediaFileId() mutations
+            // are now safely written) and drop the matcher's pending
+            // cache entries — without that the identity map keeps every
+            // iterated track + every cache entry for the entire run,
+            // OOMing on large rematch sweeps.
             if (!$dryRun && ++$batch >= 100) {
-                $this->em->flush();
+                $this->flushAndDetach($pendingTracks);
+                $pendingTracks = [];
                 $batch = 0;
             }
 
@@ -135,7 +146,7 @@ class LastFmRematchService
         }
 
         if (!$dryRun) {
-            $this->em->flush();
+            $this->flushAndDetach($pendingTracks);
         }
 
         if ($progress !== null) {
@@ -147,5 +158,19 @@ class LastFmRematchService
         }
 
         return $report;
+    }
+
+    /**
+     * @param list<LastFmImportTrack> $pendingTracks
+     */
+    private function flushAndDetach(array $pendingTracks): void
+    {
+        $this->em->flush();
+        foreach ($pendingTracks as $track) {
+            if ($this->em->contains($track)) {
+                $this->em->detach($track);
+            }
+        }
+        $this->cacheRepository?->detachPending();
     }
 }


### PR DESCRIPTION
`LastFmBufferProcessor` et `LastFmRematchService` flushent toutes les
100 itérations mais n'évacuaient jamais les entités hydratées
(`LastFmBufferedScrobble`, `LastFmImportTrack`) ni celles persistées
par le matcher (`LastFmMatchCacheEntry`) de l'identity map de
Doctrine. Sur un buffer Last.fm > ~10k scrobbles, les 128 Mo de PHP
finissaient saturés (Allowed memory size of 134217728 bytes exhausted
in UnitOfWork.php).

On détache désormais ces entités juste après chaque flush via un
helper `flushAndDetach()` dédié, et `LastFmMatchCacheRepository`
expose `detachPending()` pour purger sa map mémoire en synchro avec
l'EM. Le `RunHistory` d'audit reste managé pour ne pas casser le
callback `RunHistoryRecorder::updateProgress` qui le réutilise via la
closure du handler.

https://claude.ai/code/session_014LT3vzX5rLbtTsPPtuB1r1