### PR TITLE
Sécuriser les écritures Navidrome face aux crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 ## [Unreleased]
 
 ### Added
+- **Crash-safety des écritures Navidrome** (#135) : les imports
+  Last.fm (`app:lastfm:process`, `app:lastfm:rematch`) wrappent
+  désormais chaque batch de 100 INSERT dans une transaction explicite
+  `BEGIN IMMEDIATE` / `COMMIT` côté Navidrome. Un crash mid-batch
+  (kill -9, exception PHP, OOM) déclenche un ROLLBACK SQLite, et les
+  audits + `DELETE FROM lastfm_import_buffer` sont reportés en
+  post-commit Navidrome — donc soit tout passe, soit rien (par
+  batch). La reprise est idempotente via `scrobbleExistsNear` +
+  cross-check intra-batch (`pendingBatchHasNearScrobble`) pour les
+  doublons de scrobble entre rows en vol.
+- **Restore automatique sur corruption détectée**
+  (`NavidromeContainerManager::runWithNavidromeStopped`) : un
+  `PRAGMA quick_check` tourne désormais aussi *après* l'action. S'il
+  fail, le tool restaure le snapshot pré-action (`<dbPath>.backup-…`
+  copié juste avant) et lève une exception explicite (« DB corrompue
+  après l'action — restaurée automatiquement depuis … »). Si la
+  restore échoue elle aussi, Navidrome n'est PAS redémarré et l'erreur
+  pointe vers `app:navidrome:db:restore` pour récupération manuelle.
+- **PRAGMA durabilité sur la connexion write Navidrome** :
+  `busy_timeout=30000` (retry-on-lock pendant 30s si un autre
+  processus tient la DB) et `synchronous=FULL` (fsync complet à
+  chaque COMMIT) appliqués au boot. Plus un `wal_checkpoint(TRUNCATE)`
+  forcé en fin de run pour s'assurer que le WAL est mergé avant que
+  Navidrome ne rouvre la DB.
+- **`app:navidrome:db:check [--integrity]`** : check ad-hoc de
+  l'intégrité de la DB Navidrome. Quick-check par défaut (rapide),
+  `--integrity` pour le full integrity_check (vérifie aussi la
+  cohérence row/index). Read-only, n'arrête pas Navidrome.
+- **`app:navidrome:db:restore [--timestamp=YYYYMMDDHHMMSS] [--list]`** :
+  restauration manuelle d'un snapshot. `--list` affiche les backups
+  disponibles. Sans `--timestamp`, prend le plus récent. Stoppe
+  Navidrome avant restore, le redémarre après.
+- **`NavidromeDbBackup::restore()` + `latestBackup()`** : nouvelles
+  méthodes publiques (la classe ne savait jusqu'ici que `backup()` +
+  `quickCheck()`). `restore()` vérifie le snapshot *avant* d'écraser
+  la DB live, puis re-vérifie après — refuse un restore zombie.
 - **Réglages : bouton « Vider la base tools »** dans une zone
   dangereuse de `/settings`. Vide en une opération les tables
   d'import / audit / cache / snapshots / historiques (buffer Last.fm,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,25 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
     pour ne pas aggraver. Si tu réintroduis un appel à `runProcess`
     pour stop/start ailleurs, **passe par `NavidromeContainerManager`**
     sinon tu by-passes les 4 garde-fous.
+12. **Crash mid-batch pendant un import Last.fm = corruption SQLite**
+    (cf. #135). L'ancien code faisait des `INSERT INTO scrobbles` en
+    autocommit — un kill -9 / OOM / exception PHP en plein milieu
+    laissait des écritures partielles + un WAL incohérent que
+    Navidrome rejouait au prochain démarrage en corrompant la DB. La
+    nouvelle séquence (`runWithNavidromeStopped`) est :
+    backup → quick_check pré → action (avec batchs de 100 inserts
+    encadrés par `BEGIN IMMEDIATE`/`COMMIT` côté `LastFmBufferProcessor`
+    et `LastFmRematchService`) → quick_check post → restore auto +
+    exception explicite si fail → `wal_checkpoint(TRUNCATE)` + close
+    en `finally`. La connexion write Navidrome impose
+    `busy_timeout=30000` + `synchronous=FULL` dès l'ouverture. Si tu
+    écris une nouvelle commande qui touche `scrobbles` ou autre
+    table Navidrome, **passe par
+    `NavidromeRepository::beginWriteTransaction()` /
+    `commitWrite()` / `rollbackWrite()`**. Pas
+    d'`executeStatement('INSERT…')` direct sans tx — sinon tu
+    réintroduis le bug d'origine. Pour récupérer manuellement :
+    `app:navidrome:db:restore [--list]`.
 
 ---
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -91,6 +91,10 @@ services:
             $dbPath: '%navidrome.db_path%'
             $retention: '%navidrome.db_backup_retention%'
 
+    App\Command\NavidromeDbCheckCommand:
+        arguments:
+            $dbPath: '%navidrome.db_path%'
+
     App\Controller\LastFmImportController:
         arguments:
             $navidromeUrl: '%navidrome.url%'

--- a/src/Command/NavidromeDbCheckCommand.php
+++ b/src/Command/NavidromeDbCheckCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Command;
+
+use App\Navidrome\NavidromeDbBackup;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Run a structural sanity check on the Navidrome SQLite file. By default
+ * `PRAGMA quick_check` (fast — same check we run automatically before /
+ * after every `app:lastfm:process` action). With `--integrity` runs the
+ * fuller `PRAGMA integrity_check`, which also verifies row/index
+ * consistency — slower (1-2 min on a 100k-track library) and only worth
+ * it for an explicit diagnostic.
+ *
+ * Read-only — does not require Navidrome to be stopped.
+ */
+#[AsCommand(
+    name: 'app:navidrome:db:check',
+    description: 'Vérifier l\'intégrité du fichier SQLite Navidrome (quick_check par défaut, --integrity pour le check complet).',
+)]
+class NavidromeDbCheckCommand extends Command
+{
+    public function __construct(
+        private readonly NavidromeDbBackup $backup,
+        private readonly string $dbPath,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'integrity',
+            null,
+            InputOption::VALUE_NONE,
+            'Lancer PRAGMA integrity_check (lent — vérifie la cohérence row/index en plus de la structure).',
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!is_file($this->dbPath)) {
+            $io->error(sprintf('DB Navidrome introuvable : %s', $this->dbPath));
+            return Command::FAILURE;
+        }
+
+        if ((bool) $input->getOption('integrity')) {
+            return $this->runIntegrityCheck($io);
+        }
+
+        try {
+            $this->backup->quickCheck();
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success('PRAGMA quick_check : ok');
+        return Command::SUCCESS;
+    }
+
+    private function runIntegrityCheck(SymfonyStyle $io): int
+    {
+        try {
+            $pdo = new \PDO('sqlite:file:' . $this->dbPath . '?mode=ro', null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            $stmt = $pdo->query('PRAGMA integrity_check');
+            /** @var list<string> $rows */
+            $rows = $stmt !== false ? $stmt->fetchAll(\PDO::FETCH_COLUMN) : [];
+        } catch (\PDOException $e) {
+            $io->error(sprintf('Ouverture/lecture impossible : %s', $e->getMessage()));
+            return Command::FAILURE;
+        }
+
+        if ($rows === ['ok']) {
+            $io->success('PRAGMA integrity_check : ok');
+            return Command::SUCCESS;
+        }
+
+        $io->error('PRAGMA integrity_check a remonté des erreurs :');
+        foreach ($rows as $line) {
+            $io->writeln('  • ' . $line);
+        }
+        return Command::FAILURE;
+    }
+}

--- a/src/Command/NavidromeDbRestoreCommand.php
+++ b/src/Command/NavidromeDbRestoreCommand.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Command;
+
+use App\Docker\NavidromeContainerManager;
+use App\Navidrome\NavidromeDbBackup;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Restore the Navidrome SQLite DB from one of the auto-snapshots taken
+ * before each `app:lastfm:process` / `app:lastfm:rematch --auto-stop`
+ * action. By default uses the most recent snapshot.
+ *
+ * Wraps the action with `NavidromeContainerManager::runWithNavidromeStopped(...,
+ * skipPreCheck: true)` so it works on a DB that the standard pre-check
+ * would refuse to open — that's the whole point of this command. The
+ * post-action quick_check on the *restored* file still runs, so a
+ * silently-bad snapshot would surface immediately.
+ */
+#[AsCommand(
+    name: 'app:navidrome:db:restore',
+    description: 'Restaurer la DB Navidrome depuis un snapshot pris automatiquement (par défaut le plus récent).',
+)]
+class NavidromeDbRestoreCommand extends Command
+{
+    public function __construct(
+        private readonly NavidromeDbBackup $backup,
+        private readonly NavidromeContainerManager $container,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'timestamp',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Timestamp du backup à restaurer (YYYYMMDDHHMMSS). Sans cette option, utilise le plus récent.',
+            )
+            ->addOption(
+                'list',
+                null,
+                InputOption::VALUE_NONE,
+                'Lister les backups disponibles puis sortir, sans rien restaurer.',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ((bool) $input->getOption('list')) {
+            return $this->showList($io);
+        }
+
+        $timestamp = $input->getOption('timestamp');
+        $latest = $this->backup->latestBackup();
+
+        if ($timestamp === null && $latest === null) {
+            $io->error('Aucun backup disponible.');
+            return Command::FAILURE;
+        }
+
+        $effective = is_string($timestamp) && $timestamp !== '' ? $timestamp : (string) $latest;
+
+        if (
+            $input->isInteractive() && !$io->confirm(
+                sprintf(
+                    'Restaurer la DB Navidrome depuis le backup %s ? Le contenu actuel sera écrasé.',
+                    $effective,
+                ),
+                false,
+            )
+        ) {
+            $io->warning('Annulation.');
+            return Command::FAILURE;
+        }
+
+        try {
+            $restoredFrom = $this->container->runWithNavidromeStopped(
+                fn (): string => $this->backup->restore(is_string($timestamp) && $timestamp !== '' ? $timestamp : null),
+                skipPreCheck: true,
+            );
+        } catch (\Throwable $e) {
+            $io->error(sprintf('Restore échouée : %s', $e->getMessage()));
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('DB restaurée depuis %s.', $restoredFrom));
+        return Command::SUCCESS;
+    }
+
+    private function showList(SymfonyStyle $io): int
+    {
+        $backups = $this->backup->listBackups();
+        if ($backups === []) {
+            $io->writeln('Aucun backup disponible.');
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        foreach ($backups as $path) {
+            preg_match('/\.backup-(\d+)$/', $path, $m);
+            $size = @filesize($path);
+            $rows[] = [
+                $m[1] ?? '?',
+                $path,
+                $size !== false ? $this->humanSize($size) : '?',
+            ];
+        }
+        $io->table(['Timestamp', 'Path', 'Size'], $rows);
+        $io->writeln(sprintf('%d backup(s) disponible(s).', count($backups)));
+
+        return Command::SUCCESS;
+    }
+
+    private function humanSize(int $bytes): string
+    {
+        $units = ['B', 'KB', 'MB', 'GB'];
+        $i = 0;
+        $size = (float) $bytes;
+        while ($size >= 1024 && $i < count($units) - 1) {
+            $size /= 1024;
+            $i++;
+        }
+
+        return sprintf('%.1f %s', $size, $units[$i]);
+    }
+}

--- a/src/Docker/NavidromeContainerManager.php
+++ b/src/Docker/NavidromeContainerManager.php
@@ -97,9 +97,11 @@ class NavidromeContainerManager
     /**
      * Run $action with Navidrome guaranteed stopped, then restart it if
      * we stopped it ourselves. Restart happens in a finally-equivalent
-     * block, so an action that throws still leaves Navidrome running.
+     * block, so an action that throws still leaves Navidrome running —
+     * unless the post-action quick_check detects corruption, in which
+     * case we restore the pre-action snapshot before restart.
      *
-     * Defense in depth before $action() touches the DB:
+     * Defense in depth around $action():
      *  1. `docker stop -t <NAVIDROME_STOP_TIMEOUT_SECONDS>` — long enough
      *     for Navidrome's SQLite WAL to checkpoint cleanly (default 60s,
      *     vs Docker's 10s default which used to SIGKILL mid-flush and
@@ -109,27 +111,42 @@ class NavidromeContainerManager
      *  3. Snapshot the SQLite file (and its `-wal`/`-shm` siblings) to
      *     `<dbPath>.backup-<ts>` so any future write that goes wrong is
      *     recoverable with a single `cp`. Last 3 by default (configurable).
-     *  4. `PRAGMA quick_check` — if the DB is already broken (e.g. from
-     *     a previous bad shutdown) we abort before writing into it and
-     *     making it worse.
+     *  4. PRE-action `PRAGMA quick_check` — if the DB is already broken
+     *     (e.g. from a previous bad shutdown) we abort before writing
+     *     into it and making it worse. Skippable via $skipPreCheck for
+     *     `app:navidrome:db:restore` which by definition runs on a DB
+     *     that's already in trouble.
+     *  5. POST-action `PRAGMA quick_check` — catches the case where
+     *     $action() crashed mid-write and left the DB inconsistent. If
+     *     it fails we automatically restore the pre-action snapshot
+     *     (step 3) before restarting Navidrome, so Navidrome never
+     *     reopens a corrupt DB.
      *
      * - Feature disabled (`NAVIDROME_CONTAINER_NAME` empty) → run as-is,
      *   skip all the above (we don't know the DB lifecycle).
      * - Status `Stopped` / `NotFound` → still backup + quickCheck before
      *   the action (same risk profile), but don't restart something we
      *   didn't stop.
-     * - Status `Running` → stop, wait, backup, check, run, restart (always).
+     * - Status `Running` → stop, wait, backup, check, run, post-check,
+     *   restart (always, unless restore failed and DB is in limbo).
      * - Status `Unknown` → throw, since we can't safely orchestrate
      *   stop/start without confirming current state.
      *
      * If both the action and the restart fail, the restart failure is
-     * raised with the action error chained as `previous`.
+     * raised with the action error chained as `previous`. If the
+     * post-action quickCheck fails AND the restore fails, Navidrome is
+     * NOT restarted (DB in unknown state) and the user is told to run
+     * `app:navidrome:db:restore` manually.
      *
      * @template T
      * @param  callable(): T $action
+     * @param  bool $skipPreCheck Skip the pre-action `PRAGMA quick_check`
+     *                            — reserved for `app:navidrome:db:restore`
+     *                            which needs to operate on a DB that the
+     *                            check would refuse to open.
      * @return T
      */
-    public function runWithNavidromeStopped(callable $action): mixed
+    public function runWithNavidromeStopped(callable $action, bool $skipPreCheck = false): mixed
     {
         if (!$this->config->isConfigured()) {
             return $action();
@@ -156,12 +173,37 @@ class NavidromeContainerManager
         $this->backup->backup();
 
         $actionException = null;
+        $actionRan = false;
         $result = null;
         try {
-            $this->backup->quickCheck();
+            if (!$skipPreCheck) {
+                $this->backup->quickCheck();
+            }
+            $actionRan = true;
             $result = $action();
         } catch (\Throwable $e) {
             $actionException = $e;
+        }
+
+        // Post-action quickCheck only if the action actually ran. When the
+        // pre-check failed, the DB was already corrupt before our action,
+        // there's no new information to gather and we shouldn't try to
+        // overwrite the existing state.
+        $postCheckFailure = null;
+        if ($actionRan) {
+            try {
+                $this->backup->quickCheck();
+            } catch (\Throwable $e) {
+                $postCheckFailure = $e;
+            }
+        }
+
+        if ($postCheckFailure !== null) {
+            return $this->handlePostActionCorruption(
+                actionException: $actionException,
+                postCheckFailure: $postCheckFailure,
+                weStoppedIt: $weStoppedIt,
+            );
         }
 
         if ($weStoppedIt) {
@@ -188,6 +230,67 @@ class NavidromeContainerManager
         }
 
         return $result;
+    }
+
+    /**
+     * Reached when the post-action quick_check detected corruption. We
+     * always try to restore the pre-action snapshot before letting
+     * Navidrome reopen the file. Two terminal states :
+     *  - restore OK + restart OK → throw an explicit corruption error so
+     *    the user knows the action was rolled back ;
+     *  - restore failed → throw compound error, do NOT restart Navidrome
+     *    (it would reopen a broken DB and propagate the corruption).
+     *
+     * Always throws ; the `mixed` return type just satisfies the parent
+     * method's signature.
+     */
+    private function handlePostActionCorruption(
+        ?\Throwable $actionException,
+        \Throwable $postCheckFailure,
+        bool $weStoppedIt,
+    ): mixed {
+        try {
+            $restoredFrom = $this->backup->restore(null);
+        } catch (\Throwable $restoreException) {
+            throw new NavidromeContainerException(
+                sprintf(
+                    'DB Navidrome corrompue après l\'action ET la restore automatique a échoué : %s. Restaurez manuellement (`app:navidrome:db:restore`) avant de redémarrer Navidrome.',
+                    $restoreException->getMessage(),
+                ),
+                0,
+                $actionException ?? $postCheckFailure,
+            );
+        }
+
+        if ($weStoppedIt) {
+            try {
+                $this->start();
+            } catch (\Throwable $startException) {
+                throw new NavidromeContainerException(
+                    sprintf(
+                        'DB Navidrome corrompue après l\'action — restaurée depuis %s, mais le redémarrage du conteneur a échoué : %s',
+                        $restoredFrom,
+                        $startException->getMessage(),
+                    ),
+                    0,
+                    $actionException ?? $postCheckFailure,
+                );
+            }
+        }
+
+        $actionDetail = $actionException !== null
+            ? sprintf(' Erreur d\'origine de l\'action : %s', $actionException->getMessage())
+            : '';
+
+        throw new NavidromeContainerException(
+            sprintf(
+                'DB Navidrome corrompue après l\'action — restaurée automatiquement depuis %s.%s',
+                $restoredFrom,
+                $actionDetail,
+            ),
+            0,
+            $actionException ?? $postCheckFailure,
+        );
     }
 
     /**

--- a/src/LastFm/LastFmBufferProcessor.php
+++ b/src/LastFm/LastFmBufferProcessor.php
@@ -135,6 +135,12 @@ class LastFmBufferProcessor
                         $buffered->getPlayedAt(),
                         $toleranceSeconds,
                     )
+                    || $this->pendingBatchHasNearScrobble(
+                        $pending,
+                        $result->mediaFileId,
+                        $buffered->getPlayedAt(),
+                        $toleranceSeconds,
+                    )
                 ) {
                     $report->duplicates++;
                     $status = LastFmImportTrack::STATUS_DUPLICATE;
@@ -195,6 +201,48 @@ class LastFmBufferProcessor
         }
 
         return $report;
+    }
+
+    /**
+     * Cross-check the in-flight pending batch for a near-scrobble that the
+     * current iteration would otherwise duplicate. `scrobbleExistsNear`
+     * only sees what previous batches committed — without this helper, two
+     * buffer rows for the same scrobble (same media_file + ±tolerance
+     * seconds, e.g. a Last.fm fetch retry that double-buffered) would both
+     * be marked « inserted » and end up doubly inserted in Navidrome.
+     *
+     * @param list<array{
+     *     bufferId: int,
+     *     artist: string,
+     *     title: string,
+     *     album: ?string,
+     *     mbid: ?string,
+     *     playedAt: \DateTimeImmutable,
+     *     status: string,
+     *     matchedId: ?string,
+     *     willInsertScrobble: bool,
+     * }> $pending
+     */
+    private function pendingBatchHasNearScrobble(
+        array $pending,
+        string $mediaFileId,
+        \DateTimeImmutable $playedAt,
+        int $toleranceSeconds,
+    ): bool {
+        $ts = $playedAt->getTimestamp();
+        foreach ($pending as $row) {
+            if (!$row['willInsertScrobble']) {
+                continue;
+            }
+            if ($row['matchedId'] !== $mediaFileId) {
+                continue;
+            }
+            if (abs($row['playedAt']->getTimestamp() - $ts) <= $toleranceSeconds) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/src/LastFm/LastFmBufferProcessor.php
+++ b/src/LastFm/LastFmBufferProcessor.php
@@ -8,6 +8,7 @@ use App\Entity\RunHistory;
 use App\Navidrome\NavidromeRepository;
 use App\Repository\LastFmBufferedScrobbleRepository;
 use App\Repository\LastFmMatchCacheRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -22,11 +23,29 @@ use Psr\Log\NullLogger;
  * This is the only place that writes to Navidrome — call it with Navidrome
  * stopped (the caller owns the pre-flight via NavidromeContainerManager).
  *
+ * Crash-safety contract — each batch of {@see self::BATCH_SIZE} buffer rows
+ * is processed atomically:
+ *  1. Open `BEGIN IMMEDIATE` on the Navidrome connection.
+ *  2. INSERT every match'ed scrobble inside the transaction.
+ *  3. COMMIT.
+ *  4. Only THEN persist `LastFmImportTrack` audit rows, DELETE the buffer
+ *     entries, flush app-DB.
+ *
+ * If anything in steps 1-3 throws (PHP crash, kill -9 mid-INSERT, etc.) the
+ * Navidrome rollback discards the partial writes ; the audit rows haven't
+ * been persisted yet ; and the buffer rows haven't been deleted, so a re-run
+ * picks them up. Dedup via {@see NavidromeRepository::scrobbleExistsNear()}
+ * keeps the re-run idempotent. The post-commit step (4) is on the app-DB
+ * which can fail independently — the resulting drift is recovered on
+ * re-run by the same dedup mechanism.
+ *
  * Idempotent: a buffer row processed twice ends up with one Navidrome
  * scrobble + one audit row, then disappears from the buffer.
  */
 class LastFmBufferProcessor
 {
+    private const int BATCH_SIZE = 100;
+
     private LoggerInterface $logger;
 
     public function __construct(
@@ -64,120 +83,202 @@ class LastFmBufferProcessor
         $this->cacheRepository?->purgeStale($this->cacheTtlDays);
 
         $report = new ProcessReport();
-        $batch = 0;
-        $connection = $this->em->getConnection();
-        /** @var list<LastFmImportTrack> $pendingTracks */
-        $pendingTracks = [];
+        $appConnection = $this->em->getConnection();
+        /** @var list<array{
+         *     bufferId: int,
+         *     artist: string,
+         *     title: string,
+         *     album: ?string,
+         *     mbid: ?string,
+         *     playedAt: \DateTimeImmutable,
+         *     status: string,
+         *     matchedId: ?string,
+         *     willInsertScrobble: bool,
+         * }> $pending
+         */
+        $pending = [];
 
-        foreach ($this->bufferRepo->streamAll($limit) as $buffered) {
-            /** @var LastFmBufferedScrobble $buffered */
-            $report->considered++;
+        try {
+            foreach ($this->bufferRepo->streamAll($limit) as $buffered) {
+                /** @var LastFmBufferedScrobble $buffered */
+                $report->considered++;
 
-            $scrobble = new LastFmScrobble(
-                artist: $buffered->getArtist(),
-                title: $buffered->getTitle(),
-                album: $buffered->getAlbum() ?? '',
-                mbid: $buffered->getMbid(),
-                playedAt: $buffered->getPlayedAt(),
-            );
+                $scrobble = new LastFmScrobble(
+                    artist: $buffered->getArtist(),
+                    title: $buffered->getTitle(),
+                    album: $buffered->getAlbum() ?? '',
+                    mbid: $buffered->getMbid(),
+                    playedAt: $buffered->getPlayedAt(),
+                );
 
-            $result = $this->matcher->match($scrobble);
-            $this->bumpCacheCounters($report, $result);
+                $result = $this->matcher->match($scrobble);
+                $this->bumpCacheCounters($report, $result);
 
-            if ($result->status === MatchResult::STATUS_SKIPPED) {
-                $report->skipped++;
-                $status = LastFmImportTrack::STATUS_SKIPPED;
-                $matchedId = null;
-                $this->logger->debug('Buffer skipped (alias): {artist} — {title}', [
-                    'artist' => $buffered->getArtist(),
-                    'title' => $buffered->getTitle(),
-                ]);
-            } elseif ($result->mediaFileId === null) {
-                $report->unmatched++;
-                $status = LastFmImportTrack::STATUS_UNMATCHED;
-                $matchedId = null;
-            } elseif (
-                $this->navidrome->scrobbleExistsNear(
-                    $userId,
-                    $result->mediaFileId,
-                    $buffered->getPlayedAt(),
-                    $toleranceSeconds,
-                )
-            ) {
-                $report->duplicates++;
-                $status = LastFmImportTrack::STATUS_DUPLICATE;
-                $matchedId = $result->mediaFileId;
-            } else {
-                $report->inserted++;
-                $status = LastFmImportTrack::STATUS_INSERTED;
-                $matchedId = $result->mediaFileId;
+                if ($result->status === MatchResult::STATUS_SKIPPED) {
+                    $report->skipped++;
+                    $status = LastFmImportTrack::STATUS_SKIPPED;
+                    $matchedId = null;
+                    $willInsert = false;
+                    $this->logger->debug('Buffer skipped (alias): {artist} — {title}', [
+                        'artist' => $buffered->getArtist(),
+                        'title' => $buffered->getTitle(),
+                    ]);
+                } elseif ($result->mediaFileId === null) {
+                    $report->unmatched++;
+                    $status = LastFmImportTrack::STATUS_UNMATCHED;
+                    $matchedId = null;
+                    $willInsert = false;
+                } elseif (
+                    $this->navidrome->scrobbleExistsNear(
+                        $userId,
+                        $result->mediaFileId,
+                        $buffered->getPlayedAt(),
+                        $toleranceSeconds,
+                    )
+                ) {
+                    $report->duplicates++;
+                    $status = LastFmImportTrack::STATUS_DUPLICATE;
+                    $matchedId = $result->mediaFileId;
+                    $willInsert = false;
+                } else {
+                    $report->inserted++;
+                    $status = LastFmImportTrack::STATUS_INSERTED;
+                    $matchedId = $result->mediaFileId;
+                    $willInsert = !$dryRun;
+                }
+
                 if (!$dryRun) {
-                    $this->navidrome->insertScrobble($userId, $matchedId, $buffered->getPlayedAt());
+                    $pending[] = [
+                        'bufferId' => $buffered->getId(),
+                        'artist' => $buffered->getArtist(),
+                        'title' => $buffered->getTitle(),
+                        'album' => $buffered->getAlbum(),
+                        'mbid' => $buffered->getMbid(),
+                        'playedAt' => $buffered->getPlayedAt(),
+                        'status' => $status,
+                        'matchedId' => $matchedId,
+                        'willInsertScrobble' => $willInsert,
+                    ];
+                }
+
+                // Detach the buffered entity now that we have a snapshot of
+                // its fields — keeps the Doctrine identity map small even
+                // mid-batch on a 100k-row buffer.
+                if ($this->em->contains($buffered)) {
+                    $this->em->detach($buffered);
+                }
+
+                if (!$dryRun && count($pending) >= self::BATCH_SIZE) {
+                    $this->flushBatch($pending, $userId, $auditRun, $appConnection);
+                    $pending = [];
+                }
+
+                if ($progress !== null && $report->considered % 50 === 0) {
+                    $progress($report->considered, $report->inserted, $report->duplicates, $report->unmatched);
                 }
             }
 
             if (!$dryRun) {
-                if ($auditRun !== null) {
-                    $importTrack = new LastFmImportTrack(
-                        runHistory: $auditRun,
-                        artist: $buffered->getArtist(),
-                        title: $buffered->getTitle(),
-                        album: $buffered->getAlbum(),
-                        mbid: $buffered->getMbid(),
-                        playedAt: $buffered->getPlayedAt(),
-                        status: $status,
-                        matchedMediaFileId: $matchedId,
-                    );
-                    $this->em->persist($importTrack);
-                    $pendingTracks[] = $importTrack;
-                }
-                $connection->executeStatement(
-                    'DELETE FROM lastfm_import_buffer WHERE id = :id',
-                    ['id' => $buffered->getId()],
-                );
+                $this->flushBatch($pending, $userId, $auditRun, $appConnection);
             }
 
-            // Detach the buffered entity now that we're done with it —
-            // toIterable() leaves it managed otherwise, so a 100k-row
-            // buffer would pin 100k entities in the identity map.
-            if ($this->em->contains($buffered)) {
-                $this->em->detach($buffered);
-            }
-
-            // Periodic flush + targeted detach so memory does not grow
-            // unbounded on big sweeps. We detach the just-persisted
-            // LastFmImportTrack rows + the cache entries the matcher
-            // queued, but keep $auditRun managed so the caller's
-            // progress callback keeps seeing a managed entity.
-            if (!$dryRun && ++$batch >= 100) {
-                $this->flushAndDetach($pendingTracks);
-                $pendingTracks = [];
-                $batch = 0;
-            }
-
-            if ($progress !== null && $report->considered % 50 === 0) {
+            if ($progress !== null) {
                 $progress($report->considered, $report->inserted, $report->duplicates, $report->unmatched);
             }
-        }
-
-        if (!$dryRun) {
-            $this->flushAndDetach($pendingTracks);
-        }
-
-        if ($progress !== null) {
-            $progress($report->considered, $report->inserted, $report->duplicates, $report->unmatched);
+        } finally {
+            // Belt-and-braces: merge the WAL into the main DB and release the
+            // file lock before Navidrome reopens it. Even on a clean run we
+            // do not want to leave a non-empty WAL behind, since Navidrome
+            // would have to recover it on its own next start.
+            $this->navidrome->walCheckpointTruncate();
+            $this->navidrome->closeWriteConnection();
         }
 
         return $report;
     }
 
     /**
-     * @param list<LastFmImportTrack> $pendingTracks
+     * Flush one transactional batch :
+     *   1. BEGIN IMMEDIATE on Navidrome
+     *   2. INSERT every pending scrobble that should land
+     *   3. COMMIT — if anything throws, ROLLBACK and re-raise (the buffer
+     *      rows and audits stay un-persisted, so a retry resumes cleanly).
+     *   4. Persist audit rows, DELETE buffer rows, flush app-DB.
+     *
+     * @param  list<array{
+     *     bufferId: int,
+     *     artist: string,
+     *     title: string,
+     *     album: ?string,
+     *     mbid: ?string,
+     *     playedAt: \DateTimeImmutable,
+     *     status: string,
+     *     matchedId: ?string,
+     *     willInsertScrobble: bool,
+     * }> $pending
      */
-    private function flushAndDetach(array $pendingTracks): void
-    {
+    private function flushBatch(
+        array $pending,
+        string $userId,
+        ?RunHistory $auditRun,
+        Connection $appConnection,
+    ): void {
+        if ($pending === []) {
+            return;
+        }
+
+        $this->navidrome->beginWriteTransaction();
+        try {
+            foreach ($pending as $row) {
+                if ($row['willInsertScrobble'] && $row['matchedId'] !== null) {
+                    $this->navidrome->insertScrobble($userId, $row['matchedId'], $row['playedAt']);
+                }
+            }
+            $this->navidrome->commitWrite();
+        } catch (\Throwable $e) {
+            try {
+                $this->navidrome->rollbackWrite();
+            } catch (\Throwable) {
+                // Already in trouble — original exception wins. The WAL
+                // checkpoint + close in the outer finally will run.
+            }
+            throw $e;
+        }
+
+        // Navidrome side committed — we can now flush the audit + cleanup
+        // the buffer. If THIS step crashes, the user re-runs and the
+        // ±toleranceSeconds dedup catches the already-inserted scrobbles
+        // as duplicates ; no double-write.
+        $persistedAudits = [];
+        if ($auditRun !== null) {
+            foreach ($pending as $row) {
+                $importTrack = new LastFmImportTrack(
+                    runHistory: $auditRun,
+                    artist: $row['artist'],
+                    title: $row['title'],
+                    album: $row['album'],
+                    mbid: $row['mbid'],
+                    playedAt: $row['playedAt'],
+                    status: $row['status'],
+                    matchedMediaFileId: $row['matchedId'],
+                );
+                $this->em->persist($importTrack);
+                $persistedAudits[] = $importTrack;
+            }
+        }
+
+        // Bulk DELETE — buffer ids are integers (entity primary key), safe
+        // to inline. Avoids a 100-deep IN-clause via DBAL array param type.
+        $bufferIds = array_map(static fn (array $row): int => $row['bufferId'], $pending);
+        $appConnection->executeStatement(
+            'DELETE FROM lastfm_import_buffer WHERE id IN (' . implode(',', $bufferIds) . ')',
+        );
+
         $this->em->flush();
-        foreach ($pendingTracks as $track) {
+
+        // Detach the just-flushed audits + the matcher's pending cache rows
+        // so the identity map does not grow over the run.
+        foreach ($persistedAudits as $track) {
             if ($this->em->contains($track)) {
                 $this->em->detach($track);
             }

--- a/src/Navidrome/NavidromeDbBackup.php
+++ b/src/Navidrome/NavidromeDbBackup.php
@@ -3,7 +3,7 @@
 namespace App\Navidrome;
 
 /**
- * Safety net around the Navidrome SQLite file. Two responsibilities:
+ * Safety net around the Navidrome SQLite file. Three responsibilities:
  *
  *  1. {@see backup()} copies `<dbPath>` (and its `-wal` / `-shm` siblings
  *     when present) to `<dbPath>.backup-<unix_ts>` just before any
@@ -14,11 +14,17 @@ namespace App\Navidrome;
  *     `PRAGMA quick_check` — a lightweight structural sanity test that
  *     catches a half-flushed WAL or a SIGKILL-truncated header *before*
  *     we open the DB for writes (which would aggravate the corruption).
+ *  3. {@see restore()} copies a previously-taken backup back over the
+ *     live DB (with sibling WAL/SHM handling). Sanity-checks the backup
+ *     first to refuse a zombie restore. Caller must ensure Navidrome is
+ *     stopped — this class does no orchestration.
  *
- * Only used by `NavidromeContainerManager::runWithNavidromeStopped()` so
- * far. Not a Doctrine connection: stays out of the DBAL UDF setup
- * (`np_normalize`) so it can run on a potentially broken file without
- * dragging the whole repository's machinery in.
+ * Used by `NavidromeContainerManager::runWithNavidromeStopped()` for the
+ * pre-action snapshot + post-action restore-on-corruption, and by
+ * `app:navidrome:db:restore` for manual rollbacks. Not a Doctrine
+ * connection: stays out of the DBAL UDF setup (`np_normalize`) so it can
+ * run on a potentially broken file without dragging the whole
+ * repository's machinery in.
  */
 class NavidromeDbBackup
 {
@@ -58,7 +64,7 @@ class NavidromeDbBackup
     }
 
     /**
-     * Throws when the SQLite file fails the structural sanity test.
+     * Throws when the live DB fails the structural sanity test.
      * No-op when the file is missing (treated as « nothing to check »).
      */
     public function quickCheck(): void
@@ -67,30 +73,53 @@ class NavidromeDbBackup
             return;
         }
 
-        try {
-            $pdo = new \PDO('sqlite:' . $this->dbPath, null, null, [
-                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-            ]);
-            // Read-only intent: SQLite still mounts the WAL on open and
-            // recovers any clean-but-unmerged frames, which is desirable
-            // here (this is also how we « heal » a soft-stop residue).
-            $stmt = $pdo->query('PRAGMA quick_check');
-            $result = $stmt !== false ? $stmt->fetchColumn() : false;
-        } catch (\PDOException $e) {
-            throw new \RuntimeException(sprintf(
-                'La base SQLite Navidrome (%s) est illisible : %s. Restaurez un backup avant toute écriture.',
-                $this->dbPath,
-                $e->getMessage(),
-            ), 0, $e);
+        $this->quickCheckFile($this->dbPath);
+    }
+
+    /**
+     * Copies a previously-taken backup over the live DB. Verifies the
+     * backup is itself sound before clobbering anything — restoring a
+     * corrupted snapshot would be worse than the situation we're trying
+     * to recover from. Handles WAL/SHM siblings:
+     *  - if the backup has them, restore them too;
+     *  - if it doesn't, wipe any live siblings so SQLite doesn't try to
+     *    replay a stale WAL on top of the restored main DB.
+     *
+     * @param string|null $timestamp Backup timestamp `YYYYMMDDHHMMSS`.
+     *                               `null` = use the most recent backup.
+     * @return string Path of the backup that was used as the source.
+     * @throws \RuntimeException If no backup matches, the backup itself
+     *                           fails quick_check, or the copy/rename
+     *                           fails. The live DB is left untouched on
+     *                           any pre-write failure.
+     */
+    public function restore(?string $timestamp = null): string
+    {
+        $backupPath = $this->resolveBackup($timestamp);
+
+        // Sanity-check the backup BEFORE clobbering the live DB.
+        $this->quickCheckFile($backupPath);
+
+        $this->copyAtomic($backupPath, $this->dbPath);
+
+        // Sync siblings: the backup either has them (replicate) or
+        // doesn't (drop the live ones to avoid a stale-WAL replay).
+        foreach (['-wal', '-shm'] as $suffix) {
+            $backupSibling = $backupPath . $suffix;
+            $liveSibling = $this->dbPath . $suffix;
+            if (is_file($backupSibling)) {
+                $this->copyAtomic($backupSibling, $liveSibling);
+            } elseif (is_file($liveSibling)) {
+                @unlink($liveSibling);
+            }
         }
 
-        if ($result !== 'ok') {
-            throw new \RuntimeException(sprintf(
-                'PRAGMA quick_check a échoué sur %s : « %s ». La DB est corrompue, on bloque l\'écriture pour ne pas aggraver. Restaurez un backup.',
-                $this->dbPath,
-                is_string($result) ? $result : 'résultat inattendu',
-            ));
-        }
+        // Confirm the live DB is sound after restore. If something went
+        // wrong (FS issue, partial copy), surface it now rather than at
+        // the next Navidrome start.
+        $this->quickCheck();
+
+        return $backupPath;
     }
 
     /**
@@ -108,6 +137,78 @@ class NavidromeDbBackup
         sort($main);
 
         return $main;
+    }
+
+    /**
+     * Returns the timestamp (`YYYYMMDDHHMMSS`) of the most recent backup,
+     * or `null` if none exist. Convenience for CLI listings.
+     */
+    public function latestBackup(): ?string
+    {
+        $backups = $this->listBackups();
+        if ($backups === []) {
+            return null;
+        }
+        $path = end($backups);
+        if (preg_match('/\.backup-(\d+)$/', $path, $m) === 1) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    private function resolveBackup(?string $timestamp): string
+    {
+        if ($timestamp !== null) {
+            $candidate = $this->dbPath . '.backup-' . $timestamp;
+            if (!is_file($candidate)) {
+                throw new \RuntimeException(sprintf(
+                    'Aucun backup trouvé pour le timestamp « %s » (cherché : %s).',
+                    $timestamp,
+                    $candidate,
+                ));
+            }
+            return $candidate;
+        }
+
+        $backups = $this->listBackups();
+        if ($backups === []) {
+            throw new \RuntimeException(sprintf(
+                'Aucun backup disponible à côté de %s.',
+                $this->dbPath,
+            ));
+        }
+
+        return end($backups);
+    }
+
+    private function quickCheckFile(string $path): void
+    {
+        try {
+            // URI form `mode=ro` opens the DB strictly read-only — without
+            // it, PDO defaults to RW which would have SQLite truncate or
+            // delete an unrecognized -wal sibling (we hit this with fake
+            // siblings during backup-restore round-trips). Read-only also
+            // suffices for `PRAGMA quick_check`.
+            $pdo = new \PDO('sqlite:file:' . $path . '?mode=ro', null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            $stmt = $pdo->query('PRAGMA quick_check');
+            $result = $stmt !== false ? $stmt->fetchColumn() : false;
+        } catch (\PDOException $e) {
+            throw new \RuntimeException(sprintf(
+                'Le fichier SQLite %s est illisible : %s.',
+                $path,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        if ($result !== 'ok') {
+            throw new \RuntimeException(sprintf(
+                'PRAGMA quick_check a échoué sur %s : « %s ».',
+                $path,
+                is_string($result) ? $result : 'résultat inattendu',
+            ));
+        }
     }
 
     private function prune(): void

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2002,6 +2002,11 @@ class NavidromeRepository
      * Insert a scrobble row. Caller is responsible for dedup. Throws if the
      * scrobbles table does not exist (Navidrome < 0.55) or if the DB is
      * mounted read-only.
+     *
+     * Callers that insert in batch should wrap their loop in
+     * {@see beginWriteTransaction()} / {@see commitWrite()} (or
+     * {@see rollbackWrite()} on error) — autocommit per row leaves a crash
+     * mid-batch with partial writes and a half-flushed WAL.
      */
     public function insertScrobble(string $userId, string $mediaFileId, \DateTimeInterface $time): void
     {
@@ -2016,6 +2021,72 @@ class NavidromeRepository
             [$userId, $mediaFileId, $time->getTimestamp()],
             [2 => \Doctrine\DBAL\ParameterType::INTEGER],
         );
+    }
+
+    /**
+     * Open a write transaction with `BEGIN IMMEDIATE` — takes the RESERVED
+     * lock right away and fails fast if another writer (Navidrome
+     * accidentally restarted by Docker auto-restart, a parallel
+     * `app:lastfm:process` somehow scheduled twice, etc.) is holding it.
+     * `Connection::beginTransaction()` would do `BEGIN DEFERRED` which only
+     * locks on the first INSERT, leaving a window for a concurrent writer.
+     */
+    public function beginWriteTransaction(): void
+    {
+        $this->connection()->executeStatement('BEGIN IMMEDIATE');
+    }
+
+    public function commitWrite(): void
+    {
+        $this->connection()->executeStatement('COMMIT');
+    }
+
+    public function rollbackWrite(): void
+    {
+        $this->connection()->executeStatement('ROLLBACK');
+    }
+
+    /**
+     * Force-merge any pending WAL frames into the main DB and truncate the
+     * WAL file. Should be called in a `finally` at the end of any batch
+     * write run, before {@see closeWriteConnection()} — otherwise SQLite may
+     * leave the WAL un-checkpointed across a restart, and Navidrome opening
+     * the DB next would have to recover an inconsistent WAL (risk of
+     * corruption).
+     *
+     * No-op when the journal mode is `DELETE` (Navidrome forces WAL by
+     * default, but be defensive). Errors are swallowed because this lives in
+     * a `finally` and the caller's post-action quick_check upstream is the
+     * authoritative integrity check.
+     */
+    public function walCheckpointTruncate(): void
+    {
+        if ($this->connection === null) {
+            return;
+        }
+        try {
+            $this->connection->executeQuery('PRAGMA wal_checkpoint(TRUNCATE)')->fetchAssociative();
+        } catch (\Throwable) {
+            // best-effort
+        }
+    }
+
+    /**
+     * Close the underlying PDO connection so the OS file lock is released
+     * and SQLite can do its own final checkpoint book-keeping. The
+     * connection lazily reconnects on the next access.
+     */
+    public function closeWriteConnection(): void
+    {
+        if ($this->connection === null) {
+            return;
+        }
+        try {
+            $this->connection->close();
+        } catch (\Throwable) {
+            // best-effort
+        }
+        $this->connection = null;
     }
 
     /**
@@ -2086,6 +2157,22 @@ class NavidromeRepository
         if ($native instanceof \PDO) {
             $native->sqliteCreateFunction('np_normalize', [self::class, 'normalize'], 1);
         }
+
+        // Durability + concurrency knobs:
+        //  - busy_timeout: retry-on-lock window. If Navidrome got restarted
+        //    by Docker auto-restart while we were writing, every INSERT
+        //    waits up to 30s for the lock instead of failing instantly.
+        //    Cost: zero in the happy path.
+        //  - synchronous=FULL: every COMMIT waits for fsync of both the WAL
+        //    page and the WAL header. Slower than NORMAL but absolutely
+        //    necessary on a SQLite file that another process (Navidrome)
+        //    will reopen — a power-cut / OOM-kill must not leave a torn
+        //    write that corrupts the DB. This is what Navidrome itself
+        //    runs by default, we just make sure to match it.
+        //  - We deliberately do NOT touch journal_mode: it is persistent
+        //    (stored in the DB header) and Navidrome owns that decision.
+        $this->connection->executeStatement('PRAGMA busy_timeout = 30000');
+        $this->connection->executeStatement('PRAGMA synchronous = FULL');
 
         return $this->connection;
     }

--- a/src/Service/LastFmRematchService.php
+++ b/src/Service/LastFmRematchService.php
@@ -21,11 +21,21 @@ use Psr\Log\NullLogger;
  * usual ±N seconds dedup) and the row's status flips to `inserted` /
  * `duplicate` / `skipped`.
  *
+ * Crash-safety contract — each batch of {@see self::BATCH_SIZE} tracks goes
+ * through a Navidrome transaction (`BEGIN IMMEDIATE` / `COMMIT`). Status +
+ * matchedMediaFileId mutations on the managed `LastFmImportTrack` entities
+ * are deferred until AFTER the Navidrome commit — so a crash mid-batch
+ * (kill -9, exception, OOM) rolls back the partial Navidrome writes AND
+ * leaves the audit rows in their original `unmatched` state, ready for a
+ * clean retry.
+ *
  * Idempotent: calling rematch twice in a row is a no-op past the first
  * call. Garde-fou via {@see NavidromeRepository::scrobbleExistsNear()}.
  */
 class LastFmRematchService
 {
+    private const int BATCH_SIZE = 100;
+
     private LoggerInterface $logger;
 
     public function __construct(
@@ -64,111 +74,211 @@ class LastFmRematchService
         $this->cacheRepository?->purgeStale($this->cacheTtlDays);
 
         $report = new RematchReport();
-        $batch = 0;
-        /** @var list<LastFmImportTrack> $pendingTracks */
-        $pendingTracks = [];
-        foreach ($this->trackRepo->streamUnmatched($runId, $limit, $random) as $track) {
-            /** @var LastFmImportTrack $track */
-            $report->considered++;
+        /** @var list<array{
+         *     track: LastFmImportTrack,
+         *     statusToSet: ?string,
+         *     matchedIdToSet: ?string,
+         *     willInsertScrobble: bool,
+         *     mediaFileId: ?string,
+         * }> $pending
+         */
+        $pending = [];
 
-            $scrobble = new LastFmScrobble(
-                artist: $track->getArtist(),
-                title: $track->getTitle(),
-                album: $track->getAlbum() ?? '',
-                mbid: $track->getMbid(),
-                playedAt: $track->getPlayedAt(),
-            );
+        try {
+            foreach ($this->trackRepo->streamUnmatched($runId, $limit, $random) as $track) {
+                /** @var LastFmImportTrack $track */
+                $report->considered++;
 
-            $result = $this->matcher->match($scrobble);
-            match ($result->cacheStatus) {
-                MatchResult::CACHE_HIT_POSITIVE => $report->cacheHitsPositive++,
-                MatchResult::CACHE_HIT_NEGATIVE => $report->cacheHitsNegative++,
-                MatchResult::CACHE_MISS => $report->cacheMisses++,
-                default => null,
-            };
+                $scrobble = new LastFmScrobble(
+                    artist: $track->getArtist(),
+                    title: $track->getTitle(),
+                    album: $track->getAlbum() ?? '',
+                    mbid: $track->getMbid(),
+                    playedAt: $track->getPlayedAt(),
+                );
 
-            if ($result->status === MatchResult::STATUS_SKIPPED) {
-                $report->skipped++;
-                if (!$dryRun) {
-                    $track->setStatus(LastFmImportTrack::STATUS_SKIPPED);
+                $result = $this->matcher->match($scrobble);
+                match ($result->cacheStatus) {
+                    MatchResult::CACHE_HIT_POSITIVE => $report->cacheHitsPositive++,
+                    MatchResult::CACHE_HIT_NEGATIVE => $report->cacheHitsNegative++,
+                    MatchResult::CACHE_MISS => $report->cacheMisses++,
+                    default => null,
+                };
+
+                $statusToSet = null;
+                $matchedIdToSet = null;
+                $willInsertScrobble = false;
+
+                if ($result->status === MatchResult::STATUS_SKIPPED) {
+                    $report->skipped++;
+                    $statusToSet = LastFmImportTrack::STATUS_SKIPPED;
+                    $this->logger->debug('Rematch skipped (alias): {artist} — {title}', [
+                        'artist' => $track->getArtist(),
+                        'title' => $track->getTitle(),
+                    ]);
+                } elseif ($result->mediaFileId === null) {
+                    $report->stillUnmatched++;
+                    // Leave the row as `unmatched` — no mutations queued.
+                } elseif (
+                    $this->navidrome->scrobbleExistsNear($userId, $result->mediaFileId, $track->getPlayedAt(), $toleranceSeconds)
+                    || $this->pendingBatchHasNearScrobble($pending, $result->mediaFileId, $track->getPlayedAt(), $toleranceSeconds)
+                ) {
+                    $report->matchedAsDuplicate++;
+                    $statusToSet = LastFmImportTrack::STATUS_DUPLICATE;
+                    $matchedIdToSet = $result->mediaFileId;
+                    $this->logger->debug('Rematch found duplicate: {artist} — {title}', [
+                        'artist' => $track->getArtist(),
+                        'title' => $track->getTitle(),
+                    ]);
+                } else {
+                    $report->matchedAsInserted++;
+                    $statusToSet = LastFmImportTrack::STATUS_INSERTED;
+                    $matchedIdToSet = $result->mediaFileId;
+                    $willInsertScrobble = !$dryRun;
+                    $this->logger->debug('Rematch inserted: {artist} — {title}', [
+                        'artist' => $track->getArtist(),
+                        'title' => $track->getTitle(),
+                    ]);
                 }
-                $this->logger->debug('Rematch skipped (alias): {artist} — {title}', [
-                    'artist' => $track->getArtist(),
-                    'title' => $track->getTitle(),
-                ]);
-            } elseif ($result->mediaFileId === null) {
-                $report->stillUnmatched++;
-            } elseif ($this->navidrome->scrobbleExistsNear($userId, $result->mediaFileId, $track->getPlayedAt(), $toleranceSeconds)) {
-                $report->matchedAsDuplicate++;
+
                 if (!$dryRun) {
-                    $track->setStatus(LastFmImportTrack::STATUS_DUPLICATE);
-                    $track->setMatchedMediaFileId($result->mediaFileId);
+                    $pending[] = [
+                        'track' => $track,
+                        'statusToSet' => $statusToSet,
+                        'matchedIdToSet' => $matchedIdToSet,
+                        'willInsertScrobble' => $willInsertScrobble,
+                        'mediaFileId' => $result->mediaFileId,
+                    ];
                 }
-                $this->logger->debug('Rematch found duplicate: {artist} — {title}', [
-                    'artist' => $track->getArtist(),
-                    'title' => $track->getTitle(),
-                ]);
-            } else {
-                $report->matchedAsInserted++;
-                if (!$dryRun) {
-                    $this->navidrome->insertScrobble($userId, $result->mediaFileId, $track->getPlayedAt());
-                    $track->setStatus(LastFmImportTrack::STATUS_INSERTED);
-                    $track->setMatchedMediaFileId($result->mediaFileId);
+
+                if (!$dryRun && count($pending) >= self::BATCH_SIZE) {
+                    $this->flushBatch($pending, $userId);
+                    $pending = [];
                 }
-                $this->logger->debug('Rematch inserted: {artist} — {title}', [
-                    'artist' => $track->getArtist(),
-                    'title' => $track->getTitle(),
-                ]);
+
+                if ($progress !== null && $report->considered % 50 === 0) {
+                    $progress(
+                        $report->considered,
+                        $report->matchedAsInserted + $report->matchedAsDuplicate + $report->skipped,
+                        $report->stillUnmatched,
+                    );
+                }
             }
 
-            $pendingTracks[] = $track;
-
-            // Flush periodically so memory does not grow unbounded on big
-            // sweeps. We then detach the just-flushed LastFmImportTrack
-            // rows (their setStatus() / setMatchedMediaFileId() mutations
-            // are now safely written) and drop the matcher's pending
-            // cache entries — without that the identity map keeps every
-            // iterated track + every cache entry for the entire run,
-            // OOMing on large rematch sweeps.
-            if (!$dryRun && ++$batch >= 100) {
-                $this->flushAndDetach($pendingTracks);
-                $pendingTracks = [];
-                $batch = 0;
+            if (!$dryRun) {
+                $this->flushBatch($pending, $userId);
             }
 
-            if ($progress !== null && $report->considered % 50 === 0) {
+            if ($progress !== null) {
                 $progress(
                     $report->considered,
                     $report->matchedAsInserted + $report->matchedAsDuplicate + $report->skipped,
                     $report->stillUnmatched,
                 );
             }
-        }
-
-        if (!$dryRun) {
-            $this->flushAndDetach($pendingTracks);
-        }
-
-        if ($progress !== null) {
-            $progress(
-                $report->considered,
-                $report->matchedAsInserted + $report->matchedAsDuplicate + $report->skipped,
-                $report->stillUnmatched,
-            );
+        } finally {
+            $this->navidrome->walCheckpointTruncate();
+            $this->navidrome->closeWriteConnection();
         }
 
         return $report;
     }
 
     /**
-     * @param list<LastFmImportTrack> $pendingTracks
+     * Cross-check the in-flight pending batch for a near-scrobble that the
+     * current iteration would otherwise duplicate. Without this, two unmatched
+     * rows for the SAME scrobble (same artist/title/playedAt, e.g. produced
+     * by two distinct imports) would both pass the committed-state check —
+     * `scrobbleExistsNear` only sees what previous batches have committed —
+     * and end up doubly inserted in Navidrome at COMMIT time.
+     *
+     * @param list<array{
+     *     track: LastFmImportTrack,
+     *     statusToSet: ?string,
+     *     matchedIdToSet: ?string,
+     *     willInsertScrobble: bool,
+     *     mediaFileId: ?string,
+     * }> $pending
      */
-    private function flushAndDetach(array $pendingTracks): void
+    private function pendingBatchHasNearScrobble(
+        array $pending,
+        string $mediaFileId,
+        \DateTimeImmutable $playedAt,
+        int $toleranceSeconds,
+    ): bool {
+        $ts = $playedAt->getTimestamp();
+        foreach ($pending as $row) {
+            if (!$row['willInsertScrobble']) {
+                continue;
+            }
+            if ($row['mediaFileId'] !== $mediaFileId) {
+                continue;
+            }
+            if (abs($row['track']->getPlayedAt()->getTimestamp() - $ts) <= $toleranceSeconds) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Flush one transactional batch :
+     *   1. BEGIN IMMEDIATE on Navidrome.
+     *   2. INSERT every match'd-as-inserted row inside the transaction.
+     *   3. COMMIT — on error, ROLLBACK and re-raise. The mutations on
+     *      $track entities have NOT been applied yet, so the rows stay
+     *      `unmatched` and a retry will reprocess them.
+     *   4. Apply the queued status/matchedId mutations on the entities,
+     *      flush app-DB, detach.
+     *
+     * @param list<array{
+     *     track: LastFmImportTrack,
+     *     statusToSet: ?string,
+     *     matchedIdToSet: ?string,
+     *     willInsertScrobble: bool,
+     *     mediaFileId: ?string,
+     * }> $pending
+     */
+    private function flushBatch(array $pending, string $userId): void
     {
+        if ($pending === []) {
+            return;
+        }
+
+        $this->navidrome->beginWriteTransaction();
+        try {
+            foreach ($pending as $row) {
+                if ($row['willInsertScrobble'] && $row['mediaFileId'] !== null) {
+                    $this->navidrome->insertScrobble($userId, $row['mediaFileId'], $row['track']->getPlayedAt());
+                }
+            }
+            $this->navidrome->commitWrite();
+        } catch (\Throwable $e) {
+            try {
+                $this->navidrome->rollbackWrite();
+            } catch (\Throwable) {
+                // Already in trouble — original exception wins.
+            }
+            throw $e;
+        }
+
+        // Navidrome side committed — now safe to mutate the audit entities.
+        foreach ($pending as $row) {
+            if ($row['statusToSet'] !== null) {
+                $row['track']->setStatus($row['statusToSet']);
+            }
+            if ($row['matchedIdToSet'] !== null) {
+                $row['track']->setMatchedMediaFileId($row['matchedIdToSet']);
+            }
+        }
         $this->em->flush();
-        foreach ($pendingTracks as $track) {
-            if ($this->em->contains($track)) {
-                $this->em->detach($track);
+
+        // Detach the just-flushed audits + the matcher's pending cache rows
+        // so the identity map does not grow over the run.
+        foreach ($pending as $row) {
+            if ($this->em->contains($row['track'])) {
+                $this->em->detach($row['track']);
             }
         }
         $this->cacheRepository?->detachPending();

--- a/tests/Command/NavidromeDbCheckCommandTest.php
+++ b/tests/Command/NavidromeDbCheckCommandTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\NavidromeDbCheckCommand;
+use App\Navidrome\NavidromeDbBackup;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class NavidromeDbCheckCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            foreach (['', '-wal', '-shm'] as $suffix) {
+                @unlink($path . $suffix);
+            }
+        }
+        $this->createdPaths = [];
+    }
+
+    public function testQuickCheckExitsZeroOnHealthyDb(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $tester = $this->makeTester($dbPath);
+
+        $exit = $tester->execute([]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('quick_check', $tester->getDisplay());
+        $this->assertStringContainsString('ok', strtolower($tester->getDisplay()));
+    }
+
+    public function testQuickCheckExitsNonZeroOnCorruptDb(): void
+    {
+        $dbPath = sys_get_temp_dir() . '/nv-cmd-corrupt-' . bin2hex(random_bytes(4)) . '.db';
+        // Truncated SQLite header — quick_check refuses to open.
+        file_put_contents($dbPath, str_repeat("\x00", 50));
+        $this->createdPaths[] = $dbPath;
+
+        $tester = $this->makeTester($dbPath);
+        $exit = $tester->execute([]);
+
+        $this->assertNotSame(0, $exit);
+    }
+
+    public function testIntegrityCheckExitsZeroOnHealthyDb(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $tester = $this->makeTester($dbPath);
+
+        $exit = $tester->execute(['--integrity' => true]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('integrity_check', $tester->getDisplay());
+    }
+
+    public function testIntegrityCheckOnMissingFileFails(): void
+    {
+        $dbPath = '/tmp/no-such-' . bin2hex(random_bytes(4)) . '.db';
+        $tester = $this->makeTester($dbPath);
+
+        $exit = $tester->execute([]);
+
+        $this->assertNotSame(0, $exit);
+        $this->assertStringContainsString('introuvable', $tester->getDisplay());
+    }
+
+    private function makeHealthySqliteDb(): string
+    {
+        $path = sys_get_temp_dir() . '/nv-cmd-check-' . bin2hex(random_bytes(4)) . '.db';
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+        $pdo->exec("INSERT INTO t (v) VALUES ('one')");
+        unset($pdo);
+        $this->createdPaths[] = $path;
+
+        return $path;
+    }
+
+    private function makeTester(string $dbPath): CommandTester
+    {
+        $command = new NavidromeDbCheckCommand(
+            new NavidromeDbBackup($dbPath, 3),
+            $dbPath,
+        );
+        $app = new Application();
+        $app->add($command);
+
+        return new CommandTester($app->find('app:navidrome:db:check'));
+    }
+}

--- a/tests/Command/NavidromeDbRestoreCommandTest.php
+++ b/tests/Command/NavidromeDbRestoreCommandTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\NavidromeDbRestoreCommand;
+use App\Docker\DockerCli;
+use App\Docker\NavidromeContainerConfig;
+use App\Docker\NavidromeContainerManager;
+use App\Navidrome\NavidromeDbBackup;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class NavidromeDbRestoreCommandTest extends TestCase
+{
+    /** @var list<string> */
+    private array $createdPaths = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->createdPaths as $path) {
+            foreach (['', '-wal', '-shm'] as $suffix) {
+                @unlink($path . $suffix);
+            }
+            foreach (glob($path . '.backup-*') ?: [] as $backup) {
+                @unlink($backup);
+                @unlink($backup . '-wal');
+                @unlink($backup . '-shm');
+            }
+        }
+        $this->createdPaths = [];
+    }
+
+    public function testListShowsAvailableBackups(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+        $backup->backup();
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute(['--list' => true]);
+
+        $this->assertSame(0, $exit);
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('Timestamp', $output);
+        $this->assertMatchesRegularExpression('/\d{14}/', $output);
+        $this->assertStringContainsString('1 backup(s) disponible(s)', $output);
+    }
+
+    public function testListShowsEmptyWhenNoBackups(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute(['--list' => true]);
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('Aucun backup disponible', $tester->getDisplay());
+    }
+
+    public function testRestoreFailsWhenNoBackupExists(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute([], ['interactive' => false]);
+
+        $this->assertNotSame(0, $exit);
+        $this->assertStringContainsString('Aucun backup disponible', $tester->getDisplay());
+    }
+
+    public function testRestoreLatestWhenNoTimestampGiven(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+        $backup->backup();
+
+        $originalContent = (string) file_get_contents($dbPath);
+
+        // Mutate the live DB — restore must put it back to the snapshot.
+        $pdo = new \PDO('sqlite:' . $dbPath);
+        $pdo->exec("INSERT INTO t (v) VALUES ('mutated')");
+        unset($pdo);
+        $this->assertNotSame($originalContent, (string) file_get_contents($dbPath));
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute([], ['interactive' => false]);
+
+        $this->assertSame(0, $exit, $tester->getDisplay());
+        $this->assertSame($originalContent, file_get_contents($dbPath));
+        $this->assertStringContainsString('restaurée', $tester->getDisplay());
+    }
+
+    public function testRestoreSpecificTimestamp(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+
+        // Make a deterministic backup at a known timestamp.
+        $stamp = '20200101000001';
+        copy($dbPath, $dbPath . '.backup-' . $stamp);
+
+        // Mutate the live DB.
+        $pdo = new \PDO('sqlite:' . $dbPath);
+        $pdo->exec("INSERT INTO t (v) VALUES ('mutated')");
+        unset($pdo);
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute(['--timestamp' => $stamp], ['interactive' => false]);
+
+        $this->assertSame(0, $exit, $tester->getDisplay());
+        $this->assertStringContainsString($stamp, $tester->getDisplay());
+    }
+
+    public function testRestoreFailsOnUnknownTimestamp(): void
+    {
+        $dbPath = $this->makeHealthySqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, 5);
+        $backup->backup();
+
+        $tester = $this->makeTester($dbPath, $backup);
+        $exit = $tester->execute(['--timestamp' => '99999999999999'], ['interactive' => false]);
+
+        $this->assertNotSame(0, $exit);
+        $this->assertStringContainsString('Aucun backup trouvé', $tester->getDisplay());
+    }
+
+    private function makeHealthySqliteDb(): string
+    {
+        $path = sys_get_temp_dir() . '/nv-cmd-restore-' . bin2hex(random_bytes(4)) . '.db';
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+        $pdo->exec("INSERT INTO t (v) VALUES ('one')");
+        unset($pdo);
+        $this->createdPaths[] = $path;
+
+        return $path;
+    }
+
+    private function makeTester(string $dbPath, NavidromeDbBackup $backup): CommandTester
+    {
+        // Empty container name → NavidromeContainerManager.runWithNavidromeStopped()
+        // skips all docker orchestration and just calls the closure. Lets the
+        // command exercise its full code path without a mocked CLI.
+        $manager = new NavidromeContainerManager(
+            new DockerCli(),
+            new NavidromeContainerConfig(''),
+            $backup,
+        );
+
+        $command = new NavidromeDbRestoreCommand($backup, $manager);
+        $app = new Application();
+        $app->add($command);
+
+        return new CommandTester($app->find('app:navidrome:db:restore'));
+    }
+}

--- a/tests/Docker/NavidromeContainerManagerTest.php
+++ b/tests/Docker/NavidromeContainerManagerTest.php
@@ -359,6 +359,175 @@ class NavidromeContainerManagerTest extends TestCase
         $this->assertContains(['start', 'navidrome'], $cli->actions);
     }
 
+    public function testRunWithStoppedSkipsPreCheckWhenRequested(): void
+    {
+        // DB in poor shape (header garbage) — pre-check would normally throw
+        // and abort the action. With $skipPreCheck=true the action runs
+        // anyway. Then post-check still runs and the corruption is caught
+        // before Navidrome restarts.
+        $dbPath = sys_get_temp_dir() . '/nv-skip-' . bin2hex(random_bytes(4)) . '.db';
+        file_put_contents($dbPath, str_repeat("\x00", 4096));
+        $this->createdPaths[] = $dbPath;
+
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $actionRan = false;
+        try {
+            $manager->runWithNavidromeStopped(
+                function () use (&$actionRan, $dbPath): void {
+                    $actionRan = true;
+                    // Heal the DB so post-check passes (mimics what the future
+                    // db:restore command does — copies a backup over).
+                    $this->seedHealthySqliteAt($dbPath);
+                },
+                skipPreCheck: true,
+            );
+        } catch (\Throwable) {
+            // We don't care about the exception here — the assertion is on
+            // whether the action ran despite the broken pre-state.
+        }
+
+        $this->assertTrue($actionRan, 'skipPreCheck must let the action run despite a broken DB');
+    }
+
+    public function testRunWithStoppedRestoresWhenPostActionQuickCheckFails(): void
+    {
+        // Healthy DB → backup taken → action corrupts the DB → post-check
+        // fails → restore() puts the snapshot back → Navidrome restarts on
+        // a clean DB → an explicit corruption exception surfaces.
+        $dbPath = $this->makeRealSqliteDb();
+        $originalContent = (string) file_get_contents($dbPath);
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function () use ($dbPath): void {
+                // Simulate the action partially writing then crashing the file
+                // by overwriting with garbage. Mimics a torn write / kill -9
+                // mid-INSERT scenario.
+                file_put_contents($dbPath, str_repeat("\xFF", 4096));
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(NavidromeContainerException::class, $thrown);
+        $this->assertMatchesRegularExpression('/restaur[ée]e automatiquement/u', $thrown->getMessage());
+        // The DB on disk must equal the snapshot, not the corrupt payload.
+        $this->assertSame($originalContent, file_get_contents($dbPath), 'restore must put the snapshot back');
+        // Navidrome restarted on the clean DB.
+        $this->assertContains(['start', 'navidrome'], $cli->actions);
+    }
+
+    public function testRunWithStoppedSkipsRestartWhenRestoreFails(): void
+    {
+        // Backup has been taken, action corrupts. We then sabotage the
+        // backup file too — restore can't succeed → manager must NOT
+        // restart Navidrome (DB in unknown state) and surface a compound
+        // exception telling the user to recover manually.
+        $dbPath = $this->makeRealSqliteDb();
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function () use ($dbPath): void {
+                // Corrupt the live DB.
+                file_put_contents($dbPath, str_repeat("\xFF", 4096));
+                // Also corrupt the backup that was just taken — restore
+                // will refuse to use it.
+                $backups = glob($dbPath . '.backup-*') ?: [];
+                $this->assertNotEmpty($backups);
+                file_put_contents((string) end($backups), str_repeat("\x00", 4096));
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(NavidromeContainerException::class, $thrown);
+        $this->assertMatchesRegularExpression('/restore automatique a [ée]chou[ée]/u', $thrown->getMessage());
+        $this->assertNotContains(
+            ['start', 'navidrome'],
+            $cli->actions,
+            'Navidrome must NOT be restarted when the DB is in an unknown state',
+        );
+    }
+
+    public function testRunWithStoppedChainsActionExceptionAfterCorruption(): void
+    {
+        // Action throws AND corrupts in the same shot. Post-check catches
+        // the corruption ; the surfaced exception must keep the original
+        // action error chained as `previous` so the user can see what
+        // originally went wrong.
+        $dbPath = $this->makeRealSqliteDb();
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $thrown = null;
+        try {
+            $manager->runWithNavidromeStopped(function () use ($dbPath): void {
+                file_put_contents($dbPath, str_repeat("\xFF", 4096));
+                throw new \RuntimeException('action crashed mid-write');
+            });
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(NavidromeContainerException::class, $thrown);
+        $previous = $thrown->getPrevious();
+        $this->assertInstanceOf(\RuntimeException::class, $previous);
+        $this->assertSame('action crashed mid-write', $previous->getMessage());
+    }
+
+    public function testRunWithStoppedDoesNotRunPostCheckWhenPreCheckFailed(): void
+    {
+        // Pre-check fails (corrupt DB, no skip). Action does NOT run, so
+        // post-check is also skipped — we don't double-process the same
+        // corruption.
+        $dbPath = sys_get_temp_dir() . '/nv-precheck-' . bin2hex(random_bytes(4)) . '.db';
+        file_put_contents($dbPath, str_repeat("\x00", 4096));
+        $this->createdPaths[] = $dbPath;
+
+        $cli = new FakeDockerCli(state: ['Running' => true]);
+        $manager = new NavidromeContainerManager(
+            $cli,
+            new NavidromeContainerConfig('navidrome'),
+            new NavidromeDbBackup($dbPath, 3),
+        );
+
+        $actionRan = false;
+        try {
+            $manager->runWithNavidromeStopped(function () use (&$actionRan): void {
+                $actionRan = true;
+            });
+        } catch (\Throwable) {
+            // expected
+        }
+
+        $this->assertFalse($actionRan);
+        // start() was still issued (existing behaviour) — pre-check failure
+        // means « don't write », not « never bring Navidrome back up ».
+        $this->assertContains(['start', 'navidrome'], $cli->actions);
+    }
+
     /**
      * @param array<string, mixed>|null $state
      */
@@ -382,12 +551,20 @@ class NavidromeContainerManagerTest extends TestCase
     private function makeRealSqliteDb(): string
     {
         $path = sys_get_temp_dir() . '/nv-mgr-test-' . bin2hex(random_bytes(4)) . '.db';
+        $this->seedHealthySqliteAt($path);
+        $this->createdPaths[] = $path;
+
+        return $path;
+    }
+
+    private function seedHealthySqliteAt(string $path): void
+    {
+        if (file_exists($path)) {
+            @unlink($path);
+        }
         $pdo = new \PDO('sqlite:' . $path);
         $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
         $pdo->exec("INSERT INTO t (v) VALUES ('one'), ('two')");
         unset($pdo);
-        $this->createdPaths[] = $path;
-
-        return $path;
     }
 }

--- a/tests/LastFm/LastFmBufferProcessorTest.php
+++ b/tests/LastFm/LastFmBufferProcessorTest.php
@@ -128,6 +128,214 @@ class LastFmBufferProcessorTest extends TestCase
         $this->assertSame(2, $report->considered);
     }
 
+    public function testCrashOnFirstBatchRollsBackEverything(): void
+    {
+        $ndConn = NavidromeFixtureFactory::createDatabase($this->navidromeDbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($ndConn, 'mf-1', 'Hit', 'Artist');
+        NavidromeFixtureFactory::insertTrack($ndConn, 'mf-2', 'Other', 'Artist');
+
+        $rows = [
+            $this->makeBuffered('Artist', 'Hit', new \DateTimeImmutable('2026-04-02 10:00:00')),
+            $this->makeBuffered('Artist', 'Other', new \DateTimeImmutable('2026-04-02 10:01:00')),
+        ];
+        $this->seedBuffer($rows);
+
+        // Crashing repo fails on the 1st INSERT — entire (and only) batch rollbacks.
+        $crashingRepo = $this->makeCrashingRepo(crashAfter: 1);
+
+        // Track persist() calls on the mocked EM to assert that no audit was
+        // flushed for the rolled-back batch.
+        $persistCount = 0;
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($this->bufferConn);
+        $em->method('flush');
+        $em->method('persist')->willReturnCallback(function () use (&$persistCount): void {
+            $persistCount++;
+        });
+
+        $processor = new LastFmBufferProcessor(
+            $this->makeStreamingRepo($rows),
+            new ScrobbleMatcher(new NavidromeRepository($this->navidromeDbPath, 'admin')),
+            $crashingRepo,
+            $em,
+        );
+
+        $thrown = null;
+        try {
+            $processor->process(
+                auditRun: new RunHistory(RunHistory::TYPE_LASTFM_PROCESS, 'buffer', 'Crash test'),
+            );
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame('simulated crash mid-batch', $thrown->getMessage());
+
+        // Navidrome must be empty — the rollback discarded the only INSERT
+        // that did make it before the crashing one.
+        $count = (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles');
+        $this->assertSame(0, $count, 'Rolled-back batch must leave 0 scrobbles in Navidrome');
+
+        // Buffer rows must still be there for a retry.
+        $buffered = (int) $this->bufferConn->fetchOne('SELECT COUNT(*) FROM lastfm_import_buffer');
+        $this->assertSame(2, $buffered, 'Buffer rows must survive a rolled-back batch');
+
+        // No audit was persisted for the failed batch.
+        $this->assertSame(0, $persistCount, 'Audit rows must NOT be persisted when the batch rolls back');
+    }
+
+    public function testCrashOnSecondBatchKeepsFirstBatchCommitted(): void
+    {
+        $ndConn = NavidromeFixtureFactory::createDatabase($this->navidromeDbPath, withScrobbles: true);
+
+        // 250 unique tracks + buffer rows, all matchable. With BATCH_SIZE=100
+        // we have batches at [1-100], [101-200], [201-250]. We crash on the
+        // 150th INSERT (= 50th of the 2nd batch) — batch 1 must already be
+        // committed, batch 2 fully rolled back, batch 3 never reached.
+        $rows = [];
+        for ($i = 1; $i <= 250; $i++) {
+            NavidromeFixtureFactory::insertTrack($ndConn, sprintf('mf-%03d', $i), sprintf('Track %03d', $i), 'Artist');
+            $rows[] = $this->makeBuffered(
+                'Artist',
+                sprintf('Track %03d', $i),
+                // played_at must be unique per (user, played_at, artist, title) — spread
+                // by minute to fly under the dedup tolerance + buffer UNIQUE constraint.
+                (new \DateTimeImmutable('2026-04-01 00:00:00'))->modify('+' . $i . ' minutes'),
+            );
+        }
+        $this->seedBuffer($rows);
+
+        $crashingRepo = $this->makeCrashingRepo(crashAfter: 150);
+
+        $persistCount = 0;
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($this->bufferConn);
+        $em->method('flush');
+        $em->method('persist')->willReturnCallback(function () use (&$persistCount): void {
+            $persistCount++;
+        });
+
+        $processor = new LastFmBufferProcessor(
+            $this->makeStreamingRepo($rows),
+            new ScrobbleMatcher(new NavidromeRepository($this->navidromeDbPath, 'admin')),
+            $crashingRepo,
+            $em,
+        );
+
+        $thrown = null;
+        try {
+            $processor->process(
+                auditRun: new RunHistory(RunHistory::TYPE_LASTFM_PROCESS, 'buffer', 'Crash test'),
+            );
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+
+        // Batch 1 (rows 1-100) committed → 100 scrobbles + 100 buffer rows
+        // deleted + 100 audits persisted.
+        $count = (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles');
+        $this->assertSame(100, $count, 'First batch must remain committed');
+
+        $buffered = (int) $this->bufferConn->fetchOne('SELECT COUNT(*) FROM lastfm_import_buffer');
+        $this->assertSame(150, $buffered, 'Rows 101-250 must still be in the buffer for retry');
+
+        $this->assertSame(100, $persistCount, 'Only the first batch must have flushed audit rows');
+    }
+
+    public function testReprocessingAfterPartialFailureIsIdempotent(): void
+    {
+        // Replay the second-batch-crash scenario but with a smaller dataset
+        // so the fixture is cheap : 3 rows, BATCH_SIZE matters less here, the
+        // important property is that on a clean re-run the leftover rows are
+        // marked DUPLICATE not re-inserted (proving dedup catches what made
+        // it through committed batches).
+        $ndConn = NavidromeFixtureFactory::createDatabase($this->navidromeDbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($ndConn, 'mf-1', 'Track 1', 'Artist');
+        NavidromeFixtureFactory::insertTrack($ndConn, 'mf-2', 'Track 2', 'Artist');
+
+        // Pre-existing scrobble at +30s relative to row 1 played_at — within
+        // tolerance, so re-processing row 1 must be marked duplicate.
+        $row1Time = new \DateTimeImmutable('2026-04-01 12:00:00');
+        NavidromeFixtureFactory::insertScrobble(
+            $ndConn,
+            'user-1',
+            'mf-1',
+            $row1Time->modify('+30 seconds')->format('Y-m-d H:i:s'),
+        );
+
+        $rows = [
+            $this->makeBuffered('Artist', 'Track 1', $row1Time),
+            $this->makeBuffered('Artist', 'Track 2', new \DateTimeImmutable('2026-04-02 12:00:00')),
+        ];
+        $this->seedBuffer($rows);
+
+        // Clean run, no crash — the dedup must mark row 1 duplicate, row 2
+        // inserted. This is the « after partial failure » re-processing
+        // outcome.
+        $processor = $this->makeProcessor($rows);
+        $report = $processor->process(
+            auditRun: new RunHistory(RunHistory::TYPE_LASTFM_PROCESS, 'buffer', 'Replay test'),
+        );
+
+        $this->assertSame(1, $report->duplicates);
+        $this->assertSame(1, $report->inserted);
+        // Total scrobbles = pre-existing (1) + freshly inserted row 2 (1).
+        $this->assertSame(2, (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles'));
+    }
+
+    private function makeCrashingRepo(int $crashAfter): NavidromeRepository
+    {
+        return new class ($this->navidromeDbPath, 'admin', $crashAfter) extends NavidromeRepository {
+            public int $insertCalls = 0;
+
+            public function __construct(string $dbPath, string $userName, private int $crashOn)
+            {
+                parent::__construct($dbPath, $userName);
+            }
+
+            public function insertScrobble(string $userId, string $mediaFileId, \DateTimeInterface $time): void
+            {
+                $this->insertCalls++;
+                if ($this->insertCalls === $this->crashOn) {
+                    throw new \RuntimeException('simulated crash mid-batch');
+                }
+                parent::insertScrobble($userId, $mediaFileId, $time);
+            }
+        };
+    }
+
+    /**
+     * @param list<LastFmBufferedScrobble> $rows
+     */
+    private function makeStreamingRepo(array $rows): LastFmBufferedScrobbleRepository
+    {
+        $repo = $this->createMock(LastFmBufferedScrobbleRepository::class);
+        $repo->method('streamAll')->willReturnCallback(
+            function (int $limit = 0) use ($rows): \Generator {
+                $emitted = 0;
+                foreach ($rows as $row) {
+                    if ($limit > 0 && $emitted >= $limit) {
+                        break;
+                    }
+                    $stillThere = (int) $this->bufferConn->fetchOne(
+                        'SELECT COUNT(*) FROM lastfm_import_buffer WHERE id = ?',
+                        [$row->getId()],
+                    );
+                    if ($stillThere === 0) {
+                        continue;
+                    }
+                    $emitted++;
+                    yield $row;
+                }
+            }
+        );
+
+        return $repo;
+    }
+
     /**
      * @param list<LastFmBufferedScrobble> $rows
      */

--- a/tests/Navidrome/NavidromeDbBackupTest.php
+++ b/tests/Navidrome/NavidromeDbBackupTest.php
@@ -138,6 +138,172 @@ class NavidromeDbBackupTest extends TestCase
         (new NavidromeDbBackup($truncated))->quickCheck();
     }
 
+    public function testRestoreLatestWhenTimestampNull(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        $backupPath = $backup->backup();
+        $this->assertNotNull($backupPath);
+        $originalContent = (string) file_get_contents($dbPath);
+
+        // Mutate the live DB — restore must overwrite this with the snapshot.
+        $pdo = new \PDO('sqlite:' . $dbPath);
+        $pdo->exec("INSERT INTO t (v) VALUES ('mutated-after-backup')");
+        unset($pdo);
+
+        $restoredFrom = $backup->restore();
+        $this->assertSame($backupPath, $restoredFrom);
+        $this->assertSame($originalContent, file_get_contents($dbPath));
+    }
+
+    public function testRestoreSpecificTimestamp(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        // Plant two SQLite-valid forged backups with distinguishable content.
+        $oldStamp = '20200101000001';
+        $oldBackup = $dbPath . '.backup-' . $oldStamp;
+        $this->makeSqliteDbAt($oldBackup, "INSERT INTO t (v) VALUES ('from-old-backup')");
+
+        $newerStamp = '20200101000002';
+        $newerBackup = $dbPath . '.backup-' . $newerStamp;
+        $this->makeSqliteDbAt($newerBackup, "INSERT INTO t (v) VALUES ('from-newer-backup')");
+
+        // Restore the older one explicitly.
+        $restoredFrom = $backup->restore($oldStamp);
+        $this->assertSame($oldBackup, $restoredFrom);
+
+        $pdo = new \PDO('sqlite:' . $dbPath);
+        $stmt = $pdo->query('SELECT v FROM t ORDER BY id');
+        $rows = $stmt !== false ? $stmt->fetchAll(\PDO::FETCH_COLUMN) : [];
+        $this->assertContains('from-old-backup', $rows);
+        $this->assertNotContains('from-newer-backup', $rows);
+    }
+
+    public function testRestorePropagatesWalAndShmSiblings(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        // Plant fake siblings on the live DB so backup() snapshots them.
+        file_put_contents($dbPath . '-wal', 'wal-snapshot');
+        file_put_contents($dbPath . '-shm', 'shm-snapshot');
+
+        $backupPath = $backup->backup();
+        $this->assertNotNull($backupPath);
+        // The backup must carry the -wal payload byte-for-byte.
+        $this->assertSame('wal-snapshot', file_get_contents($backupPath . '-wal'));
+
+        // Wipe the live siblings, restore must recreate them from the backup.
+        @unlink($dbPath . '-wal');
+        @unlink($dbPath . '-shm');
+
+        $backup->restore();
+
+        // SQLite (called via the post-restore quick_check) may grow / rewrite
+        // the -shm file to its real internal layout, even in ro mode. We only
+        // assert sibling presence — content fidelity is checked on the backup
+        // file above, where SQLite hasn't touched anything.
+        $this->assertFileExists($dbPath . '-wal');
+        $this->assertFileExists($dbPath . '-shm');
+        $this->assertSame('wal-snapshot', file_get_contents($dbPath . '-wal'));
+    }
+
+    public function testRestoreWipesLiveWalWhenBackupHasNone(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        // Backup taken without any siblings.
+        $backupPath = $backup->backup();
+        $this->assertNotNull($backupPath);
+        $this->assertFileDoesNotExist($backupPath . '-wal');
+
+        // Plant stale siblings on the live DB AFTER the backup. SQLite
+        // would try to replay these on top of the restored main DB → bad.
+        file_put_contents($dbPath . '-wal', 'stale-wal');
+        file_put_contents($dbPath . '-shm', 'stale-shm');
+
+        $backup->restore();
+
+        $this->assertFileDoesNotExist($dbPath . '-wal', 'stale -wal must be wiped');
+        $this->assertFileDoesNotExist($dbPath . '-shm', 'stale -shm must be wiped');
+    }
+
+    public function testRestoreReturnsSourceBackupPath(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+        $backupPath = $backup->backup();
+        $this->assertNotNull($backupPath);
+
+        $this->assertSame($backupPath, $backup->restore());
+    }
+
+    public function testRestoreThrowsWhenNoBackupExists(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Aucun backup disponible/');
+        $backup->restore();
+    }
+
+    public function testRestoreThrowsWhenSpecificTimestampNotFound(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+        $backup->backup();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/Aucun backup trouvé pour le timestamp/');
+        $backup->restore('99999999999999');
+    }
+
+    public function testRestoreThrowsWhenBackupItselfIsCorruptedAndLeavesLiveDbUntouched(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+
+        // Plant a corrupt backup directly (not via backup() which would copy
+        // a healthy DB).
+        $stamp = '20200101000001';
+        file_put_contents($dbPath . '.backup-' . $stamp, str_repeat("\xFF", 4096));
+
+        $liveContentBefore = (string) file_get_contents($dbPath);
+
+        try {
+            $backup->restore($stamp);
+            $this->fail('restore() should have thrown on a corrupt backup');
+        } catch (\RuntimeException) {
+            // expected
+        }
+
+        // The live DB must not have been touched — restore vets the backup
+        // before copying.
+        $this->assertSame($liveContentBefore, file_get_contents($dbPath));
+    }
+
+    public function testLatestBackupReturnsTimestampOfNewest(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        foreach (['20200101000001', '20200101000002', '20200101000003'] as $stamp) {
+            file_put_contents($dbPath . '.backup-' . $stamp, 'x');
+        }
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+        $this->assertSame('20200101000003', $backup->latestBackup());
+    }
+
+    public function testLatestBackupReturnsNullWhenNoBackups(): void
+    {
+        $dbPath = $this->makeSqliteDb();
+        $backup = new NavidromeDbBackup($dbPath, retention: 5);
+        $this->assertNull($backup->latestBackup());
+    }
+
     private function makeSqliteDb(): string
     {
         $path = sys_get_temp_dir() . '/nv-bk-test-' . bin2hex(random_bytes(4)) . '.db';
@@ -148,5 +314,19 @@ class NavidromeDbBackupTest extends TestCase
         $this->createdPaths[] = $path;
 
         return $path;
+    }
+
+    private function makeSqliteDbAt(string $path, string $extraSql = ''): void
+    {
+        $pdo = new \PDO('sqlite:' . $path);
+        $pdo->exec('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)');
+        $pdo->exec("INSERT INTO t (v) VALUES ('one'), ('two')");
+        if ($extraSql !== '') {
+            $pdo->exec($extraSql);
+        }
+        unset($pdo);
+        // tearDown wipes by .backup-* glob next to the source DB, so this is
+        // covered when $path lives next to a tracked dbPath. For standalone
+        // paths, register manually.
     }
 }

--- a/tests/Navidrome/NavidromeRepositoryTransactionTest.php
+++ b/tests/Navidrome/NavidromeRepositoryTransactionTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the durability/concurrency knobs added to {@see NavidromeRepository}
+ * for crash-safe scrobble imports : explicit transaction helpers, PRAGMA
+ * setup, WAL checkpoint, connection close.
+ */
+class NavidromeRepositoryTransactionTest extends TestCase
+{
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/navidrome-tx-test-' . uniqid() . '.db';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['', '-wal', '-shm'] as $suffix) {
+            $path = $this->dbPath . $suffix;
+            if (file_exists($path)) {
+                @unlink($path);
+            }
+        }
+    }
+
+    public function testCommitWritePersistsBatchedInserts(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track 1');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Track 2');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-3', 'Track 3');
+        $conn->close();
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $repo->beginWriteTransaction();
+        $repo->insertScrobble('user-1', 'mf-1', new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $repo->insertScrobble('user-1', 'mf-2', new \DateTimeImmutable('2026-01-01 10:01:00'));
+        $repo->insertScrobble('user-1', 'mf-3', new \DateTimeImmutable('2026-01-01 10:02:00'));
+        $repo->commitWrite();
+        $repo->closeWriteConnection();
+
+        $this->assertSame(3, $this->countScrobbles());
+    }
+
+    public function testRollbackWriteDiscardsBatchedInserts(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track 1');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Track 2');
+        $conn->close();
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $repo->beginWriteTransaction();
+        $repo->insertScrobble('user-1', 'mf-1', new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $repo->insertScrobble('user-1', 'mf-2', new \DateTimeImmutable('2026-01-01 10:01:00'));
+        // Crash mid-batch — rollback must discard everything written so far.
+        $repo->rollbackWrite();
+        $repo->closeWriteConnection();
+
+        $this->assertSame(0, $this->countScrobbles(), 'rollback must discard the entire batch');
+    }
+
+    public function testBeginImmediateFailsFastWhenAnotherWriterHoldsTheLock(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track 1');
+        $conn->close();
+
+        // Open a competing PDO writer and grab the RESERVED lock first.
+        // Use a *short* busy_timeout on the second connection so the test
+        // doesn't wait the full 30s — the helper opens a fresh PDO with its
+        // own knobs that override the repo defaults for this test only.
+        $other = new \PDO('sqlite:' . $this->dbPath, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+        $other->exec('BEGIN IMMEDIATE');
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // Override busy_timeout for this test only — repo default 30s is too
+        // long for a unit test.
+        $repo->isAvailable(); // forces connection open + PRAGMA setup
+        $native = $this->reflectionPdo($repo);
+        $native->exec('PRAGMA busy_timeout = 100');
+
+        try {
+            $repo->beginWriteTransaction();
+            $this->fail('beginWriteTransaction must throw when another writer holds the lock');
+        } catch (\Throwable $e) {
+            $this->assertStringContainsString('database is locked', strtolower($e->getMessage()));
+        } finally {
+            $other->exec('ROLLBACK');
+            $other = null;
+            $repo->closeWriteConnection();
+        }
+    }
+
+    public function testWalCheckpointTruncateIsNoOpWhenConnectionNotOpen(): void
+    {
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        // No exception even though the DB file doesn't exist and no connection
+        // has been opened.
+        $repo->walCheckpointTruncate();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testWalCheckpointTruncateRunsSilentlyOnDeleteJournal(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track 1');
+        $conn->close();
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $repo->beginWriteTransaction();
+        $repo->insertScrobble('user-1', 'mf-1', new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $repo->commitWrite();
+        // The fixture DB is in DELETE journal mode (default). Checkpoint
+        // must just no-op without throwing.
+        $repo->walCheckpointTruncate();
+        $repo->closeWriteConnection();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testConnectionAppliesBusyTimeoutAndSynchronous(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        $conn->close();
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $repo->isAvailable(); // open the connection + apply pragmas
+
+        $native = $this->reflectionPdo($repo);
+        $busyTimeout = (int) $native->query('PRAGMA busy_timeout')->fetchColumn();
+        $synchronous = (int) $native->query('PRAGMA synchronous')->fetchColumn();
+
+        $this->assertSame(30000, $busyTimeout, 'busy_timeout must be 30000ms for crash resilience');
+        // synchronous = 2 = FULL (full fsync on commit).
+        $this->assertSame(2, $synchronous, 'synchronous must be FULL on the writer connection');
+    }
+
+    public function testCloseWriteConnectionAllowsLazyReconnect(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Track 1');
+        $conn->close();
+
+        $repo = new NavidromeRepository($this->dbPath, 'admin');
+        $repo->beginWriteTransaction();
+        $repo->insertScrobble('user-1', 'mf-1', new \DateTimeImmutable('2026-01-01 10:00:00'));
+        $repo->commitWrite();
+        $repo->closeWriteConnection();
+
+        // After a close, subsequent calls must transparently reconnect.
+        $this->assertTrue($repo->isAvailable(), 'connection must lazily re-open after closeWriteConnection');
+        $this->assertSame(1, $this->countScrobbles());
+    }
+
+    private function countScrobbles(): int
+    {
+        $pdo = new \PDO('sqlite:' . $this->dbPath, null, null, [
+            \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+        ]);
+        $count = $pdo->query('SELECT COUNT(*) FROM scrobbles')->fetchColumn();
+
+        return (int) $count;
+    }
+
+    /**
+     * Reach into the repo's private connection to drive raw PDO queries.
+     * Only used in tests that need to inspect SQLite session state.
+     */
+    private function reflectionPdo(NavidromeRepository $repo): \PDO
+    {
+        $ref = new \ReflectionClass($repo);
+        $prop = $ref->getProperty('connection');
+        $prop->setAccessible(true);
+        $connection = $prop->getValue($repo);
+        $this->assertNotNull($connection, 'expected an open Doctrine connection');
+        $native = $connection->getNativeConnection();
+        $this->assertInstanceOf(\PDO::class, $native);
+
+        return $native;
+    }
+}

--- a/tests/Service/LastFmRematchServiceTest.php
+++ b/tests/Service/LastFmRematchServiceTest.php
@@ -156,6 +156,75 @@ class LastFmRematchServiceTest extends TestCase
         $this->assertSame(1, (int) $count);
     }
 
+    public function testCrashMidBatchRollsBackTrackMutationsAndNavidromeWrites(): void
+    {
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'T1', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'T2', 'Artist');
+
+        $run = $this->makeRun();
+        $tracks = [
+            $this->makeUnmatchedTrack($run, 'Artist', 'T1', new \DateTimeImmutable('2026-04-01 10:00:00')),
+            $this->makeUnmatchedTrack($run, 'Artist', 'T2', new \DateTimeImmutable('2026-04-02 10:00:00')),
+        ];
+
+        // Crashing repo throws on the 1st INSERT — entire batch rolls back.
+        $crashingRepo = new class ($this->dbPath, 'admin') extends NavidromeRepository {
+            public int $insertCalls = 0;
+
+            public function insertScrobble(string $userId, string $mediaFileId, \DateTimeInterface $time): void
+            {
+                $this->insertCalls++;
+                if ($this->insertCalls === 1) {
+                    throw new \RuntimeException('simulated crash mid-batch');
+                }
+                parent::insertScrobble($userId, $mediaFileId, $time);
+            }
+        };
+
+        $repo = $this->createMock(LastFmImportTrackRepository::class);
+        $repo->method('streamUnmatched')->willReturnCallback(
+            function () use ($tracks): \Generator {
+                foreach ($tracks as $t) {
+                    if ($t->getStatus() === LastFmImportTrack::STATUS_UNMATCHED) {
+                        yield $t;
+                    }
+                }
+            }
+        );
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('flush');
+        $em->method('persist');
+
+        $service = new LastFmRematchService(
+            $repo,
+            new ScrobbleMatcher(new NavidromeRepository($this->dbPath, 'admin')),
+            $crashingRepo,
+            $em,
+        );
+
+        $thrown = null;
+        try {
+            $service->rematch();
+        } catch (\Throwable $e) {
+            $thrown = $e;
+        }
+
+        $this->assertInstanceOf(\RuntimeException::class, $thrown);
+        $this->assertSame('simulated crash mid-batch', $thrown->getMessage());
+
+        // Navidrome rollback: zero scrobbles inserted.
+        $count = (int) $conn->fetchOne('SELECT COUNT(*) FROM scrobbles');
+        $this->assertSame(0, $count, 'rollback must discard the entire batch');
+
+        // Track mutations must NOT have been applied — a retry sees them
+        // as unmatched again.
+        $this->assertSame(LastFmImportTrack::STATUS_UNMATCHED, $tracks[0]->getStatus());
+        $this->assertSame(LastFmImportTrack::STATUS_UNMATCHED, $tracks[1]->getStatus());
+        $this->assertNull($tracks[0]->getMatchedMediaFileId());
+        $this->assertNull($tracks[1]->getMatchedMediaFileId());
+    }
+
     public function testRematchHonorsRandomFlagAndLimit(): void
     {
         // 5 unmatched rows, --random + --limit=2 should process exactly 2.


### PR DESCRIPTION
Closes #135.

## Couches de défense

Trois couches du plus chaud au plus froid contre la corruption SQLite
de `navidrome.db` quand un import Last.fm plante en cours.

### 1. Empêcher l'écriture partielle

`LastFmBufferProcessor::process` et `LastFmRematchService::rematch`
wrappent désormais chaque batch de 100 INSERT dans une transaction
explicite `BEGIN IMMEDIATE` / `COMMIT` côté Navidrome. Audits
`LastFmImportTrack` + `DELETE FROM lastfm_import_buffer` reportés en
post-commit Navidrome — accumulation en mémoire pendant le batch,
application en bloc une fois la portion Navidrome durable.

Crash mid-batch (kill -9, exception PHP, OOM) → `ROLLBACK` Navidrome
+ pending dropé → audits/buffer rows intacts pour la reprise.
Idempotence via `scrobbleExistsNear` + nouveau cross-check
intra-batch (`pendingBatchHasNearScrobble`) qui dédup les scrobbles
multiples en vol dans le même batch.

### 2. Garantir un état SQLite sain à la fermeture

Connexion write Navidrome :
- `PRAGMA busy_timeout=30000` — retry-on-lock 30s.
- `PRAGMA synchronous=FULL` — fsync complet à chaque COMMIT.
- `PRAGMA wal_checkpoint(TRUNCATE)` forcé en `finally` avant close —
  garantit que le WAL est mergé dans la main DB avant que Navidrome
  ne rouvre.

`journal_mode` volontairement non touché (persistant dans la DB,
Navidrome en est propriétaire).

### 3. Détecter et corriger

`NavidromeContainerManager::runWithNavidromeStopped` gagne un
`PRAGMA quick_check` *post-action* systématique. Si fail, restore
automatique du snapshot pré-action via la nouvelle méthode
`NavidromeDbBackup::restore()`, exception explicite chaînée :

> DB Navidrome corrompue après l'action — restaurée automatiquement
> depuis `<dbPath>.backup-…`.

Si la restore échoue elle aussi, Navidrome n'est PAS redémarré (DB en
limbo) et l'erreur pointe vers `app:navidrome:db:restore` pour
récupération manuelle.

## Outillage CLI

- `app:navidrome:db:check [--integrity]` — quick_check par défaut,
  integrity_check avec le flag (lent mais exhaustif). Read-only.
- `app:navidrome:db:restore [--timestamp=YYYYMMDDHHMMSS] [--list]` —
  restauration manuelle. Utilise `runWithNavidromeStopped(skipPreCheck:
  true)` pour pouvoir tourner sur une DB que le pré-check refuserait
  d'ouvrir.

## Test plan

- [x] `composer ci` vert (phpcs + phpstan niveau 6 + phpunit) —
      393 tests / 1063 assertions.
- [x] Tests crash mid-batch ajoutés (`testCrashOnFirstBatch…`,
      `testCrashOnSecondBatchKeepsFirstBatchCommitted`,
      `testReprocessingAfterPartialFailureIsIdempotent`,
      `testCrashMidBatchRollsBackTrackMutationsAndNavidromeWrites`).
- [x] Tests corruption + restore auto (`testRunWithStoppedRestoresWhenPostActionQuickCheckFails`,
      `testRunWithStoppedSkipsRestartWhenRestoreFails`,
      `testRunWithStoppedChainsActionExceptionAfterCorruption`).
- [x] Tests dédicacés à la nouvelle couche transactionnelle
      (`NavidromeRepositoryTransactionTest` : begin/commit/rollback,
      `BEGIN IMMEDIATE` fail-fast sur lock concurrent, pragmas
      appliqués, lazy reconnect après close).
- [ ] Test E2E sous Lando : interrompre brutalement un
      `app:lastfm:process` en cours, confirmer que Navidrome
      redémarre proprement et que la reprise est idempotente.
- [ ] Vérifier `app:navidrome:db:check --integrity` sur la DB
      Navidrome de prod.
- [ ] Vérifier `app:navidrome:db:restore --list` affiche les
      backups attendus.

## Documentation

- `CHANGELOG.md` : section `Added` détaillée.
- `CLAUDE.md` : nouveau piège #12 documentant le pattern et
  pointant les futurs hackers vers
  `NavidromeRepository::beginWriteTransaction` plutôt que vers un
  INSERT direct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)