### PR TITLE
Add example cron script for Last.fm import and Navidrome management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@
 .lando.local.yml
 ###< lando ###
 /.claude/settings.local.json
+
+###> cron scripts ###
+# Les fichiers *.sh.example sont commités comme templates ; les copies
+# de travail (sans le .example) sont gitignored — adaptez-les à votre
+# stack sans pollution du repo.
+/cron-*.sh
+###< cron scripts ###

--- a/cron-lastfm-import-and-match.sh.example
+++ b/cron-lastfm-import-and-match.sh.example
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Exemple de script cron pour l'enchaînement
+# fetch → process → rematch côté Last.fm, avec backup et arrêt /
+# redémarrage explicites du conteneur Navidrome.
+#
+# Usage :
+#   cp cron-lastfm-import-and-match.sh.example cron-lastfm-import-and-match.sh
+#   chmod +x cron-lastfm-import-and-match.sh
+#   # éditer les variables de la section « Configuration » ci-dessous
+#   ./cron-lastfm-import-and-match.sh
+#
+# Exemple de ligne crontab (chaque nuit à 04:00) :
+#   0 4 * * * /chemin/vers/cron-lastfm-import-and-match.sh \
+#       >> /var/log/navidrome-tools/lastfm.log 2>&1
+#
+# Le fichier `cron-lastfm-import-and-match.sh` est gitignored — adaptez-le
+# librement à votre stack sans risquer de polluer le repo.
+#
+# Le script s'appuie sur `docker compose` :
+#   - stop / start du conteneur Navidrome (service `NAVIDROME_SERVICE`) ;
+#   - `exec` dans le conteneur navidrome-tools-web (`TOOLS_SERVICE`) pour
+#     lancer les `bin/console app:lastfm:*`.
+#
+# Navidrome est arrêté manuellement au début et redémarré dans un trap
+# (même en cas d'erreur), donc les commandes `process` / `rematch`
+# tournent sans `--auto-stop` : le pré-flight Navidrome doit passer
+# puisque le conteneur est down.
+
+set -euo pipefail
+
+# ======================================================================
+# Configuration — à adapter à votre stack
+# ======================================================================
+
+# Dossier qui contient votre `docker-compose.yml`.
+COMPOSE_DIR="/srv/navidrome-tools"
+
+# Nom du service Navidrome dans votre `docker-compose.yml`.
+NAVIDROME_SERVICE="navidrome"
+
+# Nom du service navidrome-tools-web dans votre `docker-compose.yml`.
+TOOLS_SERVICE="navidrome-tools-web"
+
+# Chemin sur l'hôte vers la DB SQLite Navidrome (à sauvegarder).
+NAVIDROME_DB_PATH="/srv/navidrome/data/navidrome.db"
+
+# Dossier où stocker les backups (sera créé s'il n'existe pas).
+BACKUP_DIR="/srv/navidrome/backups"
+
+# Nombre de backups à conserver — les plus anciens sont supprimés.
+BACKUP_RETENTION=7
+
+# Fenêtre de récupération Last.fm en jours (--date-min = today - N).
+DAYS_BACK=7
+
+# Limite de scrobbles à traiter par `app:lastfm:process`.
+PROCESS_LIMIT=5000
+
+# Limite de scrobbles à retenter par `app:lastfm:rematch --random`.
+REMATCH_LIMIT=5000
+
+# Délai (s) laissé à Navidrome pour s'arrêter proprement avant SIGKILL.
+# Trop court = WAL non checkpointé = risque de corruption SQLite.
+STOP_TIMEOUT=60
+
+# ======================================================================
+# Script
+# ======================================================================
+
+cd "$COMPOSE_DIR"
+
+log() {
+    printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$*"
+}
+
+start_navidrome() {
+    log "Redémarrage de Navidrome…"
+    docker compose start "$NAVIDROME_SERVICE" >/dev/null || \
+        log "ATTENTION : échec du redémarrage Navidrome — à relancer manuellement."
+}
+trap start_navidrome EXIT
+
+log "[1/6] Arrêt du conteneur Navidrome (timeout ${STOP_TIMEOUT}s)…"
+docker compose stop -t "$STOP_TIMEOUT" "$NAVIDROME_SERVICE"
+
+log "[2/6] Backup de $NAVIDROME_DB_PATH vers $BACKUP_DIR…"
+mkdir -p "$BACKUP_DIR"
+TIMESTAMP="$(date -u +'%Y%m%d-%H%M%S')"
+cp -a "$NAVIDROME_DB_PATH" "$BACKUP_DIR/navidrome.db.$TIMESTAMP"
+
+log "[3/6] Purge des backups (rétention : $BACKUP_RETENTION)…"
+# `ls -1t` trie par mtime décroissant, `tail -n +N` garde à partir de la
+# ligne N (donc supprime les fichiers au-delà de BACKUP_RETENTION).
+ls -1t "$BACKUP_DIR"/navidrome.db.* 2>/dev/null \
+    | tail -n +"$((BACKUP_RETENTION + 1))" \
+    | xargs -r rm -f
+
+DATE_MIN="$(date -u -d "$DAYS_BACK days ago" +'%Y-%m-%d')"
+log "[4/6] Fetch Last.fm depuis $DATE_MIN…"
+docker compose exec -T "$TOOLS_SERVICE" \
+    php bin/console app:lastfm:import --date-min="$DATE_MIN"
+
+log "[5/6] Process buffer (limit=$PROCESS_LIMIT)…"
+docker compose exec -T "$TOOLS_SERVICE" \
+    php bin/console app:lastfm:process --limit="$PROCESS_LIMIT"
+
+log "[6/6] Rematch random (limit=$REMATCH_LIMIT)…"
+docker compose exec -T "$TOOLS_SERVICE" \
+    php bin/console app:lastfm:rematch --random --limit="$REMATCH_LIMIT"
+
+log "Terminé."


### PR DESCRIPTION
## Summary

Add an example cron script (`cron-lastfm-import-and-match.sh.example`) that orchestrates the full Last.fm import workflow with explicit Navidrome container lifecycle management, database backups, and cleanup.

## Changes

- **New file: `cron-lastfm-import-and-match.sh.example`**
  - Complete bash script demonstrating the recommended cron setup for Last.fm import pipeline
  - Implements the full workflow: fetch → process → rematch with Navidrome stopped
  - Features:
    - Configurable section for stack-specific paths and service names
    - Automatic SQLite database backup with retention policy
    - Graceful Navidrome container stop/start with configurable timeout
    - Trap handler to ensure Navidrome restarts even on script failure
    - Parameterized limits for fetch window, process batch size, and rematch batch size
    - ISO 8601 timestamped logging
  - Includes comprehensive inline documentation and usage instructions

- **Updated: `.gitignore`**
  - Added pattern to ignore working cron scripts (`/cron-*.sh`)
  - Allows `.example` templates to be committed while keeping local adaptations out of version control
  - Includes explanatory comment about the gitignore strategy

## Implementation Details

The script follows the architectural pattern described in CLAUDE.md where `app:lastfm:process` and `app:lastfm:rematch` require Navidrome to be stopped (pré-flight CSRF check bypassed). By stopping the container upfront and using a trap for guaranteed restart, the script avoids the need for `--auto-stop` flags and ensures clean SQLite WAL checkpointing. The backup retention mechanism uses `ls -1t` sorting and `tail` to keep only the N most recent backups.

https://claude.ai/code/session_01LpmStp5BEXFabXHkzJ2fAf