### PR TITLE
Retry transient HTTP errors in Last.fm API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,17 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
   exemples dans `docker-compose.example.yml`.
 
 ### Fixed
+- **`app:lastfm:import` — retry sur erreurs HTTP transitoires de
+  l'API Last.fm** : `LastFmClient::call()` intercepte désormais les
+  500/5xx, 429 et erreurs réseau (`TransportExceptionInterface`) et
+  réessaie jusqu'à 3 fois en attendant `LASTFM_PAGE_DELAY_SECONDS`
+  entre chaque tentative. Évite qu'un long fetch (`Last.fm API call
+  failed (method=user.getRecentTracks page=215): HTTP/2 500`) ne tue
+  toute la run alors que la prochaine page passerait sans souci. Les
+  erreurs applicatives (clé d'API invalide, etc., signalées via le
+  champ `error` du JSON) ne sont pas retentées — elles surfacent
+  immédiatement. Le message d'erreur final inclut le compteur
+  d'attempts pour diagnostiquer.
 - **`app:lastfm:process` / `app:lastfm:rematch` — fuite mémoire sur
   les gros volumes** : `LastFmBufferProcessor` et `LastFmRematchService`
   flushaient toutes les 100 itérations mais ne vidaient jamais

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -2,12 +2,15 @@
 
 namespace App\LastFm;
 
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 class LastFmClient
 {
     private const BASE_URL = 'https://ws.audioscrobbler.com/2.0/';
     private const PAGE_SIZE = 200;
+    private const MAX_ATTEMPTS = 3;
 
     public function __construct(
         private readonly HttpClientInterface $httpClient,
@@ -338,19 +341,38 @@ class LastFmClient
      */
     private function call(array $params): array
     {
-        try {
-            $response = $this->httpClient->request('GET', self::BASE_URL, [
-                'query' => $params,
-                'timeout' => 30,
-            ]);
-            $body = $response->toArray(throw: true);
-        } catch (\Throwable $e) {
-            throw new \RuntimeException(sprintf(
-                'Last.fm API call failed (method=%s page=%s): %s',
-                $params['method'] ?? '?',
-                $params['page'] ?? '?',
-                $e->getMessage(),
-            ), 0, $e);
+        $attempt = 0;
+        while (true) {
+            $attempt++;
+            try {
+                $response = $this->httpClient->request('GET', self::BASE_URL, [
+                    'query' => $params,
+                    'timeout' => 30,
+                ]);
+                $body = $response->toArray(throw: true);
+                break;
+            } catch (\Throwable $e) {
+                // Transient errors (network blips, 5xx, 429) are common on
+                // long imports — Last.fm sometimes 500s mid-history. Retry
+                // up to MAX_ATTEMPTS using the configured page delay before
+                // bubbling up. Application-level errors (`error` key in the
+                // body) are NOT caught here since they reach us only after
+                // a successful HTTP exchange.
+                if ($attempt < self::MAX_ATTEMPTS && $this->isTransientHttpError($e)) {
+                    if ($this->pageDelaySeconds > 0) {
+                        sleep($this->pageDelaySeconds);
+                    }
+                    continue;
+                }
+
+                throw new \RuntimeException(sprintf(
+                    'Last.fm API call failed (method=%s page=%s) after %d attempt(s): %s',
+                    $params['method'] ?? '?',
+                    $params['page'] ?? '?',
+                    $attempt,
+                    $e->getMessage(),
+                ), 0, $e);
+            }
         }
 
         if (isset($body['error'])) {
@@ -361,5 +383,19 @@ class LastFmClient
         }
 
         return $body;
+    }
+
+    private function isTransientHttpError(\Throwable $e): bool
+    {
+        if ($e instanceof TransportExceptionInterface) {
+            return true;
+        }
+        if ($e instanceof HttpExceptionInterface) {
+            $status = $e->getResponse()->getStatusCode();
+
+            return $status === 429 || $status >= 500;
+        }
+
+        return false;
     }
 }

--- a/tests/LastFm/LastFmClientTest.php
+++ b/tests/LastFm/LastFmClientTest.php
@@ -192,6 +192,87 @@ class LastFmClientTest extends TestCase
         $this->assertNull($similar[1]['mbid'], 'empty MBID coerced to null');
     }
 
+    public function testCallRetriesOnTransient500AndSucceeds(): void
+    {
+        // Last.fm sometimes 500s mid-history during long imports — the
+        // client must absorb up to two transient failures and resume on
+        // the third attempt without bubbling up.
+        $http = new MockHttpClient([
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse(json_encode([
+                'similarartists' => ['artist' => []],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $client = new LastFmClient($http, 0);
+
+        // Should not throw — third attempt succeeds.
+        $similar = $client->artistGetSimilar('apikey', 'Daft Punk');
+        $this->assertSame([], $similar);
+        $this->assertSame(3, $http->getRequestsCount());
+    }
+
+    public function testCallGivesUpAfterThreeFailedAttempts(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse('boom', ['http_code' => 500]),
+            new MockResponse('boom', ['http_code' => 500]),
+        ]);
+
+        $client = new LastFmClient($http, 0);
+
+        try {
+            $client->artistGetSimilar('apikey', 'Daft Punk');
+            $this->fail('Expected RuntimeException to be thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('after 3 attempt(s)', $e->getMessage());
+            $this->assertSame(3, $http->getRequestsCount());
+        }
+    }
+
+    public function testCallDoesNotRetryOnApplicationLevelErrorPayload(): void
+    {
+        // `error` in the JSON body is an application-level failure (e.g.
+        // invalid API key) — retrying just hammers the API. Must surface
+        // immediately as LastFmApiException.
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                'error' => 10,
+                'message' => 'Invalid API key',
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+
+        $client = new LastFmClient($http, 0);
+
+        $this->expectException(LastFmApiException::class);
+        try {
+            $client->artistGetSimilar('badkey', 'Daft Punk');
+        } finally {
+            $this->assertSame(1, $http->getRequestsCount());
+        }
+    }
+
+    public function testCallDoesNotRetryOn4xxClientErrors(): void
+    {
+        // 4xx is the caller's fault (bad params, missing key) — retrying
+        // wastes calls. Only 5xx and 429 are treated as transient.
+        $http = new MockHttpClient([
+            new MockResponse('not found', ['http_code' => 404]),
+        ]);
+
+        $client = new LastFmClient($http, 0);
+
+        try {
+            $client->artistGetSimilar('apikey', 'Daft Punk');
+            $this->fail('Expected RuntimeException to be thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('after 1 attempt(s)', $e->getMessage());
+            $this->assertSame(1, $http->getRequestsCount());
+        }
+    }
+
     public function testArtistGetSimilarHandlesSingleObjectShape(): void
     {
         // Last.fm collapses to a single object when only one neighbour is found.


### PR DESCRIPTION
## Summary
Adds automatic retry logic to the Last.fm API client to handle transient failures (5xx errors, 429 rate limiting, and network errors) that commonly occur during long import operations.

## Changes
- **Retry mechanism**: `LastFmClient::call()` now retries up to 3 times on transient HTTP errors (5xx, 429, and `TransportExceptionInterface`) with configurable delays between attempts
- **Error classification**: Distinguishes between transient errors (which are retried) and application-level errors (which fail immediately):
  - Transient: HTTP 5xx, 429, network/transport exceptions
  - Non-transient: HTTP 4xx client errors, application errors in JSON response body
- **New helper method**: `isTransientHttpError()` determines if an exception should trigger a retry based on HTTP status code and exception type
- **Improved error messages**: Final error message now includes attempt count for better diagnostics
- **Comprehensive test coverage**: Four new test cases covering success after retries, exhausted retries, application-level errors, and 4xx errors

## Implementation Details
- Uses existing `pageDelaySeconds` configuration between retry attempts
- Application-level errors (indicated by `error` field in JSON response) are not retried since they indicate caller issues (invalid API key, bad parameters)
- Only retries on `TransportExceptionInterface` (network issues) and `HttpExceptionInterface` with 5xx or 429 status codes
- Maintains backward compatibility with existing error handling for non-transient failures

https://claude.ai/code/session_013j4CkQjA2gk4bnMFk3NEqz