### PR TITLE
fix(docker): cache Symfony hors volume + suffixe version dans le <title>

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,10 @@ APP_ENV=dev
 APP_SECRET=ChangeMeInProduction0123456789abcdef
 # Display timezone applied at boot (PHP + Twig |date). Default UTC.
 APP_TIMEZONE=UTC
+# Build version stamp displayed in the page title (e.g. "0.1.0" or
+# "main-abc1234"). Baked into the Docker image at build time via
+# ARG/ENV. Defaults to "dev" for local non-Docker runs.
+APP_VERSION=dev
 ###< symfony/framework-bundle ###
 
 ###> Navidrome source ###

--- a/.env.dist
+++ b/.env.dist
@@ -8,6 +8,11 @@ APP_SECRET=                   # generate with: openssl rand -hex 32
 # the conversion only happens at render. Default UTC.
 # Example values: Europe/Paris, America/New_York, Asia/Tokyo.
 APP_TIMEZONE=UTC
+# Build version stamp surfaced in the <title> of every page. The Docker
+# image bakes it at build time via ARG/ENV (CI passes the git tag for
+# tagged releases, branch+short-sha otherwise). Override only if you
+# rebuild the image yourself.
+APP_VERSION=dev
 ###< Symfony ###
 
 ###> Navidrome source (read-only access to its SQLite DB + Subsonic API) ###

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,15 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
 
+      - name: Compute APP_VERSION
+        id: appver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=${GITHUB_REF_NAME}-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v6
         with:
@@ -142,5 +151,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            APP_VERSION=${{ steps.appver.outputs.value }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -112,13 +112,16 @@ docker-publish:
         for t in "$VERSION" "$MAJOR.$MINOR" "$MAJOR" "latest"; do
           TAG_ARGS="$TAG_ARGS -t $REGISTRY_IMAGE:$t"
         done
+        APP_VERSION="$VERSION"
       else
         # default branch → latest + main-<short_sha>
         TAG_ARGS="-t $REGISTRY_IMAGE:latest -t $REGISTRY_IMAGE:main-$SHORT_SHA"
+        APP_VERSION="${CI_COMMIT_REF_NAME}-$SHORT_SHA"
       fi
-      echo "Pushing tags:$TAG_ARGS"
+      echo "Pushing tags:$TAG_ARGS  APP_VERSION=$APP_VERSION"
       docker buildx build \
         --platform linux/amd64,linux/arm64 \
+        --build-arg APP_VERSION="$APP_VERSION" \
         $TAG_ARGS \
         --push \
         .

--- a/.lando.yml.dist
+++ b/.lando.yml.dist
@@ -28,6 +28,8 @@ services:
         APP_SECRET: dev-secret-change-me-please-1234567890
         # Display timezone (PHP + Twig). Default UTC. Try Europe/Paris.
         APP_TIMEZONE: 'UTC'
+        # Build version stamp shown in the <title>.
+        APP_VERSION: 'lando'
         NAVIDROME_DB_PATH: /app/var/navidrome-data/navidrome.db
         NAVIDROME_URL: http://navidrome:4533
         NAVIDROME_USER: admin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Added
+- **Suffixe + version dans le `<title>` des pages** : chaque onglet
+  affiche désormais `Dashboard - Navidrome Tools 0.1.0` (ou
+  `… - Navidrome Tools main-abc1234` sur un build de branche). Le
+  stamp est exposé via la nouvelle variable Twig globale `app_version`,
+  alimentée par `APP_VERSION` (paramètre `app.version`). Le build
+  Docker bake la valeur via un `ARG APP_VERSION` que les CI GitHub et
+  GitLab passent depuis le tag git (`v0.1.0` → `0.1.0`) ou depuis
+  `<branch>-<short_sha>` en push de branche. Défaut `dev` pour les
+  exécutions hors Docker.
+
 ### Fixed
 - **Cache Symfony hors volume persistant** : la fin d'un long
   `app:lastfm:import` plantait sporadiquement avec `Failed opening

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -441,6 +441,7 @@ Le push du tag déclenche `docker-publish` (cf. `.github/workflows/ci.yml`).
 | `APP_SECRET`                   | Symfony — `openssl rand -hex 32`                            |
 | `APP_ENV`                      | `prod` / `dev` / `test`                                     |
 | `APP_MODE`                     | `web` (FrankenPHP) / `cli` (one-shot Symfony command)       |
+| `APP_VERSION`                  | Stamp de version baked à la build Docker (`ARG APP_VERSION` → `ENV`). Affiché dans le `<title>` après ` - Navidrome Tools`. CI : tag git → `0.1.0`, branche → `<branch>-<sha7>`. Défaut `dev`. |
 | `APP_AUTH_USER` / `..._PASSWORD` | Login UI                                                  |
 | `NAVIDROME_DB_PATH`            | Chemin du fichier SQLite Navidrome (mount `:ro` en prod)    |
 | `NAVIDROME_URL`                | Base URL HTTP Navidrome                                     |

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ RUN composer dump-autoload --optimize --no-dev \
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Build version stamp surfaced in the page <title>. CI passes the git
+# tag on a tagged release (e.g. "0.1.0") and "<branch>-<sha7>" on a
+# branch push ; defaults to "dev" for a hand-built local image.
+ARG APP_VERSION=dev
+
 # APP_CACHE_DIR points the compiled-container cache at the image layer
 # (per-container, ephemeral) instead of /app/var (persistent volume,
 # shared across container instances). Sharing the cache caused
@@ -33,6 +38,7 @@ RUN chmod +x /entrypoint.sh
 ENV APP_ENV=prod \
     APP_DEBUG=0 \
     APP_MODE=web \
+    APP_VERSION=${APP_VERSION} \
     APP_CACHE_DIR=/app/.symfony-cache \
     SERVER_NAME=":8080"
 

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -6,6 +6,7 @@ twig:
         timezone: '%env(APP_TIMEZONE)%'
     globals:
         navidrome_url: '%navidrome.url%'
+        app_version: '%app.version%'
 
 when@test:
     twig:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,6 +24,11 @@ parameters:
     navidrome.container_stop_wait_ceiling: '%env(int:NAVIDROME_STOP_WAIT_CEILING_SECONDS)%'
     navidrome.db_backup_retention: '%env(int:NAVIDROME_DB_BACKUP_RETENTION)%'
     app.homepage_api_token: '%env(HOMEPAGE_API_TOKEN)%'
+    # Build-time version stamp — surfaced in the page title so a user
+    # can tell at a glance which release/sha is deployed. Baked into the
+    # image via Dockerfile ARG/ENV (CI passes the git tag on a tagged
+    # release, branch+short-sha otherwise) ; defaults to `dev` localement.
+    app.version: '%env(default::APP_VERSION)%'
 
 services:
     _defaults:

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -10,6 +10,11 @@ services:
       APP_ENV: prod
       APP_SECRET: ${APP_SECRET:?set APP_SECRET in .env}
       APP_TIMEZONE: ${APP_TIMEZONE:-UTC}
+      # Surfaced in the page <title> (e.g. "Dashboard - Navidrome Tools 0.1.0").
+      # Normally baked into the image at build time by CI (git tag for
+      # tagged releases, branch+short-sha otherwise). Override here only
+      # if you rebuild the image locally.
+      APP_VERSION: ${APP_VERSION:-}
       NAVIDROME_DB_PATH: /data/navidrome.db
       NAVIDROME_URL: ${NAVIDROME_URL:-http://navidrome:4533}
       NAVIDROME_USER: ${NAVIDROME_USER:-admin}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,6 +12,7 @@
         <server name="SHELL_VERBOSITY" value="-1"/>
         <env name="APP_SECRET" value="test-secret-do-not-use-in-prod-1234567890"/>
         <env name="APP_TIMEZONE" value="UTC"/>
+        <env name="APP_VERSION" value="test"/>
         <env name="APP_AUTH_USER" value="admin"/>
         <env name="APP_AUTH_PASSWORD" value="changeme"/>
         <env name="DATABASE_URL" value="sqlite:///%kernel.project_dir%/var/data_test.db"/>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% block title %}Navidrome Tools{% endblock %}</title>
+    <title>{% block title %}Accueil{% endblock %} - Navidrome Tools{% if app_version %} {{ app_version }}{% endif %}</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
     <script src="https://cdn.tailwindcss.com"></script>
     <style>


### PR DESCRIPTION
## Summary

Deux changements liés au reporting d'un crash en fin de `app:lastfm:import` :

- **fix(docker)** : isole le cache compilé du conteneur DI hors du volume persistant `/app/var`. La fin d'un long `app:lastfm:import` plantait sporadiquement avec `Failed opening required '/app/var/cache/prod/Container…/getConsole_ErrorListenerService.php'` au `ConsoleTerminateEvent`. Cause : le cache vivait sous le volume persistant partagé entre instances ; un autre conteneur (web qui redémarre, `docker compose run --rm` pour un one-shot CLI…) faisait `rm -rf var/cache/prod` avant son `cache:warmup` et supprimait les fichiers de service que la CLI en cours allait charger paresseusement à la sortie. Même classe de bug que [Symfony #24885](https://github.com/symfony/symfony/issues/24885). Le cache passe désormais dans `/app/.symfony-cache` (image layer, par-conteneur) via `APP_CACHE_DIR` honoré par `App\Kernel::getCacheDir()`. Les setups hors Docker (Lando, dev local, tests) gardent le défaut Symfony.

- **feat(ui)** : suffixe + version dans le `<title>` des pages — chaque onglet affiche désormais `Dashboard - Navidrome Tools 0.1.0` (ou `… - Navidrome Tools main-abc1234` sur un build de branche). Nouvelle variable Twig globale `app_version` ← paramètre `app.version` ← env `APP_VERSION`. Le Docker bake la valeur via `ARG APP_VERSION` propagé en `ENV` ; les CI GitHub et GitLab calculent la valeur depuis le tag git (`v0.1.0` → `0.1.0`) ou `<branch>-<sha7>` en push de branche. Défaut `dev` hors Docker.

## Test plan

- [x] `composer ci` vert (phpcs + phpstan + 398 tests / 1077 assertions)
- [ ] Vérifier que `docker-build` job CI passe avec le nouvel `ARG APP_VERSION` (validation)
- [ ] Sur le `docker-publish` job (push main ou tag), vérifier que `APP_VERSION` est correctement passé en build-arg et présent dans l'image (`docker run … env | grep APP_VERSION`)
- [ ] Smoke-test post-déploiement : ouvrir le dashboard, vérifier le `<title>` du navigateur affiche `Accueil - Navidrome Tools <version>` puis idem sur `/stats`, `/lastfm/import`, etc.
- [ ] Lancer un long `app:lastfm:import` et confirmer qu'aucun fatal `getConsole_ErrorListenerService.php` n'apparaît à la sortie

https://claude.ai/code/session_016sT4zogk8HW53cEELsP4gn

---
_Generated by [Claude Code](https://claude.ai/code/session_016sT4zogk8HW53cEELsP4gn)_