### PR TITLE
Fix Symfony cache race condition in shared volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+- **Cache Symfony hors volume persistant** : la fin d'un long
+  `app:lastfm:import` plantait sporadiquement avec `Failed opening
+  required '/app/var/cache/prod/Container…/getConsole_ErrorListenerService.php'`
+  au moment du `ConsoleTerminateEvent`. Cause : le cache compilé du
+  conteneur DI vivait dans `/app/var/cache/prod`, sous le volume
+  persistant `/app/var` partagé entre instances ; chaque entrypoint
+  qui démarrait (web qui redémarre, container `cli` one-shot lancé
+  via `docker compose run`) faisait un `rm -rf var/cache/prod` avant
+  son `cache:warmup`, supprimant les fichiers de service que la CLI
+  en cours allait charger paresseusement à la sortie. Fix : la
+  variable `APP_CACHE_DIR` (positionnée à `/app/.symfony-cache` dans
+  l'image) sort le cache du volume — chaque conteneur a désormais
+  son propre cache dans son layer image, plus de course possible.
+  `App\Kernel::getCacheDir()` honore `APP_CACHE_DIR` ; les setups
+  hors Docker (Lando, dev local, tests) gardent le défaut Symfony
+  (`var/cache/<env>`).
+
 ### Added
 - **Crash-safety des écritures Navidrome** (#135) : les imports
   Last.fm (`app:lastfm:process`, `app:lastfm:rematch`) wrappent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -553,6 +553,22 @@ Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
     d'`executeStatement('INSERT…')` direct sans tx — sinon tu
     réintroduis le bug d'origine. Pour récupérer manuellement :
     `app:navidrome:db:restore [--list]`.
+13. **Cache Symfony jamais dans un volume partagé.** Les fichiers
+    compilés `var/cache/<env>/Container<hash>/getXxxService.php` sont
+    chargés *paresseusement* — `console.error_listener` typiquement
+    n'est require'é qu'au `ConsoleTerminateEvent`, à la fin de la
+    commande. Si entre-temps un autre conteneur partageant le même
+    volume `/app/var` a fait `rm -rf var/cache/prod` dans son
+    entrypoint (web qui redémarre, `docker compose run --rm` pour un
+    one-shot CLI…), le require échoue : `Failed opening required …
+    getConsole_ErrorListenerService.php`. Symptôme classique après
+    un long `app:lastfm:import` (cf. issue Symfony #24885 même
+    cause). Fix : `App\Kernel::getCacheDir()` honore `APP_CACHE_DIR`,
+    qui pointe sur `/app/.symfony-cache` (image layer, hors volume)
+    via `ENV` du Dockerfile. Si tu ajoutes un nouveau service à
+    `docker-compose.example.yml` qui exécute du PHP, **assure-toi
+    que tu ne montes pas `/app/.symfony-cache`** depuis le host —
+    chaque conteneur DOIT avoir son cache privé.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,24 @@ RUN composer install --no-dev --no-scripts --prefer-dist --no-interaction --no-p
 COPY . .
 
 RUN composer dump-autoload --optimize --no-dev \
- && mkdir -p var plugins \
- && chown -R www-data:www-data var plugins \
- && APP_ENV=prod APP_DEBUG=0 php bin/console cache:warmup --env=prod || true
+ && mkdir -p var plugins /app/.symfony-cache \
+ && chown -R www-data:www-data var plugins /app/.symfony-cache \
+ && APP_ENV=prod APP_DEBUG=0 APP_CACHE_DIR=/app/.symfony-cache php bin/console cache:warmup --env=prod || true
 
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# APP_CACHE_DIR points the compiled-container cache at the image layer
+# (per-container, ephemeral) instead of /app/var (persistent volume,
+# shared across container instances). Sharing the cache caused
+# `rm -rf var/cache/prod` from one entrypoint to nuke files an
+# in-flight CLI in another container was about to require lazily —
+# typical symptom: `Failed opening required getConsole_ErrorListenerService.php`
+# at ConsoleTerminateEvent after a long fetch. See CLAUDE.md piège #13.
 ENV APP_ENV=prod \
     APP_DEBUG=0 \
     APP_MODE=web \
+    APP_CACHE_DIR=/app/.symfony-cache \
     SERVER_NAME=":8080"
 
 EXPOSE 8080

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,8 +6,15 @@ cd /app
 mkdir -p var plugins
 
 # Refresh autoload + DI cache so plugins dropped in /app/plugins are picked up.
+# The cache lives in $APP_CACHE_DIR (default /app/.symfony-cache, set as ENV
+# in the image), which is in the container's image layer — NOT in the
+# /app/var named volume. Two container instances must not share the cache:
+# one entrypoint's `rm -rf` would nuke files an in-flight CLI in the other
+# container is lazy-loading, surfacing as `Failed opening required
+# getConsole_ErrorListenerService.php` at the next ConsoleTerminateEvent.
+CACHE_DIR="${APP_CACHE_DIR:-/app/var/cache}"
 composer dump-autoload --no-dev --optimize --working-dir=/app --no-interaction --quiet
-rm -rf /app/var/cache/prod
+rm -rf "${CACHE_DIR}/${APP_ENV:-prod}"
 php bin/console cache:warmup --env="${APP_ENV:-prod}"
 
 # Apply Doctrine migrations on every boot (idempotent).

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -28,4 +28,20 @@ class Kernel extends BaseKernel
 
         parent::boot();
     }
+
+    public function getCacheDir(): string
+    {
+        // Allow Docker to point the compiled-container cache outside the
+        // persistent /app/var volume. Without this, two container instances
+        // sharing the named volume race on `rm -rf var/cache/prod` during
+        // their entrypoints, and a long-running CLI command (e.g.
+        // app:lastfm:import) hits a missing lazy service file at
+        // ConsoleTerminateEvent — see piège #13 in CLAUDE.md.
+        $override = $_SERVER['APP_CACHE_DIR'] ?? $_ENV['APP_CACHE_DIR'] ?? null;
+        if (is_string($override) && $override !== '') {
+            return rtrim($override, '/') . '/' . $this->environment;
+        }
+
+        return parent::getCacheDir();
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a race condition where long-running CLI commands (e.g., `app:lastfm:import`) would crash with `Failed opening required getConsole_ErrorListenerService.php` when multiple container instances share the same persistent volume. The issue occurs because lazy-loaded service files are deleted by concurrent entrypoint cache warmups.

## Changes

- **`src/Kernel.php`**: Added `getCacheDir()` override to honor the `APP_CACHE_DIR` environment variable, allowing the compiled container cache to be placed outside the shared `/app/var` volume. Falls back to Symfony's default behavior if not set.

- **`Dockerfile`**: 
  - Created `/app/.symfony-cache` directory in the image layer
  - Set `APP_CACHE_DIR=/app/.symfony-cache` as an environment variable
  - Updated cache warmup command to use the new cache directory
  - Added documentation explaining the cache isolation strategy

- **`docker/entrypoint.sh`**: 
  - Updated to respect `APP_CACHE_DIR` when clearing the cache
  - Changed from hardcoded `/app/var/cache/prod` to `${CACHE_DIR}/${APP_ENV:-prod}`
  - Added detailed comments explaining why cache must not be shared

- **`CLAUDE.md`**: Documented this as piège #13, explaining the root cause and the fix for future maintainers

## Implementation Details

The fix leverages Docker's image layer isolation: each container instance gets its own ephemeral cache in `/app/.symfony-cache` (part of the image layer), while the persistent `/app/var` volume is shared only for application data. This prevents one container's entrypoint from deleting cache files that another container's in-flight CLI command is about to lazy-load at `ConsoleTerminateEvent`.

Non-Docker setups (Lando, local dev, tests) continue to use Symfony's default `var/cache/<env>` directory.

https://claude.ai/code/session_016sT4zogk8HW53cEELsP4gn