### PR TITLE
Add database wipe feature to settings with safety confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+- **Réglages : bouton « Vider la base tools »** dans une zone
+  dangereuse de `/settings`. Vide en une opération les tables
+  d'import / audit / cache / snapshots / historiques (buffer Last.fm,
+  `lastfm_import_track`, `lastfm_match_cache`, `lastfm_history`,
+  `navidrome_history`, `stats_snapshot`, `top_snapshot`,
+  `run_history`) tout en **conservant** les réglages, les
+  définitions de playlists et les deux tables d'alias
+  (`lastfm_alias` track-level + `lastfm_artist_alias` artist-level).
+  Confirmation par saisie de « WIPE » + dialogue navigateur, CSRF
+  dédié `settings_wipe_database`. Implémenté par
+  `App\Service\ToolsDatabaseWiper` (DBAL pur, ordre FK-safe).
+
 ### Removed
 - **BREAKING — Worker Symfony Messenger** : la mécanique async qui
   permettait de lancer les 4 long-runners Last.fm (`fetch`, `process`,

--- a/src/Controller/SettingsController.php
+++ b/src/Controller/SettingsController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\LastFm\LastFmAuthService;
 use App\Service\SettingsService;
+use App\Service\ToolsDatabaseWiper;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,6 +35,27 @@ class SettingsController extends AbstractController
             'default_template' => $settings->getDefaultNameTemplate(),
             'lastfm_auth_configured' => $lastfmAuth->isConfigured(),
             'lastfm_session_user' => $lastfmAuth->getStoredSessionUser(),
+            'wipeable_tables' => ToolsDatabaseWiper::wipedTables(),
         ]);
+    }
+
+    #[Route('/settings/wipe-tools-database', name: 'app_settings_wipe_database', methods: ['POST'])]
+    public function wipeToolsDatabase(Request $request, ToolsDatabaseWiper $wiper): Response
+    {
+        if (!$this->isCsrfTokenValid('settings_wipe_database', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        if (trim((string) $request->request->get('confirm', '')) !== 'WIPE') {
+            $this->addFlash('warning', 'Confirmation manquante : tapez WIPE pour vider la base.');
+            return $this->redirectToRoute('app_settings');
+        }
+
+        $deleted = $wiper->wipe();
+        $total = array_sum($deleted);
+        $this->addFlash(
+            'success',
+            sprintf('Base tools vidée : %d lignes supprimées (alias et réglages conservés).', $total),
+        );
+        return $this->redirectToRoute('app_settings');
     }
 }

--- a/src/Service/ToolsDatabaseWiper.php
+++ b/src/Service/ToolsDatabaseWiper.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Service;
+
+use Doctrine\DBAL\Connection;
+
+/**
+ * Clears the local tools database of all import / audit / cache / snapshot
+ * data while preserving user-curated content: settings, playlist
+ * definitions, track-level Last.fm aliases (lastfm_alias) and artist-level
+ * aliases (lastfm_artist_alias).
+ */
+class ToolsDatabaseWiper
+{
+    /**
+     * Tables wiped, in FK-safe order (children before parents).
+     */
+    private const TABLES_TO_WIPE = [
+        'lastfm_import_track',
+        'lastfm_import_buffer',
+        'lastfm_match_cache',
+        'lastfm_history',
+        'navidrome_history',
+        'stats_snapshot',
+        'top_snapshot',
+        'run_history',
+    ];
+
+    public function __construct(private readonly Connection $connection)
+    {
+    }
+
+    /**
+     * @return array<string, int> table name → number of rows deleted
+     */
+    public function wipe(): array
+    {
+        $deleted = [];
+        foreach (self::TABLES_TO_WIPE as $table) {
+            $deleted[$table] = (int) $this->connection->executeStatement('DELETE FROM ' . $table);
+        }
+        return $deleted;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function wipedTables(): array
+    {
+        return self::TABLES_TO_WIPE;
+    }
+}

--- a/templates/settings/index.html.twig
+++ b/templates/settings/index.html.twig
@@ -62,4 +62,40 @@
                class="inline-block px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Se connecter à Last.fm</a>
         {% endif %}
     </div>
+
+    <div class="bg-white shadow rounded p-6 max-w-xl mt-6 border border-rose-200 space-y-3">
+        <h2 class="text-lg font-semibold text-rose-800">Zone dangereuse</h2>
+        <p class="text-sm text-slate-700">
+            Vide complètement la base locale du tool : buffer Last.fm, audit par-track,
+            historiques (Last.fm + Navidrome), snapshots stats / wrapped / tops, cache de
+            matching et historique des runs cron.
+        </p>
+        <p class="text-sm text-slate-700">
+            <strong>Conservés :</strong> réglages, définitions de playlists, alias morceaux
+            (<code>lastfm_alias</code>) et alias artistes (<code>lastfm_artist_alias</code>).
+        </p>
+        <details class="text-xs text-slate-500">
+            <summary class="cursor-pointer">Tables vidées ({{ wipeable_tables|length }})</summary>
+            <ul class="list-disc list-inside mt-1 font-mono">
+                {% for t in wipeable_tables %}<li>{{ t }}</li>{% endfor %}
+            </ul>
+        </details>
+        <form method="post" action="{{ path('app_settings_wipe_database') }}"
+              class="space-y-3 border-t border-rose-100 pt-3"
+              onsubmit="return confirm('Vider la base tools ? Cette action est irréversible (les alias et réglages sont conservés).');">
+            <input type="hidden" name="_token" value="{{ csrf_token('settings_wipe_database') }}">
+            <div>
+                <label for="wipe_confirm" class="block text-sm font-medium mb-1">
+                    Tapez <code>WIPE</code> pour confirmer
+                </label>
+                <input type="text" id="wipe_confirm" name="confirm" autocomplete="off"
+                       class="w-full border rounded px-3 py-2 font-mono text-sm" required pattern="WIPE">
+            </div>
+            <div class="flex justify-end">
+                <button type="submit" class="px-4 py-2 text-sm rounded bg-rose-600 hover:bg-rose-700 text-white">
+                    Vider la base tools
+                </button>
+            </div>
+        </form>
+    </div>
 {% endblock %}

--- a/tests/Service/ToolsDatabaseWiperTest.php
+++ b/tests/Service/ToolsDatabaseWiperTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\ToolsDatabaseWiper;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+
+class ToolsDatabaseWiperTest extends TestCase
+{
+    private string $dbPath;
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/tools-wiper-' . uniqid() . '.db';
+        $this->conn = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => $this->dbPath,
+        ]);
+
+        // Tables that must be wiped — minimal schemas, just the columns we touch.
+        foreach (ToolsDatabaseWiper::wipedTables() as $table) {
+            $this->conn->executeStatement(
+                'CREATE TABLE ' . $table . ' (id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)',
+            );
+            $this->conn->executeStatement(
+                'INSERT INTO ' . $table . " (payload) VALUES ('row-1'), ('row-2')",
+            );
+        }
+
+        // Tables that must be preserved.
+        foreach (['lastfm_alias', 'lastfm_artist_alias', 'setting', 'playlist_definition'] as $table) {
+            $this->conn->executeStatement(
+                'CREATE TABLE ' . $table . ' (id INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT)',
+            );
+            $this->conn->executeStatement(
+                'INSERT INTO ' . $table . " (payload) VALUES ('keep-me')",
+            );
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testWipeEmptiesTrackedTablesAndReportsCounts(): void
+    {
+        $wiper = new ToolsDatabaseWiper($this->conn);
+
+        $deleted = $wiper->wipe();
+
+        foreach (ToolsDatabaseWiper::wipedTables() as $table) {
+            self::assertSame(2, $deleted[$table], $table . ' should report 2 rows deleted');
+            self::assertSame(
+                0,
+                (int) $this->conn->fetchOne('SELECT COUNT(*) FROM ' . $table),
+                $table . ' should be empty after wipe',
+            );
+        }
+    }
+
+    public function testWipePreservesAliasAndSettingTables(): void
+    {
+        $wiper = new ToolsDatabaseWiper($this->conn);
+
+        $wiper->wipe();
+
+        foreach (['lastfm_alias', 'lastfm_artist_alias', 'setting', 'playlist_definition'] as $table) {
+            self::assertSame(
+                1,
+                (int) $this->conn->fetchOne('SELECT COUNT(*) FROM ' . $table),
+                $table . ' must not be touched by the wipe',
+            );
+        }
+    }
+
+    public function testWipeIsIdempotent(): void
+    {
+        $wiper = new ToolsDatabaseWiper($this->conn);
+
+        $wiper->wipe();
+        $second = $wiper->wipe();
+
+        foreach ($second as $count) {
+            self::assertSame(0, $count);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a "Danger Zone" section to the settings page with a database wipe feature that safely clears import, audit, cache, and snapshot data while preserving user-curated content (settings, playlists, and aliases).

## Changes

- **New Service: `ToolsDatabaseWiper`**
  - Implements safe deletion of 8 tables in FK-safe order: `lastfm_import_track`, `lastfm_import_buffer`, `lastfm_match_cache`, `lastfm_history`, `navidrome_history`, `stats_snapshot`, `top_snapshot`, `run_history`
  - Preserves critical user data: `setting`, `playlist_definition`, `lastfm_alias`, `lastfm_artist_alias`
  - Returns deletion counts per table for audit purposes
  - Fully idempotent (safe to call multiple times)

- **Settings Controller Enhancement**
  - New POST endpoint `/settings/wipe-tools-database` with CSRF protection
  - Requires explicit confirmation by typing "WIPE" in a text field
  - Browser confirmation dialog as additional safety layer
  - Flash message feedback with total row count deleted

- **Settings UI**
  - New "Danger Zone" section with red styling (rose-200/600/800 borders)
  - Collapsible list of tables being wiped
  - Clear documentation of what is preserved
  - Form with confirmation input field and submit button

- **Comprehensive Test Suite**
  - Tests verify correct tables are wiped and counts reported
  - Tests confirm protected tables remain untouched
  - Tests validate idempotency (multiple wipes return 0 deletions)
  - Uses temporary SQLite database for isolation

## Implementation Details
- Uses Doctrine DBAL directly (no ORM) for efficient bulk deletion
- CSRF token validation prevents accidental/malicious requests
- Pattern validation on confirmation input (`pattern="WIPE"`)
- French UI text matching application language

https://claude.ai/code/session_01CVj5CS5sFmLEeUtCzWfYyB