### PR TITLE
Reorganize documentation into dedicated docs/ folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,8 +481,7 @@ Le push du tag déclenche `docker-publish` (cf. `.github/workflows/ci.yml`).
 | `NOTIFY_PUSHOVER_TOKEN` / `NOTIFY_PUSHOVER_USER` | Pushover application token + user/group key. |
 
 Plus de variables `*_SCHEDULE` : la planification se fait dans le
-crontab unix de l'hôte (cf. `README.md` § « Lancement des jobs
-récurrents »).
+crontab unix de l'hôte (cf. [`docs/CRON.md`](docs/CRON.md)).
 
 Wirées dans : `.env` (dev), `.env.dist` (template), `phpunit.xml.dist`
 (test), `.lando.yml.dist` (Lando), `docker-compose.example.yml`,

--- a/README.md
+++ b/README.md
@@ -4,57 +4,65 @@
 
 Boîte à outils web self-hosted (Symfony 7) autour de
 [Navidrome](https://www.navidrome.org/) : générateur de playlists basé
-sur les écoutes, statistiques détaillées, import one-shot des scrobbles
+sur les écoutes, statistiques détaillées, import des scrobbles
 Last.fm, intégration Lidarr et historique des runs cron.
 
-## Image Docker publiée
+> Le repo Git s'appelle toujours `navidrome-playlist-generator` ; le
+> projet et l'image Docker s'appellent désormais `navidrome-tools`.
 
-L'image officielle est publiée automatiquement sur GitHub Container
-Registry (`ghcr.io/kgaut/navidrome-tools`) par la CI :
+## Fonctionnalités
 
-| Évènement                | Tags publiés                                              |
-|--------------------------|-----------------------------------------------------------|
-| Push sur `main`          | `latest`, `main-<sha7>`                                   |
-| Push d'un tag `v1.2.3`   | `1.2.3`, `1.2`, `1`, `latest`                             |
-| Push sur autre branche   | `<nom-de-branche>` (utile pour tester un PR mergé)        |
-| Pull request             | aucun push, build de validation seulement                 |
+- **Génération de playlists** par règle, basée sur les écoutes
+  Navidrome. 8 générateurs livrés + système de plugins (cf.
+  [`docs/PLUGINS.md`](docs/PLUGINS.md)).
+- **Statistiques d'écoute** : 7 pages cachées (tops, compare, charts,
+  heatmaps, histoires Last.fm/Navidrome, wrapped annuel). Cf.
+  [`docs/STATS.md`](docs/STATS.md).
+- **Import Last.fm** en deux étapes (fetch → process) avec matching
+  cascade à 4 paliers + alias track/artiste + re-match cumulé.
+  Cf. [`docs/LASTFM.md`](docs/LASTFM.md).
+- **Sync loved ↔ starred** entre Last.fm et Navidrome.
+- **Intégration Lidarr** pour pousser un artiste manquant en un clic.
+  Cf. [`docs/LIDARR.md`](docs/LIDARR.md).
+- **Tagging assisté** : page « tracks sans MBID » + export CSV /
+  queue beets. Cf. [`docs/TAGGING.md`](docs/TAGGING.md).
+- **Pilotage du conteneur Navidrome** depuis le dashboard (start /
+  stop + pré-flight + `--auto-stop` sur les commandes qui écrivent).
+- **Historique des runs cron** avec audit par-track des imports.
+  Cf. [`docs/CRON.md`](docs/CRON.md).
+- **Notifications de fin de run** vers Gotify / Slack / Discord /
+  Pushover (broadcast supporté). Cf. [`docs/NOTIFICATIONS.md`](docs/NOTIFICATIONS.md).
+- **Auth UI** : un seul user défini dans `.env`, pas de base
+  utilisateurs.
+- **Image Docker** légère (FrankenPHP, multi-arch amd64/arm64) qui
+  sert l'UI et expose les commandes Symfony via `APP_MODE=cli`.
 
-Image multi-arch : `linux/amd64` + `linux/arm64`.
+## Documentation
 
-```bash
-docker pull ghcr.io/kgaut/navidrome-tools:latest
-```
+Toute la doc utilisateur vit dans le dossier [`docs/`](docs/) :
 
-> Pour héberger un miroir sur GitLab, le repo livre aussi un
-> [`.gitlab-ci.yml`](.gitlab-ci.yml) avec les mêmes 5 jobs (phpcs,
-> phpstan, tests matrix 8.3+8.4, docker build + publish multi-arch).
-> Par défaut il pousse vers le registre du projet
-> (`$CI_REGISTRY_IMAGE`) ; surchargez la variable `REGISTRY_IMAGE`
-> dans Settings → CI/CD pour viser une autre cible.
+| Document                              | Contenu                                                                  |
+|---------------------------------------|--------------------------------------------------------------------------|
+| [`DOCKER.md`](docs/DOCKER.md)         | Déploiement Docker Compose (intégration à une stack existante + Caddy).  |
+| [`ENVIRONMENT.md`](docs/ENVIRONMENT.md) | Référence exhaustive de toutes les variables d'environnement.          |
+| [`DEVELOPMENT.md`](docs/DEVELOPMENT.md) | Dev local (Lando ou natif), tests, qualité, éditeur.                   |
+| [`CRON.md`](docs/CRON.md)             | Schedule des jobs récurrents + historique des runs.                      |
+| [`LASTFM.md`](docs/LASTFM.md)         | Import scrobbles, matching, alias, rematch, sync loved↔starred.          |
+| [`STATS.md`](docs/STATS.md)           | Toutes les pages stats / wrapped / histories.                            |
+| [`PLAYLISTS.md`](docs/PLAYLISTS.md)   | Génération, gestion, schéma Navidrome utilisé.                           |
+| [`LIDARR.md`](docs/LIDARR.md)         | Intégration Lidarr (bouton « + Lidarr »).                                |
+| [`TAGGING.md`](docs/TAGGING.md)       | Tracks sans MBID, export CSV, queue beets.                               |
+| [`HOMEPAGE.md`](docs/HOMEPAGE.md)     | Widget Homepage (gethomepage.dev) + healthcheck Docker.                  |
+| [`NOTIFICATIONS.md`](docs/NOTIFICATIONS.md) | Notifications de fin de run (Gotify, Slack, Discord, Pushover).    |
+| [`PLUGINS.md`](docs/PLUGINS.md)       | Créer un nouveau type de générateur de playlist.                         |
 
-Fonctionnalités principales :
+Contexte projet (stack, architecture, conventions, pièges connus,
+roadmap) : [`CLAUDE.md`](CLAUDE.md).
 
-- **Système de plugins** : chaque type de playlist (« top des X derniers jours »,
-  « morceaux jamais écoutés », « top du mois de mai il y a X années »…) est
-  une simple classe PHP. En ajouter un nouveau = créer un fichier dans
-  `src/Generator/`. Voir [`docs/PLUGINS.md`](docs/PLUGINS.md).
-- **Configuration en base** (SQLite locale, Doctrine ORM) : nom, paramètres,
-  limite, activation par playlist. Géré via l'UI.
-- **Lancement des jobs** depuis le crontab unix de l'hôte (ou tout
-  scheduler maison) : `bin/console app:playlist:run <id>`,
-  `app:lastfm:import`, `app:lastfm:process`, etc. Pas de cron embarqué
-  dans le tool.
-- **Auth UI** : un seul couple login/mot de passe défini dans `.env`, pas de
-  base utilisateurs.
-- **Détection automatique** de la table `scrobbles` (Navidrome ≥ 0.55, fin
-  2025) pour des stats exactes ; fallback sur `annotation.play_date` sinon.
-- **Image Docker** légère (FrankenPHP) qui sert l'UI web et expose les
-  commandes Symfony via `APP_MODE=cli`.
+## Quickstart Docker
 
-## Quickstart Docker (production / self-host)
-
-> Pour un guide complet (intégration à une stack existante, networks
-> Docker partagés, exemple de Caddyfile, troubleshooting), voir
+> Guide complet (intégration à une stack existante, networks Docker
+> partagés, exemple de Caddyfile, troubleshooting) :
 > [`docs/DOCKER.md`](docs/DOCKER.md).
 
 ```bash
@@ -81,30 +89,8 @@ open http://localhost:8080
 ```
 
 Au premier lancement, 4 définitions de playlist d'exemple sont créées
-**désactivées** : Top 7j, Top 30j, Top mois passé, Top année passée. Vous
-pouvez les éditer puis les activer.
-
-### Variables d'environnement
-
-| Variable             | Obligatoire | Description                                                              |
-|----------------------|-------------|--------------------------------------------------------------------------|
-| `APP_SECRET`         | oui         | Secret Symfony (32 caractères hex). `openssl rand -hex 32`.              |
-| `APP_ENV`            | non (`prod`)| `prod` ou `dev`.                                                         |
-| `APP_MODE`           | non (`web`) | `web` (FrankenPHP) ou `cli` (one-shot Symfony command).                  |
-| `APP_TIMEZONE`       | non (`UTC`) | Fuseau d'affichage (PHP + Twig). Ex. `Europe/Paris`. Stockage reste UTC. |
-| `NAVIDROME_DB_PATH`  | oui         | Chemin du fichier SQLite Navidrome dans le conteneur. Bind-mounter `:ro`.|
-| `NAVIDROME_URL`      | oui         | URL HTTP(S) de Navidrome (sans slash final).                             |
-| `NAVIDROME_USER`     | oui         | Utilisateur Navidrome dont on lit les écoutes et qui possède les playlists. |
-| `NAVIDROME_PASSWORD` | oui         | Mot de passe de cet utilisateur.                                         |
-| `APP_AUTH_USER`      | oui         | Identifiant pour se connecter à l'UI du tool.                            |
-| `APP_AUTH_PASSWORD`  | oui         | Mot de passe pour se connecter à l'UI du tool.                           |
-| `DATABASE_URL`       | non         | DSN Doctrine pour la DB locale du tool. Défaut : SQLite dans `var/data.db`. |
-| `COVERS_CACHE_PATH`  | non         | Cache disque des miniatures album/artiste. Défaut : `/app/var/covers` (volume Docker dédié dans le compose). |
-| `NAVIDROME_CONTAINER_NAME` | non   | Nom du conteneur Navidrome dans la même stack docker-compose. Quand renseigné, le dashboard affiche un statut UP/DOWN avec boutons Start/Stop, et les commandes d'import refusent de tourner si Navidrome est détecté UP (`--force` pour outrepasser). Requiert le mount `/var/run/docker.sock` (cf. `docker-compose.example.yml`). |
-| `NAVIDROME_STOP_TIMEOUT_SECONDS` | non (`60`) | Fenêtre de shutdown gracieux passée à `docker stop -t` lorsqu'on arrête Navidrome via `--auto-stop`. Doit confortablement excéder le checkpoint WAL SQLite — le défaut Docker (10s) suffit pour un Navidrome inactif mais peut SIGKILL en plein flush sur une grosse librairie après un import lourd, et corrompre `navidrome.db` (cf. #118). |
-| `NAVIDROME_STOP_WAIT_CEILING_SECONDS` | non (`30`) | Après `docker stop`, on poll encore `docker inspect` jusqu'à ce que `Running=false`, plafonné à cette durée. On refuse d'écrire dans la DB tant qu'`inspect` voit Navidrome vivant — ceinture-bretelles contre un SIGTERM handler qui traîne. |
-| `NAVIDROME_DB_BACKUP_RETENTION` | non (`3`) | Nombre de snapshots `<navidrome.db>.backup-<unix_ts>` conservés. Avant chaque action `--auto-stop`, le tool copie automatiquement la DB SQLite (et ses siblings `-wal` / `-shm`) — un simple `cp` rétablit l'état précédent. `0` = pas de purge. |
-| `HOMEPAGE_API_TOKEN` | non       | Bearer token pour le widget [Homepage](https://gethomepage.dev/widgets/services/customapi/) sur l'endpoint `/api/status`. Vide = mode enrichi désactivé (seul le mode healthcheck no-auth est servi). Voir la section [Widget Homepage](#widget-homepage-gethomepage). |
+**désactivées** : Top 7j, Top 30j, Top mois passé, Top année passée.
+Vous pouvez les éditer puis les activer.
 
 ### Mise à jour
 
@@ -113,876 +99,44 @@ docker compose pull
 docker compose up -d
 ```
 
-Les migrations Doctrine sont jouées automatiquement à chaque démarrage
-(idempotent). Le volume `playlist-data` préserve la configuration entre
-redémarrages.
+Les migrations Doctrine sont jouées automatiquement à chaque
+démarrage (idempotent). Le volume `navidrome-tools-data` préserve la
+configuration entre redémarrages.
 
-### Lancement des jobs récurrents
+## Image Docker publiée
 
-Le tool n'embarque **plus** de cron interne (pas de supercronic, pas
-de service `navidrome-tools-cron`, pas de `app:cron:dump`). Vous
-pilotez les commandes Symfony depuis votre crontab unix (ou tout
-autre scheduler). Pour exécuter une commande dans le conteneur
-existant :
+L'image officielle est publiée sur GitHub Container Registry
+(`ghcr.io/kgaut/navidrome-tools`) par la CI :
 
-```bash
-docker compose exec -T navidrome-tools-web php bin/console <command>
-```
+| Évènement                | Tags publiés                                              |
+|--------------------------|-----------------------------------------------------------|
+| Push sur `main`          | `latest`, `main-<sha7>`                                   |
+| Push d'un tag `v1.2.3`   | `1.2.3`, `1.2`, `1`, `latest`                             |
+| Push sur autre branche   | `<nom-de-branche>` (utile pour tester un PR mergé)        |
+| Pull request             | aucun push, build de validation seulement                 |
 
-Exemples de lignes crontab adaptées au flux Last.fm en deux étapes
-(fetch quand Navidrome tourne, process quand il est stoppé) :
-
-```cron
-# Génération d'une playlist (l'id vient de l'UI ou de
-# `bin/console doctrine:dbal:run-sql 'SELECT id, name FROM playlist_definition'`).
-0 3 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:playlist:run 1
-
-# Refresh du cache stats (lecture seule sur Navidrome — sans risque).
-0 */6 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:stats:compute
-
-# Fetch Last.fm dans le buffer (Navidrome up — aucune écriture sur sa DB).
-*/15 * * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:lastfm:import
-
-# Drain du buffer dans Navidrome (--auto-stop orchestre stop/run/restart).
-0 4 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:lastfm:process --auto-stop
-
-# Re-match des unmatched cumulés (idem, --auto-stop).
-0 5 * * 0 docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:lastfm:rematch --auto-stop
-
-# Purge de l'historique des runs (rétention RUN_HISTORY_RETENTION_DAYS).
-30 4 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
-    php bin/console app:history:purge
-```
-
-`docker compose exec -T` réutilise le conteneur `navidrome-tools-web`
-déjà démarré (toutes les variables d'environnement requises y sont
-déjà). Pas besoin d'un `run --rm` qui relancerait l'entrypoint et
-rejouerait les migrations à chaque tick.
-
-Pour les commandes qui écrivent dans Navidrome (`app:lastfm:process`,
-`app:lastfm:rematch`), `--auto-stop` orchestre stop / write / restart
-quand `NAVIDROME_CONTAINER_NAME` est configuré. Sans cette variable,
-arrêtez Navidrome manuellement avant d'invoquer la commande.
-
-## Développement local avec Lando (recommandé)
-
-[Lando](https://lando.dev/) fournit l'environnement complet sans rien
-installer sur l'hôte. La stack expose **deux services** :
-
-- `appserver` — Symfony 7 (PHP 8.4 + nginx + Composer 2), UI sur
-  `https://navidrome-tools.lndo.site`.
-- `navidrome` — instance Navidrome de test sur
-  `https://navidrome.lndo.site`, partage sa base SQLite avec le tool
-  via `var/navidrome-data/`.
+Image multi-arch : `linux/amd64` + `linux/arm64`.
 
 ```bash
-git clone https://github.com/kgaut/navidrome-playlist-generator
-cd navidrome-playlist-generator
-
-# Préparer le dossier partagé Navidrome ↔ tool (DB + cache).
-mkdir -p var/navidrome-data
-# (Optionnel) seeder avec votre vraie base, sinon Navidrome en créera
-# une vide au premier boot.
-cp /chemin/vers/navidrome.db var/navidrome-data/navidrome.db
-
-# Copier le template Lando puis adapter le bind-mount du dossier
-# musique (search « /change/me/path/to/music » dans .lando.yml).
-# .lando.yml est gitignored.
-cp .lando.yml.dist .lando.yml
-
-lando start          # premier lancement : build + composer install
-lando migrate        # crée la DB locale du tool
-lando seed           # insère les 4 définitions d'exemple
+docker pull ghcr.io/kgaut/navidrome-tools:latest
 ```
 
-URLs disponibles après `lando start` :
-
-- UI tool : <https://navidrome-tools.lndo.site>
-- Navidrome : <https://navidrome.lndo.site> (admin créé au premier
-  démarrage via l'UI Navidrome)
-
-Commandes utiles :
-
-| Commande Lando             | Effet                                                          |
-|----------------------------|----------------------------------------------------------------|
-| `lando symfony cache:clear`| Vider le cache Symfony.                                        |
-| `lando composer require X` | Installer un package.                                          |
-| `lando test`               | Lancer PHPUnit.                                                |
-| `lando migrate`            | Jouer les migrations Doctrine.                                 |
-| `lando seed`               | Réinsérer les fixtures (idempotent).                           |
-| `lando playlist-run "Top 30 derniers jours" --dry-run` | Tester une définition. |
-| `lando logs -s navidrome -f`    | Suivre les logs du Navidrome embarqué. |
-
-Pour activer Xdebug : éditer votre copie locale `.lando.yml` (`xdebug: debug`) puis
-`lando rebuild -y`.
-
-> **Note sur l'écriture dans la base Navidrome** : `app:lastfm:process`
-> et `app:lastfm:rematch` doivent être lancés **Navidrome arrêté**
-> (`lando stop navidrome` puis relancer après l'import). Le flag
-> `--auto-stop` n'est pas câblé sous Lando — c'est un setup dev, pas
-> prod.
-
-## Développement local sans Lando
-
-Pré-requis : PHP 8.4+, ext-pdo_sqlite, Composer 2, [Symfony CLI](https://symfony.com/download).
-
-```bash
-composer install
-cp .env.dist .env.local              # ajuster les valeurs
-mkdir -p var
-cp /chemin/vers/navidrome.db var/navidrome.db
-php bin/console doctrine:migrations:migrate -n
-php bin/console app:fixtures:seed
-symfony serve                        # https://127.0.0.1:8000
-```
-
-## Statistiques d'écoute
-
-Cinq pages stats accessibles via le menu déroulant **Statistiques** :
-
-| Route                | Contenu                                                                      |
-|----------------------|------------------------------------------------------------------------------|
-| `/stats`             | Vue d'ensemble par période (7d/30d/last-month/last-year/all-time), cachée    |
-|                      | dans `stats_snapshot`, refresh manuel + cron `STATS_REFRESH_SCHEDULE`.       |
-| `/stats/tops`        | Tops sur fenêtre `[from, to]` arbitraire : 50 artistes / 100 albums /        |
-|                      | 500 morceaux, filtre par client. Cache dans `top_snapshot` (clé              |
-|                      | (from, to, client)). Bouton « + Créer playlist Navidrome » sur le top        |
-|                      | morceaux. Refresh manuel ou via `app:stats:tops:compute`.                    |
-| `/stats/compare`     | Comparaison côte à côte de deux périodes : top artistes / morceaux fusionnés |
-|                      | avec deltas et badges (nouveau / disparu / ↑N / ↓N / =).                     |
-| `/stats/charts`      | Trois graphiques Chart.js : écoutes par mois, top 5 artistes au fil du       |
-|                      | temps, distribution par jour de la semaine.                                  |
-| `/stats/heatmap`     | Deux heatmaps HTML/CSS pures : jour×heure (90 derniers jours) et             |
-|                      | année×jour façon GitHub contribs (avec sélecteur d'année).                   |
-| `/wrapped/{year}`    | Rétrospective annuelle façon Spotify Wrapped : total plays / heures écoutées |
-|                      | / morceaux distincts, top 25 artistes, top 50 morceaux, nouvelles            |
-|                      | découvertes, mois le plus actif, plus longue série d'écoutes consécutives.   |
-|                      | Cachée dans `stats_snapshot` (key `wrapped-<year>`).                         |
-
-Toutes les pages requièrent la table `scrobbles` Navidrome (≥ 0.55) et
-affichent un bandeau si elle n'est pas trouvée.
-
-## Import des scrobbles Last.fm — workflow en deux étapes
-
-L'import Last.fm est **découplé** en deux phases :
-
-1. **Récupération** (`app:lastfm:import` ou section 1 de
-   `/lastfm/import`) — lit l'historique Last.fm via
-   `user.getRecentTracks` et stocke chaque scrobble dans la table
-   locale `lastfm_import_buffer`. Aucune écriture côté Navidrome :
-   **Navidrome peut tourner**.
-2. **Traitement** (`app:lastfm:process` ou section 2 de
-   `/lastfm/import`) — vide le buffer : matching cascade, insertion
-   dans la table `scrobbles` Navidrome, audit dans
-   `lastfm_import_track`, suppression de la row du buffer.
-   **Navidrome doit être arrêté** (l'écriture concurrente sur la
-   SQLite peut corrompre le journal WAL).
-
-Cette séparation permet de fetcher régulièrement (cron léger,
-Navidrome up) puis de processer le buffer ponctuellement (manuel
-quand vous arrêtez Navidrome ou via cron `--auto-stop`).
-
-### Via l'interface web
-
-`/lastfm/import` propose les deux étapes côte à côte. Le compteur
-du buffer (« N scrobbles en attente ») est aussi exposé sur le
-**dashboard** (card santé), avec un lien direct.
-
-#### Section 1 — Récupérer depuis Last.fm
-
-- Identifiant Last.fm + API key. Les deux peuvent venir de
-  l'environnement via `LASTFM_USER` (pré-remplit le champ) et
-  `LASTFM_API_KEY` (utilisée si le champ est laissé vide).
-- Filtres `date_min` / `date_max` optionnels.
-- Limite de sécurité (max scrobbles, défaut 5 000) pour éviter les
-  timeouts HTTP.
-- Case **Dry-run** (parcourir l'API Last.fm sans rien écrire dans
-  le buffer — utile pour vérifier la connectivité).
-
-Le re-fetch de la même fenêtre est **idempotent** : la contrainte
-unique sur `(lastfm_user, played_at, artist, title)` rejette les
-doublons et le rapport remonte un compteur `already_buffered`.
-
-#### Section 2 — Traiter le buffer
-
-Affiche le compteur du buffer + l'état du conteneur Navidrome.
-Bouton « ▶ Traiter le buffer » disponible une fois Navidrome
-arrêté (pré-flight via `NavidromeContainerManager`). Redirige vers
-le détail du run `lastfm-process` qui liste l'audit par-track
-(inserted / duplicate / unmatched / skipped) avec filtre par statut.
-
-### Via la commande CLI
-
-```bash
-# Étape 1 : peut tourner Navidrome up
-php bin/console app:lastfm:import [<lastfm-user>] [--api-key=YOUR_KEY] \
-    [--date-min=YYYY-MM-DD] [--date-max=YYYY-MM-DD] \
-    [--dry-run] [--max-scrobbles=N]
-
-# Étape 2 : Navidrome doit être arrêté
-php bin/console app:lastfm:process [--dry-run] [--limit=N] \
-    [--tolerance=60] [--force] [--auto-stop]
-```
-
-L'API key Last.fm s'obtient gratuitement sur
-<https://www.last.fm/api/account/create>. Elle peut aussi être passée via
-la variable d'environnement `LASTFM_API_KEY`. De même, le username peut
-être omis si `LASTFM_USER` est défini dans l'environnement.
-
-`--auto-stop` (sur `app:lastfm:process` uniquement, comme pour
-`app:lastfm:rematch`) orchestre stop → process → restart de
-Navidrome via Docker — utile pour les runs cron unattended.
-
-### Stratégie
-
-1. **Pagination** : utilise `user.getRecentTracks` de l'API Last.fm,
-   200 scrobbles par page, jusqu'au bout de l'historique (filtré par
-   `--date-min` / `--date-max` si fournis). Une pause configurable
-   (`LASTFM_PAGE_DELAY_SECONDS`, défaut 10s) sépare deux pages
-   consécutives pour éviter de surcharger l'API ; passez à 0 pour
-   désactiver.
-2. **Matching** sur la lib Navidrome (essais successifs jusqu'à
-   succès) :
-   0. **Alias manuel** : si une entrée existe dans la table
-      `lastfm_alias` (page `/lastfm/aliases`) pour le couple
-      `(artist, title)` normalisé, elle court-circuite tout. Cible
-      vide = scrobble compté en `skipped` (utile pour les podcasts).
-   0bis. **Cache de résolution** (`lastfm_match_cache`) : avant de
-      relancer la cascade, le matcher consulte une table de
-      mémoïsation. Hit positif → réponse immédiate. Hit négatif
-      non-stale → unmatched immédiat (on évite l'API Last.fm). Les
-      négatifs expirent au bout de `LASTFM_MATCH_CACHE_TTL_DAYS` jours
-      (défaut 30, 0 = jamais), purgés au démarrage de chaque import
-      / rematch. Les positifs sont éternels et invalidés par les
-      mutations d'alias (track ou artiste). CLI
-      `bin/console app:lastfm:cache:clear [--negative-only]` pour
-      vider à la main.
-   1. **MusicBrainz ID** si Last.fm le fournit (le plus fiable) ;
-   2. **Triplet** `(artist, title, album)` normalisé — départage les
-      morceaux qui existent sur plusieurs albums (single + version
-      album + compilation) ;
-   3. **Couple** `(artist, title)` normalisé, avec tie-break
-      `album_artist = artist` puis `id ASC` ;
-   4. **Last.fm `track.getInfo`** : si la cascade locale échoue, on
-      interroge Last.fm pour récupérer (a) un MBID officiel quand le
-      scrobble n'en avait pas, (b) une graphie corrigée du couple
-      `(artist, title)` via `autocorrect=1`. Réutilise `LASTFM_API_KEY`.
-      Les résultats — positifs comme négatifs — passent par le cache
-      de résolution, donc on n'appelle l'API qu'**une fois** par
-      couple distinct.
-   5. **Fallback fuzzy** Levenshtein artist+title (opt-in via
-      `LASTFM_FUZZY_MAX_DISTANCE`, défaut 0 = désactivé). **Recommandé
-      pour les imports one-shot** : passer à `2` rattrape les typos
-      type `Du riiechst so gut` → `Du riechst so gut` ou
-      `Tchaïkovski` → `Tchaikovsky` avec très peu de faux-positifs.
-      Coûteux : O(N) par scrobble unmatched — acceptable pour un
-      import manuel, à laisser à `0` sur de très grosses libs.
-
-   La normalisation utilisée à toutes les étapes : lowercase + trim
-   + décomposition Unicode NFKD + strip des diacritiques (Beyoncé ↔
-   Beyonce) + strip de la ponctuation (AC/DC ↔ ACDC) + collapse des
-   espaces. Les helpers `stripFeaturedArtists()` /
-   `stripFeaturingFromTitle()` / `stripVersionMarkers()` retirent en
-   plus les suffixes parasites côté Last.fm (`feat. X`, `(Radio
-   Edit)`, `- Remastered 2011`, `(Live at …)`, `(Acoustic)`, etc.).
-3. **Déduplication** : un scrobble n'est pas réinséré s'il existe déjà
-   dans la table `scrobbles` une ligne avec le même `media_file_id` et
-   un `submission_time` à ±`--tolerance` secondes (60 par défaut, option
-   sur `app:lastfm:process`). Cela absorbe les petits décalages
-   d'horloge entre clients de scrobble.
-4. **Rapport final** : compteurs `considered / inserted / duplicates /
-   unmatched / skipped` (sur le run `lastfm-process`). Le détail du
-   run liste les morceaux par statut, avec filtre par défaut sur
-   `unmatched` quand il y en a — pratique pour identifier en priorité
-   les morceaux à ajouter dans la bibliothèque Navidrome (ou à mapper
-   via un alias).
-
-### Pré-requis
-
-- **Navidrome ≥ 0.55** (la table `scrobbles` doit exister, sinon
-  `app:lastfm:process` échoue avec un message explicite).
-- **Accès en écriture** sur la base SQLite Navidrome pour
-  `app:lastfm:process` (la phase fetch n'a pas besoin d'écrire). Si
-  vous lancez les commandes depuis le conteneur Docker du tool, montez
-  le fichier en read-write — par exemple :
-  ```bash
-  docker run --rm -it \
-      -v /srv/navidrome/data/navidrome.db:/data/navidrome.db \
-      -e NAVIDROME_DB_PATH=/data/navidrome.db \
-      -e LASTFM_API_KEY=... \
-      -e APP_SECRET=... -e APP_AUTH_USER=admin -e APP_AUTH_PASSWORD=... \
-      -e NAVIDROME_USER=admin -e NAVIDROME_PASSWORD=... \
-      ghcr.io/kgaut/navidrome-tools:latest \
-      php bin/console app:lastfm:import myuser
-  # puis, Navidrome arrêté :
-  ghcr.io/kgaut/navidrome-tools:latest \
-      php bin/console app:lastfm:process --auto-stop
-  ```
-- Sous Lando : `lando symfony app:lastfm:import myuser --api-key=...`
-  puis `lando symfony app:lastfm:process` fonctionnent directement
-  (la DB Navidrome bind-mountée est en RW par défaut).
-
-> **Backup automatique avant chaque écriture.** Quand vous lancez
-> `app:lastfm:process --auto-stop` ou `app:lastfm:rematch --auto-stop`,
-> le tool snapshote `navidrome.db` (+ siblings `-wal`/`-shm`) en
-> `<dbPath>.backup-<unix_ts>` **avant** d'écrire. Rétention configurable
-> via `NAVIDROME_DB_BACKUP_RETENTION` (défaut 3 snapshots). Si quoi que
-> ce soit tourne mal et que Navidrome refuse de redémarrer, restauration
-> en une commande :
->
-> ```bash
-> # Lister les backups disponibles (du plus ancien au plus récent)
-> ls -lh /srv/navidrome/data/navidrome.db.backup-*
->
-> # Rollback : remplacer la DB par le dernier backup connu sain
-> cp /srv/navidrome/data/navidrome.db.backup-<unix_ts> /srv/navidrome/data/navidrome.db
-> docker compose start navidrome
-> ```
-
-### Exemples
-
-```bash
-# Fetch dry-run (vérifie la connectivité API sans toucher au buffer) :
-lando symfony app:lastfm:import myuser --api-key=XXX --dry-run
-
-# Fetch de toute l'année 2024 dans le buffer :
-lando symfony app:lastfm:import myuser --api-key=XXX \
-    --date-min=2024-01-01 --date-max=2025-01-01
-
-# Vidange du buffer dans Navidrome avec stop/start automatique :
-lando symfony app:lastfm:process --auto-stop
-
-# Process dry-run (matching + comptage, ne touche ni Navidrome ni le buffer) :
-lando symfony app:lastfm:process --dry-run
-```
-
-## Alias d'artistes (synonymes)
-
-Quand un artiste a été **renommé** (« La Ruda Salska » → « La Ruda »),
-ou existe sous plusieurs **variantes** (romanisations, conventions
-« The X » / « X, The »), Last.fm peut envoyer le nom historique alors
-que Navidrome utilise le nom canonique. Plutôt que de créer un alias
-manuel par track, la page **`/lastfm/artist-aliases`** (menu Last.fm
-→ Alias artistes) gère ces synonymes au niveau artiste : un seul
-alias `source → cible` couvre tous les morceaux.
-
-Le matcher (`App\LastFm\ScrobbleMatcher`) consulte la table
-**après** l'alias track-level (qui garde la priorité absolue) mais
-**avant** la cascade MBID / triplet / couple : il réécrit le nom
-d'artiste dans le `LastFmScrobble` puis laisse les heuristiques
-habituelles tourner.
-
-Un bouton « 🎭 Aliaser artiste » apparaît sur `/lastfm/unmatched`
-pour créer rapidement un alias depuis un scrobble non matché.
-
-Une fois l'alias créé, lancez **« Re-tenter le matching cumulé »**
-(cf. ci-dessous) pour ré-essayer rétrospectivement tous les
-scrobbles concernés.
-
-## Liste cumulée des unmatched
-
-La page **`/lastfm/unmatched`** (menu Last.fm → Unmatched (titres))
-liste tous les scrobbles non matchés sur l'ensemble des imports
-passés, agrégés par `(artiste, titre, album)` avec compteur de
-scrobbles. Filtres en GET sur `artist`, `title`, `album` (substring
-case-insensitive) et pagination 50 par page.
-
-Pour chaque ligne :
-
-- **« ✏️ Mapper »** ouvre le formulaire d'alias manuel pré-rempli avec
-  l'artiste et le titre.
-- **« 🎭 Aliaser artiste »** ouvre le formulaire d'alias d'artiste.
-- **« + Lidarr »** envoie l'artiste à Lidarr (si configuré) et
-  redirige sur la page après ajout.
-- Le statut Lidarr (✓ déjà / ✗ absent / —) est affiché par ligne en
-  cherchant l'artiste dans le catalogue Lidarr existant.
-
-Deux vues complémentaires reliées par une barre d'onglets en haut de
-chaque page :
-
-- **`/lastfm/unmatched/artists`** (Top artistes unmatched) — agrège
-  par artiste seul. Idéal pour repérer les artistes complètement
-  absents de la collection : un seul clic « + Lidarr » couvre tous
-  les morceaux manquants de l'artiste. Affiche pour chaque ligne le
-  nombre de titres distincts non matchés et le total de scrobbles.
-  Filtre GET sur `artist`.
-- **`/lastfm/unmatched/albums`** (Top albums unmatched) — agrège par
-  couple `(artiste, album)`. Les rows sans album renseigné sont
-  écartées. Lidarr ne supporte pas l'ajout d'un album hors contexte
-  artiste : le bouton « + Lidarr » ajoute donc l'artiste de l'album,
-  le téléchargement de l'album dépend de la stratégie de monitoring
-  Lidarr (`LIDARR_MONITOR`). Filtres GET sur `artist` et `album`.
-
-Couplée à la commande `app:lastfm:rematch` (ci-dessous), ces pages
-forment le workflow de récupération : identifier ce qui manque
-→ créer alias / ajouter à Lidarr → relancer le rematch.
-
-## Re-match des unmatched
-
-Quand on ajoute des morceaux à Navidrome après un import (ou qu'on
-déploie une nouvelle heuristique de matching), les scrobbles déjà
-marqués `unmatched` dans `lastfm_import_track` peuvent être ré-essayés
-**sans retélécharger l'historique Last.fm**. La cascade de matching
-courante (alias → MBID → triplet → couple 4-paliers → fuzzy) est
-ré-appliquée et les scrobbles trouvés sont insérés dans Navidrome
-(idempotent : `scrobbleExistsNear` évite les doublons).
-
-### CLI
-
-```bash
-php bin/console app:lastfm:rematch [--dry-run] [--run-id=N] [--limit=N] [--random]
-```
-
-`--dry-run` montre le rapport sans écrire. `--run-id=N` limite le
-rematch aux unmatched du run #N. `--limit=0` (défaut) = pas de limite.
-`--random` mélange l'ordre des unmatched avant d'appliquer `--limit`,
-utile pour échantillonner un sous-ensemble représentatif (par défaut
-les rows sont parcourues par id croissant, donc avec un `--limit` fixe
-on retraiterait toujours les mêmes morceaux en tête de table).
-
-### Web
-
-- Sur `/history/{id}` d'un run `lastfm-process` ou `lastfm-import` :
-  bouton « 🔁 Re-tenter le matching de ce run » si le run a au moins
-  1 unmatched.
-- Sur `/lastfm/import` : carte « Re-tenter le matching cumulé » avec
-  le compteur global d'unmatched et un bouton de re-match global.
-
-### Cron
-
-Trois variables pilotent les schedules Last.fm :
-
-- `LASTFM_FETCH_SCHEDULE` — ajoute `app:lastfm:import` au crontab
-  (peut tourner Navidrome up).
-- `LASTFM_PROCESS_SCHEDULE` — ajoute `app:lastfm:process --auto-stop`
-  au crontab quand `NAVIDROME_CONTAINER_NAME` est défini (sinon sans
-  auto-stop, à vous de stopper Navidrome).
-- `LASTFM_REMATCH_SCHEDULE` — ajoute `app:lastfm:rematch --auto-stop`
-  pour retraiter périodiquement les unmatched cumulés.
-
-Toutes vides par défaut. Exemple raisonnable : fetch toutes les
-heures, process + rematch chaque dimanche à 05:00.
-
-⚠️ **Navidrome doit être arrêté** pendant le rematch (mêmes contraintes
-que `app:lastfm:process` : écriture dans la table `scrobbles`).
-
-## Connexion Last.fm authentifiée (optionnelle)
-
-Certaines actions vers Last.fm — notamment la future synchronisation
-loved ↔ starred (issue #23) — exigent une **session authentifiée**, pas
-juste l'API key publique utilisée par l'import.
-
-1. Récupérez la **API secret** sur la même page que la API key
-   (<https://www.last.fm/api/account/create>) et configurez-la :
-   ```env
-   LASTFM_API_KEY=votre-api-key
-   LASTFM_API_SECRET=votre-api-secret
-   ```
-2. Connectez-vous à Navidrome Tools puis allez sur `/lastfm/connect` :
-   l'app vous redirige vers Last.fm pour consentement, puis vous renvoie
-   sur `/settings` avec une session persistée localement (table
-   `setting`, clés `lastfm.session_key` / `lastfm.session_user`).
-3. La page `/settings` affiche un badge ✓/✗ et un bouton « Déconnecter »
-   pour révoquer la session locale (la révocation côté Last.fm se fait
-   sur <https://www.last.fm/settings/applications>).
-
-L'**URL de callback** que Last.fm appelle après consentement est
-construite automatiquement à partir de l'URL publique de votre instance.
-En prod, votre déploiement Docker doit donc être derrière un domaine
-résolvable par Last.fm (HTTPS recommandé).
-
-## Sync loved ↔ starred
-
-Une fois la connexion Last.fm faite (cf. ci-dessus), la page
-`/lastfm/love-sync` propage les ajouts dans les deux sens entre les
-morceaux ❤ Last.fm et les morceaux ★ Navidrome :
-
-- **lf → nd** : un morceau loved sur Last.fm est starré dans Navidrome
-  (s'il est résolu via MBID, alias manuel ou couple `(artist, title)`).
-- **nd → lf** : un morceau starred dans Navidrome est loved sur Last.fm.
-- **adds-only** : la v1 ne déstarre / délove jamais — la propagation
-  des suppressions arrivera dans une issue séparée.
-
-La sync est **idempotente** : un re-run immédiat ne fait rien tant que
-les deux ensembles sont alignés.
-
-### CLI
-
-```bash
-php bin/console app:lastfm:sync-loved [--direction=both|lf-to-nd|nd-to-lf] [--dry-run]
-```
-
-### Cron
-
-Définissez `LASTFM_LOVE_SYNC_SCHEDULE` pour ajouter une ligne cron
-automatiquement (ex. `0 4 * * *` pour tourner chaque nuit à 04:00). Vide
-par défaut.
-
-### Loved sans match
-
-Les morceaux loved sur Last.fm qui n'ont pas de correspondance dans la
-lib Navidrome apparaissent dans le rapport avec un bouton « ✏️ Mapper »
-qui pré-remplit le formulaire d'alias manuel `/lastfm/aliases/new`.
-
-## Intégration Lidarr (optionnelle)
-
-Sur la page d'import Last.fm, le tableau des morceaux non trouvés
-expose pour chaque ligne :
-
-- **Last.fm ↗** : page artiste publique sur Last.fm.
-- **Navidrome ↗** : si l'artiste existe déjà dans Navidrome (lookup par
-  nom normalisé), lien direct vers sa fiche dans l'app Navidrome.
-- **+ Lidarr** : ajoute l'artiste à Lidarr en un clic. Lidarr déclenchera
-  ensuite la recherche/téléchargement et alimentera la lib que Navidrome
-  scanne. Bouton masqué si Lidarr n'est pas configuré.
-
-### Configuration
-
-Variables d'environnement (laisser `LIDARR_URL` vide pour désactiver
-proprement) :
-
-| Variable                     | Description                                                         |
-|------------------------------|---------------------------------------------------------------------|
-| `LIDARR_URL`                 | Base URL Lidarr (ex. `http://lidarr:8686`).                         |
-| `LIDARR_API_KEY`             | API key (Lidarr → Settings → General).                              |
-| `LIDARR_ROOT_FOLDER_PATH`    | Chemin où Lidarr place les artistes (ex. `/music`).                 |
-| `LIDARR_QUALITY_PROFILE_ID`  | Id d'un Quality Profile existant.                                   |
-| `LIDARR_METADATA_PROFILE_ID` | Id d'un Metadata Profile existant.                                  |
-| `LIDARR_MONITOR`             | `all`/`future`/`missing`/`existing`/`first`/`latest`/`none` (défaut `all`). |
-
-Le service :
-1. Cherche l'artiste sur MusicBrainz via l'endpoint Lidarr
-   `/api/v1/artist/lookup` (l'API key permet d'éviter les rate-limits MB).
-2. Prend le premier hit (Lidarr ordonne par pertinence) et POST
-   `/api/v1/artist` en demandant `searchForMissingAlbums: true`.
-3. Si Lidarr répond que l'artiste existe déjà, l'UI affiche un flash
-   info (« déjà présent ») au lieu d'une erreur.
-
-## Tracks sans MBID
-
-La page **`/tagging/missing-mbid`** (menu **Tagging**) liste les
-morceaux Navidrome dont les colonnes `mbz_track_id` ET
-`mbz_recording_id` sont vides. Sans MBID, le palier le plus fiable de
-la cascade de matching Last.fm est inutilisable, et l'outil retombe
-sur les paliers (artiste, titre, album) + fuzzy, plus fragiles.
-
-L'architecture est volontairement read-only : navidrome-tools
-**n'écrit jamais** dans tes fichiers audio (le volume `/music` peut
-rester monté `:ro`). Le workflow est :
-
-1. **Audit** sur la page : filtres artiste/album, pagination, voir
-   les chemins absolus.
-2. **Export CSV** (bouton « ⬇ Export CSV ») : télécharge la liste
-   des chemins (id, path, artist, album, title…) que tu pipes dans
-   un tagger sur la machine où ton dossier de musique est en
-   lecture/écriture. Exemples :
-   - **beets** :
-     ```bash
-     # extrait la colonne path et nourris beet
-     tail -n +2 missing-mbid-2026-05-02.csv \
-       | awk -F'"' '{print $4}' \
-       | xargs -d '\n' beet import -A --quiet
-     ```
-   - **MusicBrainz Picard** : ouvre Picard, drag-and-drop le dossier
-     de musique, lance « Scan » puis « Save ».
-3. **Rescan Navidrome** (bouton « ↻ Rescan Navidrome ») : déclenche
-   `startScan` via Subsonic une fois le tagging fini. Les nouveaux
-   MBIDs apparaissent dans `media_file.mbz_track_id` sans attendre
-   le scan planifié. Logué dans `/history` sous le type
-   `navidrome-rescan`.
-
-Une card « Tracks sans MBID » sur le dashboard affiche le compteur
-courant et un raccourci vers la page.
-
-### Queue beets (intégration semi-automatique)
-
-Si tu préfères ne pas copier-coller le CSV à chaque fois, configure
-`BEETS_QUEUE_PATH` (ex. `/shared/beets-queue.txt`). La page expose
-alors un bouton **« 📋 Pousser dans la queue beets »** qui appendit
-les chemins filtrés dans ce fichier sous `flock` (sûr en
-concurrence). Côté hôte beets, monter le même volume et lancer un
-cron qui consomme la queue, par exemple :
-
-```bash
-# /etc/cron.d/beets-queue : toutes les 15 min
-*/15 * * * * beets   ( flock -x 9 ; \
-   [ -s /shared/beets-queue.txt ] || exit 0 ; \
-   mv /shared/beets-queue.txt /shared/beets-queue.processing ; \
- ) 9>/shared/beets-queue.lock && \
- beet import -A --quiet $(cat /shared/beets-queue.processing) && \
- rm /shared/beets-queue.processing
-```
-
-Avec ce pattern, navidrome-tools ne touche **que** le fichier de
-queue (RW), `/music` reste `:ro`. Le push est tracé dans
-`/history` (type `beets-queue-push`) et le bandeau de la page
-affiche la taille courante de la queue.
-
-## Historique des runs cron
-
-Tous les jobs longs sont audités dans la table locale `run_history`.
-La page `/history` (lien dans la nav) liste les exécutions avec :
-
-- type (`playlist`, `stats`, `lastfm-import`),
-- libellé humain,
-- statut (✓ success / ✗ error / skipped) avec badge coloré,
-- date de démarrage et durée,
-- métriques (par exemple `tracks=50`, `inserted=237`, `unmatched=42`),
-- bouton « Détails » pour le message complet et le JSON metrics.
-
-Filtres par type/statut + recherche libre + pagination (50/page).
-
-Le dashboard (`/`) affiche en plus un bloc « Derniers runs » avec les
-10 dernières entrées (tous types confondus) pour repérer en un coup
-d'œil les erreurs récentes, avec un lien direct vers la page
-complète.
-
-Une commande `app:history:purge` supprime les entrées plus vieilles que
-`RUN_HISTORY_RETENTION_DAYS` (défaut 90). À planifier dans votre
-crontab unix (cf. la section [Lancement des jobs récurrents](#lancement-des-jobs-récurrents)).
-
-## Notifications de fin de run
-
-À chaque fin de traitement enveloppé par `RunHistoryRecorder` (backup
-DB Navidrome, fetch Last.fm, process buffer, rematch, sync loved,
-compute stats, purge history…), l'app peut pousser une notification
-vers un ou plusieurs canaux. Le payload inclut le type du run, le label
-humain, le status (`success` / `error`), la durée, les métriques et,
-en cas d'échec, le message d'erreur tronqué.
-
-Configuration via env vars — vide partout = feature désactivée :
-
-| Variable                       | Usage                                                              |
-|--------------------------------|--------------------------------------------------------------------|
-| `NOTIFY_DRIVERS`               | CSV des canaux actifs. Valeurs : `gotify`, `slack`, `discord`, `pushover`. Exemple : `gotify,slack` pour broadcaster. |
-| `NOTIFY_ON`                    | `error` (défaut, n'envoie que les échecs) ou `all` (succès aussi). |
-| `NOTIFY_GOTIFY_URL`            | URL de base de votre instance Gotify, ex. `https://gotify.example.com`. |
-| `NOTIFY_GOTIFY_TOKEN`          | Application token Gotify.                                          |
-| `NOTIFY_GOTIFY_PRIORITY`       | Priorité par défaut (1..10, défaut 5). Bumpée à au moins 8 sur erreur. |
-| `NOTIFY_SLACK_WEBHOOK_URL`     | Webhook incoming Slack (Apps → Incoming Webhooks).                 |
-| `NOTIFY_DISCORD_WEBHOOK_URL`   | Webhook channel Discord (Server Settings → Integrations).          |
-| `NOTIFY_PUSHOVER_TOKEN`        | Application token Pushover ([pushover.net](https://pushover.net/)).|
-| `NOTIFY_PUSHOVER_USER`         | User ou group key Pushover.                                        |
-
-L'orchestrateur isole chaque driver : une erreur de transport sur l'un
-des canaux est loggée mais n'empêche pas les autres canaux de partir,
-et n'interrompt jamais le job lui-même.
-
-Ajouter un nouveau canal = créer une classe dans `src/Notifier/Driver/`
-qui implémente `App\Notifier\NotifierDriverInterface` (auto-taggée
-`app.notifier_driver`), déclarer ses paramètres dans
-`config/services.yaml`, et l'activer en l'ajoutant à `NOTIFY_DRIVERS`.
-
-## Widget Homepage (gethomepage)
-
-Endpoint JSON `/api/status` consommable par le widget
-[Custom API](https://gethomepage.dev/widgets/services/customapi/) de
-[Homepage](https://gethomepage.dev/). Sert aussi de healthcheck Docker.
-
-Deux modes d'accès :
-
-| Sans token (no-auth)                                     | Avec token (`HOMEPAGE_API_TOKEN`)                                  |
-|----------------------------------------------------------|--------------------------------------------------------------------|
-| `GET /api/status`                                        | `GET /api/status?token=…` ou `Authorization: Bearer …`             |
-| Payload minimal `{status, navidrome_db}`                 | Payload enrichi : compteurs, dernier run, statut conteneur         |
-| Codes HTTP 200 (ok) / 503 (degraded) — Docker friendly   | Code HTTP 200 ; 401 si token erroné, 404 si feature désactivée     |
-
-### Activer le mode enrichi
-
-Générer un token et l'injecter dans l'environnement du conteneur web :
-
-```bash
-openssl rand -hex 32                  # copier dans HOMEPAGE_API_TOKEN
-```
-
-Puis configurer le widget Homepage (`services.yaml`) :
-
-```yaml
-- Navidrome Tools:
-    icon: navidrome.png
-    href: https://navidrome-tools.example.com
-    widget:
-      type: customapi
-      url: https://navidrome-tools.example.com/api/status?token={{HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}}
-      refreshInterval: 60000
-      mappings:
-        - field: scrobbles_total
-          label: Scrobbles
-          format: number
-        - field: unmatched_total
-          label: Unmatched
-          format: number
-        - field: { last_run: status }
-          label: Dernier run
-        - field: { last_run: started_at }
-          label: À
-          format: relativeDate
-```
-
-Et déclarer la variable Homepage côté docker-compose :
-
-```yaml
-environment:
-  HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN: ${HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}
-```
-
-### Payload enrichi
-
-```json
-{
-  "status": "ok",
-  "navidrome_db": true,
-  "scrobbles_total": 142387,
-  "unmatched_total": 312,
-  "missing_mbid": 47,
-  "navidrome_container": "running",
-  "last_run": {
-    "type": "lastfm-import",
-    "reference": "me",
-    "label": "Last.fm import (me)",
-    "status": "success",
-    "started_at": "2026-05-03T08:00:01+00:00",
-    "finished_at": "2026-05-03T08:03:05+00:00",
-    "duration_ms": 184230
-  }
-}
-```
-
-`navidrome_container` reprend l'enum `ContainerStatus` :
-`disabled` / `running` / `stopped` / `notfound` / `unknown`. `last_run`
-vaut `null` quand `run_history` est vide.
-
-### Healthcheck Docker
-
-Sans HOMEPAGE_API_TOKEN, l'endpoint reste un healthcheck pratique :
-
-```yaml
-healthcheck:
-  test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/status"]
-  interval: 30s
-  timeout: 5s
-  retries: 3
-```
-
-## Configuration éditeur
-
-Le repo livre une **config PhpStorm partageable** (PSR-12, inspections
-PHPCS et PHPStan câblées sur `phpcs.xml.dist` et `phpstan.dist.neon`,
-PHP language level 8.3, framework PHPUnit 11) sous `.idea/` :
-
-- `.idea/codeStyles/` — schéma de code projet
-- `.idea/inspectionProfiles/Project_Default.xml` — inspections actives
-- `.idea/php.xml` — version PHP, container Symfony, namespace Twig
-- `.idea/php-test-framework.xml` — PHPUnit version
-
-Ces fichiers sont whitelistés dans `.gitignore` ; le reste de `.idea/`
-(workspace, fichiers per-user) reste ignoré.
-
-Un `.editorconfig` à la racine fournit le minimum universel pour les
-autres éditeurs (VS Code, Vim, Sublime…) : indentation 4 espaces (2
-pour YAML/JSON/XML/HTML/Twig), LF, UTF-8, trim trailing whitespace.
-
-## Qualité de code et tests
-
-Le projet utilise PHPUnit, PHPStan et PHP_CodeSniffer (PSR-12). Les
-trois sont exécutés par la CI GitHub Actions sur chaque push / pull
-request, plus un build de l'image Docker en parallèle.
-
-```bash
-composer test       # PHPUnit
-composer phpstan    # Static analysis (level 6 + extensions Symfony/Doctrine/PHPUnit)
-composer phpcs      # PSR-12 coding standard
-composer phpcbf     # Auto-fix many PHPCS errors
-composer ci         # phpcs + phpstan + tests, séquentiellement
-```
-
-Configuration : `phpunit.xml.dist`, `phpstan.dist.neon`, `phpcs.xml.dist`.
-
-Sous Lando :
-
-```bash
-lando composer test
-lando composer phpstan
-lando composer phpcs
-lando composer ci
-```
-
-## Ajouter un nouveau type de playlist (plugin)
-
-Voir [`docs/PLUGINS.md`](docs/PLUGINS.md). En résumé : créer une classe
-qui implémente `App\Generator\PlaylistGeneratorInterface` dans
-`src/Generator/`, elle est auto-détectée et apparaît immédiatement dans
-le dropdown de l'UI.
-
-**En déploiement Docker**, il n'est pas nécessaire de rebuilder
-l'image : il suffit de bind-mounter un dossier hôte sur `/app/plugins`
-(namespace `App\Plugin\`) et d'y déposer ses classes. L'autoload et le
-cache Symfony sont régénérés à chaque démarrage du conteneur. Détails et
-exemple complet dans [`docs/PLUGINS.md`](docs/PLUGINS.md#plugins-custom-en-déploiement-docker).
-
-## Schéma Navidrome utilisé (lecture seule)
-
-| Table          | Colonnes lues                                                |
-|----------------|--------------------------------------------------------------|
-| `media_file`   | id, title, album, artist, album_artist, duration, year       |
-| `annotation`   | user_id, item_id, item_type, play_count, play_date           |
-| `user`         | id, user_name (résolution `NAVIDROME_USER` → user_id Subsonic)|
-| `scrobbles`    | media_file_id, user_id, submission_time (Navidrome ≥ 0.55)   |
-
-Si la table `scrobbles` n'existe pas, le tool retombe sur
-`annotation.play_date`, qui ne contient que la date du **dernier** play.
-Les tops « par fenêtre temporelle » deviennent donc approximatifs ; un
-bandeau d'avertissement est affiché dans l'UI dans ce cas.
-
-## Création de playlists
-
-Toutes les playlists sont créées via l'API Subsonic de Navidrome
-(`createPlaylist.view`). Le tool **n'écrit jamais directement** dans la
-SQLite Navidrome. Avantages : aucun risque de corruption ou de conflit
-de lock, fonctionne même si Navidrome tourne en parallèle.
-
-L'option « remplacer la playlist existante » utilise
-`getPlaylists.view` + `deletePlaylist.view` pour retirer l'ancienne du
-même nom appartenant au même utilisateur, puis recrée la nouvelle.
-
-## Gestion des playlists existantes
-
-Page `/playlists` (lien « Playlists » dans la barre de nav) : liste
-toutes les playlists Navidrome avec leur métadonnées (nombre de
-morceaux, durée, dates de création/modification, owner, public/privé).
-Cases à cocher + bouton « Supprimer la sélection » pour la suppression
-en masse. Bouton « M3U » par ligne pour télécharger la playlist au
-format M3U Extended (lisible par VLC / mpv / foobar2000).
-
-Page détail `/playlists/{id}` : affiche le contenu de la playlist
-(titre, artiste, album, durée, play count, statut starred ★) et permet :
-
-- **Renommer** la playlist (`updatePlaylist.view`)
-- **Dupliquer** la playlist sous le nom « X (copie) »
-- **Supprimer** la playlist (avec nettoyage automatique du
-  `lastSubsonicPlaylistId` des `PlaylistDefinition` rattachées)
-- **Star/unstar individuel** d'un morceau (icône ★/☆)
-- **Bulk star/unstar** : « ★ Tout starrer » / « ☆ Tout dé-starrer »,
-  un seul appel API
-- **Retirer un morceau** de la playlist (`updatePlaylist.view` avec
-  `songIndexToRemove`)
-- **Détecter les morceaux morts** (présents dans la playlist mais
-  absents de `media_file`) et les purger en un clic
-- **Statistiques** : durée totale, nombre starré, % jamais joués, top
-  10 artistes, top 10 albums, distribution par année (mini bar chart)
-- **Exporter en M3U**
-
-Toutes les écritures passent par l'API Subsonic — aucune écriture
-directe dans la DB Navidrome (qui peut donc rester montée `:ro`).
-
-L'export M3U est aussi disponible sur la prévisualisation des
-définitions de playlist (`/playlist/{id}/preview` → bouton « Exporter
-M3U »), pour récupérer la liste avant même de la créer côté Navidrome.
+> Pour héberger un miroir sur GitLab, le repo livre aussi un
+> [`.gitlab-ci.yml`](.gitlab-ci.yml) avec les mêmes jobs (phpcs,
+> phpstan, tests PHP 8.4, docker build + publish multi-arch). Par
+> défaut il pousse vers `$CI_REGISTRY_IMAGE` ; surcharger via
+> `REGISTRY_IMAGE` dans Settings → CI/CD pour viser une autre cible.
+
+## Pré-requis
+
+- **Navidrome ≥ 0.55** (la table `scrobbles` est requise pour la
+  plupart des fonctionnalités). Avec une 0.54, l'app fonctionne avec
+  des stats approximatives.
+- **PHP 8.4 minimum** (image officielle), Composer 2 si vous buildez
+  vous-même.
+- Lecture sur le fichier SQLite Navidrome ; écriture seulement pour
+  `app:lastfm:process` et `app:lastfm:rematch` (cf.
+  [`docs/LASTFM.md`](docs/LASTFM.md)).
 
 ## Changelog
 

--- a/docs/CRON.md
+++ b/docs/CRON.md
@@ -1,0 +1,127 @@
+# Jobs récurrents et historique des runs
+
+Le tool **n'embarque pas** de cron interne (pas de supercronic, pas
+de service `navidrome-tools-cron`, plus de variables `*_SCHEDULE`).
+Vous pilotez les commandes Symfony depuis votre **crontab unix** (ou
+tout autre scheduler : systemd timers, Nomad cron, etc.).
+
+## Exécuter une commande dans le conteneur web
+
+`docker compose exec -T` réutilise le conteneur `navidrome-tools-web`
+déjà démarré (toutes les variables d'environnement y sont déjà
+chargées, pas besoin d'un `run --rm` qui relancerait l'entrypoint et
+rejouerait les migrations à chaque tick) :
+
+```bash
+docker compose exec -T navidrome-tools-web php bin/console <command>
+```
+
+Sous Lando, l'équivalent est `lando symfony <command>`.
+
+## Exemple de crontab
+
+Adapté au flux Last.fm en deux étapes (fetch quand Navidrome tourne,
+process / rematch quand il est stoppé via `--auto-stop`) :
+
+```cron
+# Génération d'une playlist (id depuis l'UI ou
+# `bin/console doctrine:dbal:run-sql 'SELECT id, name FROM playlist_definition'`).
+0 3 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:playlist:run 1
+
+# Refresh du cache stats (lecture seule sur Navidrome — sans risque).
+0 */6 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:stats:compute
+
+# Fetch Last.fm dans le buffer (Navidrome up — aucune écriture sur sa DB).
+*/15 * * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:lastfm:import
+
+# Drain du buffer dans Navidrome (--auto-stop orchestre stop/run/restart).
+0 4 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:lastfm:process --auto-stop
+
+# Re-match des unmatched cumulés (idem, --auto-stop).
+0 5 * * 0 docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:lastfm:rematch --auto-stop
+
+# Sync loved ↔ starred (quotidien).
+30 4 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:lastfm:sync-loved
+
+# Purge de l'historique des runs (rétention RUN_HISTORY_RETENTION_DAYS).
+45 4 * * * docker compose -f /srv/navidrome/docker-compose.yml exec -T navidrome-tools-web \
+    php bin/console app:history:purge
+```
+
+Si vous écrivez le crontab sur l'hôte (pas dans un conteneur sidecar),
+remplacez `/srv/navidrome/docker-compose.yml` par le chemin réel et
+assurez-vous que l'utilisateur cron a accès à Docker.
+
+## Stop / start automatique de Navidrome
+
+`--auto-stop` est dispo sur les commandes qui **écrivent** dans la DB
+Navidrome (`app:lastfm:process`, `app:lastfm:rematch`). Quand
+`NAVIDROME_CONTAINER_NAME` est renseigné, il orchestre :
+
+1. **Backup** : copie `navidrome.db` + ses siblings `-wal` / `-shm`
+   vers `<dbPath>.backup-<unix_ts>` (rétention `NAVIDROME_DB_BACKUP_RETENTION`).
+2. **Stop** : `docker stop -t $NAVIDROME_STOP_TIMEOUT_SECONDS` puis
+   poll `docker inspect` jusqu'à `Running=false`.
+3. **Quick check pré** : `PRAGMA quick_check` sur la DB — refuse de
+   continuer si elle est déjà brisée.
+4. **Action** : `process` / `rematch`, batchs encadrés par
+   `BEGIN IMMEDIATE` / `COMMIT`.
+5. **Quick check post** : si fail, restaure le backup
+   automatiquement + exception explicite.
+6. **Restart** : `docker start` (toujours, même en cas d'erreur — try/
+   finally).
+
+Sans `NAVIDROME_CONTAINER_NAME`, arrêtez Navidrome manuellement avant
+d'invoquer les commandes (sinon pré-flight bloquant ; passez
+`--force` pour outrepasser **à vos risques**).
+
+## Historique des runs
+
+Tous les jobs longs sont audités dans la table locale `run_history`.
+La page `/history` (lien dans la nav) liste les exécutions avec :
+
+- type (`playlist`, `stats`, `lastfm-import`, `lastfm-fetch`,
+  `lastfm-process`, `lastfm-rematch`, `lastfm-love-sync`,
+  `navidrome-rescan`, `beets-queue-push`, …),
+- libellé humain,
+- statut (✓ success / ✗ error / skipped) avec badge coloré,
+- date de démarrage et durée,
+- métriques en JSON (`tracks=50`, `inserted=237`, `unmatched=42`),
+- bouton « Détails » pour le message complet et le JSON metrics.
+
+Filtres par type/statut + recherche libre + pagination (50/page).
+
+### Détail par-track pour les runs Last.fm
+
+Les runs `lastfm-process` (et `lastfm-import` legacy) affichent **en
+plus** le listing par-track depuis la table `lastfm_import_track` :
+filtre par statut (`inserted` / `duplicate` / `unmatched`, défaut «
+non matchés » s'il y en a) et recherche full-text artiste/titre.
+
+### Dashboard
+
+Le dashboard `/` affiche un bloc « Derniers runs » avec les 10
+dernières entrées (tous types confondus) pour repérer en un coup
+d'œil les erreurs récentes, avec un lien direct vers la page
+complète.
+
+### Purge
+
+La commande `app:history:purge` supprime les entrées plus vieilles
+que `RUN_HISTORY_RETENTION_DAYS` (défaut 90). À planifier dans le
+crontab (cf. exemple plus haut). Idempotent — exécutions répétées
+n'effacent que ce qui est tombé sous le seuil entre deux runs.
+
+## Notifications de fin de run
+
+Chaque run wrappé par `RunHistoryRecorder` peut déclencher une
+notification (Gotify / Slack / Discord / Pushover, broadcast supporté
+via CSV `NOTIFY_DRIVERS`). Voir [`NOTIFICATIONS.md`](NOTIFICATIONS.md)
+pour la configuration, et la page **`/settings`** pour tester
+l'envoi depuis l'UI.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,151 @@
+# Développement local
+
+Deux options sont supportées : [Lando](https://lando.dev/) (recommandé,
+zéro install local) ou un setup natif PHP 8.4 + Symfony CLI.
+
+## Avec Lando (recommandé)
+
+Lando fournit l'environnement complet sans rien installer sur l'hôte.
+La stack expose **deux services** :
+
+- `appserver` — Symfony 7 (PHP 8.4 + nginx + Composer 2), UI sur
+  `https://navidrome-tools.lndo.site`.
+- `navidrome` — instance Navidrome de test sur
+  `https://navidrome.lndo.site`, qui partage sa DB SQLite avec le tool
+  via `var/navidrome-data/`.
+
+### Setup initial
+
+```bash
+git clone https://github.com/kgaut/navidrome-playlist-generator
+cd navidrome-playlist-generator
+
+# Préparer le dossier partagé Navidrome ↔ tool (DB + cache).
+mkdir -p var/navidrome-data
+
+# (Optionnel) seeder avec votre vraie base, sinon Navidrome
+# en créera une vide au premier boot.
+cp /chemin/vers/navidrome.db var/navidrome-data/navidrome.db
+
+# Copier le template Lando puis adapter le bind-mount du dossier
+# musique (cherche « /change/me/path/to/music » dans .lando.yml).
+# .lando.yml est gitignored.
+cp .lando.yml.dist .lando.yml
+
+lando start          # premier lancement : build + composer install
+lando migrate        # crée la DB locale du tool
+lando seed           # insère les 4 définitions d'exemple
+```
+
+URLs disponibles après `lando start` :
+
+- UI tool : <https://navidrome-tools.lndo.site>
+- Navidrome : <https://navidrome.lndo.site> (admin créé au premier
+  démarrage via l'UI Navidrome elle-même)
+
+### Commandes utiles
+
+| Commande Lando                       | Effet                                                  |
+|--------------------------------------|--------------------------------------------------------|
+| `lando symfony cache:clear`          | Vider le cache Symfony.                                |
+| `lando composer require X`           | Installer un package Composer.                         |
+| `lando test`                         | Lancer PHPUnit.                                        |
+| `lando migrate`                      | Jouer les migrations Doctrine.                         |
+| `lando seed`                         | Réinsérer les fixtures (idempotent).                   |
+| `lando playlist-run "Top 7j" --dry-run` | Tester une définition de playlist sans la publier.  |
+| `lando logs -s navidrome -f`         | Suivre les logs du Navidrome embarqué.                 |
+
+### Xdebug
+
+Éditer votre copie locale `.lando.yml` et passer `xdebug: false` à
+`xdebug: debug`, puis `lando rebuild -y`.
+
+### Écrire dans la DB Navidrome sous Lando
+
+`app:lastfm:process` et `app:lastfm:rematch` doivent être lancés
+**Navidrome arrêté**. Le flag `--auto-stop` n'est pas câblé sous Lando
+(c'est un setup dev, pas prod) — utilisez `lando stop navidrome` avant
+puis `lando start navidrome` après :
+
+```bash
+lando stop navidrome
+lando symfony app:lastfm:process
+lando start navidrome
+```
+
+## Sans Lando
+
+Pré-requis : PHP 8.4+, ext-pdo_sqlite, Composer 2,
+[Symfony CLI](https://symfony.com/download).
+
+```bash
+composer install
+cp .env.dist .env.local              # ajuster les valeurs
+mkdir -p var
+cp /chemin/vers/navidrome.db var/navidrome.db
+php bin/console doctrine:migrations:migrate -n
+php bin/console app:fixtures:seed
+symfony serve                        # https://127.0.0.1:8000
+```
+
+> Si `composer install` rouspète sur le superuser, préfixer avec
+> `COMPOSER_ALLOW_SUPERUSER=1` — c'est nécessaire pour que Symfony
+> Flex tourne ses recipes et génère `vendor/autoload_runtime.php`.
+
+## Qualité de code et tests
+
+Le projet utilise PHPUnit 11, PHPStan niveau 6 et PHP_CodeSniffer
+(PSR-12). Les trois tournent en CI sur chaque push / pull request,
+plus un build de l'image Docker en parallèle.
+
+```bash
+composer test       # PHPUnit
+composer phpstan    # Static analysis (level 6 + extensions Symfony/Doctrine/PHPUnit)
+composer phpcs      # PSR-12 coding standard
+composer phpcbf     # Auto-fix la plupart des erreurs PHPCS
+composer ci         # phpcs + phpstan + tests, séquentiellement
+```
+
+Configuration : [`phpunit.xml.dist`](../phpunit.xml.dist),
+[`phpstan.dist.neon`](../phpstan.dist.neon),
+[`phpcs.xml.dist`](../phpcs.xml.dist).
+
+Sous Lando :
+
+```bash
+lando composer test
+lando composer phpstan
+lando composer phpcs
+lando composer ci
+```
+
+PHP cible : **8.4 minimum** (`composer.json` pinne
+`config.platform.php=8.4.0`). La CI ne teste plus la 8.3 — le code
+utilise certaines features 8.4 (chained `new ClassName(...)->method()`,
+lazy objects natifs Doctrine).
+
+## Configuration éditeur
+
+Le repo livre une **config PhpStorm partageable** sous `.idea/`
+(whitelistée dans `.gitignore`) :
+
+- `.idea/codeStyles/` — schéma de code projet (PSR-12).
+- `.idea/inspectionProfiles/Project_Default.xml` — inspections actives,
+  câblées sur `phpcs.xml.dist` et `phpstan.dist.neon`.
+- `.idea/php.xml` — version PHP, container Symfony, namespace Twig.
+- `.idea/php-test-framework.xml` — PHPUnit version.
+
+Le reste de `.idea/` (workspace, fichiers per-user) reste ignoré.
+
+Un `.editorconfig` à la racine fournit le minimum universel pour les
+autres éditeurs (VS Code, Vim, Sublime…) : indentation 4 espaces (2
+pour YAML/JSON/XML/HTML/Twig), LF, UTF-8, trim trailing whitespace.
+
+## Pour aller plus loin
+
+- [`PLUGINS.md`](PLUGINS.md) — créer un nouveau type de générateur de
+  playlist.
+- [`CRON.md`](CRON.md) — schedule des jobs récurrents.
+- [`ENVIRONMENT.md`](ENVIRONMENT.md) — référence des variables.
+- [`CLAUDE.md`](../CLAUDE.md) — contexte projet complet (stack,
+  architecture, pièges, conventions).

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -10,10 +10,9 @@ Deux scénarios sont couverts :
   + beets, le cas le plus fréquent).
 - **Scénario B** : création d'une stack complète from scratch.
 
-Pour le tableau exhaustif des variables d'environnement, voir le
-[`README.md`](../README.md#variables-denvironnement). Pour
-ajouter ses propres générateurs de playlist, voir
-[`docs/PLUGINS.md`](PLUGINS.md).
+Pour le tableau exhaustif des variables d'environnement, voir
+[`ENVIRONMENT.md`](ENVIRONMENT.md). Pour ajouter ses propres
+générateurs de playlist, voir [`PLUGINS.md`](PLUGINS.md).
 
 ## 1. Prérequis
 
@@ -83,8 +82,8 @@ Les jobs récurrents (génération de playlists, refresh stats, fetch /
 process Last.fm, purge d'historique) sont **lancés depuis le crontab
 unix de l'hôte** via `docker compose exec -T navidrome-tools-web
 php bin/console <cmd>` — il n'y a plus de service cron embarqué dans
-l'image. Voir la section [« Lancement des jobs récurrents »](../README.md#lancement-des-jobs-récurrents)
-du README pour des exemples de lignes crontab.
+l'image. Voir [`CRON.md`](CRON.md) pour des exemples de lignes
+crontab.
 
 ## 5. Points de montage (volumes)
 
@@ -233,8 +232,7 @@ Cas typique : `/srv/media/docker-compose.yml` contient déjà
    ```
 
 6. Configurer les jobs récurrents dans le **crontab unix** de l'hôte
-   (cf. [README — Lancement des jobs récurrents](../README.md#lancement-des-jobs-récurrents))
-   plutôt que dans un service cron Docker.
+   (cf. [`CRON.md`](CRON.md)) plutôt que dans un service cron Docker.
 
 ## 8. Scénario B : stack complète from scratch
 
@@ -423,11 +421,13 @@ redémarrages.
 
 ## 13. Pour aller plus loin
 
-- [`README.md`](../README.md#variables-denvironnement) — tableau
-  exhaustif des variables d'environnement.
-- [`README.md`](../README.md#lancement-des-jobs-récurrents) — lignes
-  crontab unix prêtes à coller pour les jobs récurrents.
-- [`docs/PLUGINS.md`](PLUGINS.md) — créer ses propres générateurs de
+- [`ENVIRONMENT.md`](ENVIRONMENT.md) — référence exhaustive des
+  variables d'environnement.
+- [`CRON.md`](CRON.md) — lignes crontab unix prêtes à coller pour
+  les jobs récurrents.
+- [`PLUGINS.md`](PLUGINS.md) — créer ses propres générateurs de
   playlist.
-- [`CHANGELOG.md`](../CHANGELOG.md) — détail chronologique des
+- [`DEVELOPMENT.md`](DEVELOPMENT.md) — dev local (Lando ou natif),
+  tests, qualité, éditeur.
+- [`../CHANGELOG.md`](../CHANGELOG.md) — détail chronologique des
   changements.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,0 +1,176 @@
+# Variables d'environnement
+
+Toutes les variables consommées par Navidrome Tools, groupées par
+fonctionnalité. Une variable vide vaut « feature désactivée » pour
+toutes les intégrations optionnelles (Lidarr, Last.fm, Homepage,
+pilotage conteneur, queue beets, …) — le reste de l'app continue de
+tourner.
+
+> **Où les éditer ?**
+>
+> - **Prod Docker** : variables d'environnement du conteneur
+>   `navidrome-tools-web` dans votre `docker-compose.yml` (cf.
+>   [`docker-compose.example.yml`](../docker-compose.example.yml)).
+> - **Dev local hors Lando** : `.env.local` à la racine du projet
+>   (copie de [`.env.dist`](../.env.dist), non versionnée).
+> - **Dev Lando** : section `environment` de votre `.lando.yml`
+>   (copie de [`.lando.yml.dist`](../.lando.yml.dist), non versionnée).
+> - **Tests** : `phpunit.xml.dist` (valeurs neutres, ne pas y stocker
+>   de credentials réels).
+
+Tableau récapitulatif rapide, suivi des sections détaillées avec
+exemples et contexte.
+
+## Récapitulatif par catégorie
+
+| Domaine                            | Variables                                                                                       |
+|------------------------------------|-------------------------------------------------------------------------------------------------|
+| [Symfony / app](#symfony--app)     | `APP_SECRET`, `APP_ENV`, `APP_MODE`, `APP_TIMEZONE`, `APP_VERSION`, `APP_AUTH_USER`, `APP_AUTH_PASSWORD`, `DATABASE_URL`, `DEFAULT_URI` |
+| [Source Navidrome](#source-navidrome) | `NAVIDROME_DB_PATH`, `NAVIDROME_URL`, `NAVIDROME_USER`, `NAVIDROME_PASSWORD`                  |
+| [Pilotage conteneur](#pilotage-du-conteneur-navidrome) | `NAVIDROME_CONTAINER_NAME`, `NAVIDROME_STOP_TIMEOUT_SECONDS`, `NAVIDROME_STOP_WAIT_CEILING_SECONDS`, `NAVIDROME_DB_BACKUP_RETENTION` |
+| [Last.fm](#lastfm)                 | `LASTFM_API_KEY`, `LASTFM_API_SECRET`, `LASTFM_USER`, `LASTFM_PAGE_DELAY_SECONDS`, `LASTFM_FUZZY_MAX_DISTANCE`, `LASTFM_MATCH_CACHE_TTL_DAYS` |
+| [Lidarr](#lidarr)                  | `LIDARR_URL`, `LIDARR_API_KEY`, `LIDARR_ROOT_FOLDER_PATH`, `LIDARR_QUALITY_PROFILE_ID`, `LIDARR_METADATA_PROFILE_ID`, `LIDARR_MONITOR` |
+| [Historique des runs](#historique-des-runs) | `RUN_HISTORY_RETENTION_DAYS`                                                            |
+| [Cover art](#cover-art)            | `COVERS_CACHE_PATH`                                                                             |
+| [Queue beets](#queue-beets)        | `BEETS_QUEUE_PATH`                                                                              |
+| [Widget Homepage](#widget-homepage-gethomepagedev) | `HOMEPAGE_API_TOKEN`                                                            |
+| [Notifications](#notifications)    | `NOTIFY_DRIVERS`, `NOTIFY_ON`, `NOTIFY_GOTIFY_URL`, `NOTIFY_GOTIFY_TOKEN`, `NOTIFY_GOTIFY_PRIORITY`, `NOTIFY_SLACK_WEBHOOK_URL`, `NOTIFY_DISCORD_WEBHOOK_URL`, `NOTIFY_PUSHOVER_TOKEN`, `NOTIFY_PUSHOVER_USER` |
+
+## Symfony / app
+
+| Variable             | Défaut       | Description                                                                                                   |
+|----------------------|--------------|---------------------------------------------------------------------------------------------------------------|
+| `APP_SECRET`         | (obligatoire)| Secret Symfony (32 caractères hex). Générer avec `openssl rand -hex 32`.                                      |
+| `APP_ENV`            | `prod`       | `prod` / `dev` / `test`. Met l'app en mode debug + erreurs verbeuses en `dev`.                                |
+| `APP_MODE`           | `web`        | `web` = serveur FrankenPHP exposé sur le port 8080. `cli` = exécution one-shot d'une commande Symfony.        |
+| `APP_TIMEZONE`       | `UTC`        | Fuseau d'affichage appliqué à PHP **et** au filtre Twig `\|date`. Les timestamps restent stockés en UTC.      |
+| `APP_VERSION`        | `dev`        | Suffixe affiché dans le `<title>` (ex. `Dashboard - Navidrome Tools 0.1.0`). Bake automatique côté CI.        |
+| `APP_AUTH_USER`      | (obligatoire)| Identifiant pour se connecter à l'UI du tool. Un seul utilisateur supporté.                                   |
+| `APP_AUTH_PASSWORD`  | (obligatoire)| Mot de passe associé (hashé en mémoire au boot, jamais persisté).                                             |
+| `DATABASE_URL`       | (sqlite var/)| DSN Doctrine pour la DB locale du tool. Défaut : SQLite dans `var/data.db`.                                   |
+| `DEFAULT_URI`        | `http://localhost` | Base URL utilisée pour générer des URLs hors contexte HTTP (ex. liens dans les notifs, exports M3U).    |
+
+> `APP_VERSION` est normalement bakée au build Docker via
+> `ARG APP_VERSION` (la CI passe le tag git sur un push tagué, ou
+> `<branch>-<sha7>` sinon). Ne l'override en compose que si vous
+> rebuildez localement.
+
+## Source Navidrome
+
+Toutes obligatoires : ce sont les credentials qui permettent au tool
+de lire la lib Navidrome (côté SQLite **et** côté API Subsonic).
+
+| Variable             | Défaut             | Description                                                                                            |
+|----------------------|--------------------|--------------------------------------------------------------------------------------------------------|
+| `NAVIDROME_DB_PATH`  | `/data/navidrome.db` (compose) | Chemin du fichier SQLite Navidrome **dans le conteneur**. À bind-mounter `:ro` en prod sauf si vous utilisez `app:lastfm:process` / `rematch` (qui écrivent dans `scrobbles`). |
+| `NAVIDROME_URL`      | `http://navidrome:4533` | URL HTTP(S) de Navidrome (sans slash final). Utilisée pour l'API Subsonic.                       |
+| `NAVIDROME_USER`     | `admin`            | Utilisateur Navidrome dont on lit les écoutes (filtrage de `scrobbles.user_id`) et qui possède les playlists créées par le tool. |
+| `NAVIDROME_PASSWORD` | (obligatoire)      | Mot de passe Navidrome correspondant.                                                                  |
+
+## Pilotage du conteneur Navidrome
+
+Activé si `NAVIDROME_CONTAINER_NAME` est non vide. Permet : card
+dashboard avec boutons Start/Stop, pré-flight automatique sur les
+commandes qui écrivent dans Navidrome, et `--auto-stop` pour les
+runs cron unattended. Requiert le mount `/var/run/docker.sock` dans
+le conteneur `navidrome-tools-web`.
+
+| Variable                                | Défaut | Description                                                                                                |
+|-----------------------------------------|--------|------------------------------------------------------------------------------------------------------------|
+| `NAVIDROME_CONTAINER_NAME`              | (vide) | Nom (ou ID) du conteneur Navidrome dans la stack compose. Vide = feature désactivée.                       |
+| `NAVIDROME_STOP_TIMEOUT_SECONDS`        | `60`   | Fenêtre passée à `docker stop -t` lors d'un `--auto-stop`. Doit excéder le checkpoint WAL SQLite — le défaut Docker (10s) peut SIGKILL en plein flush et corrompre `navidrome.db` (#118). |
+| `NAVIDROME_STOP_WAIT_CEILING_SECONDS`   | `30`   | Après `docker stop`, polling de `docker inspect` jusqu'à `Running=false`, plafonné à cette durée. Ceinture-bretelles contre un SIGTERM handler qui traîne. |
+| `NAVIDROME_DB_BACKUP_RETENTION`         | `3`    | Nombre de snapshots `<dbPath>.backup-<unix_ts>` conservés. Avant chaque action `--auto-stop`, la DB SQLite (+ siblings `-wal`/`-shm`) est copiée — un `cp` rétablit l'état antérieur. `0` = pas de purge. |
+
+## Last.fm
+
+Tout vide par défaut — l'intégration Last.fm (import des scrobbles,
+sync loved↔starred) reste dispo via formulaire, mais l'API key
+devra alors être saisie à chaque appel.
+
+| Variable                       | Défaut | Description                                                                                                                                       |
+|--------------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `LASTFM_API_KEY`               | (vide) | API key publique. Création gratuite : <https://www.last.fm/api/account/create>. Fallback pour `/lastfm/import` et `app:lastfm:import` quand non passée explicitement. |
+| `LASTFM_API_SECRET`            | (vide) | API secret (même page). **Requis** pour `/lastfm/connect` et la sync loved↔starred (signature `auth.getSession` / `track.love`).                  |
+| `LASTFM_USER`                  | (vide) | Username pré-rempli dans le formulaire `/lastfm/import` et utilisé comme fallback CLI.                                                            |
+| `LASTFM_PAGE_DELAY_SECONDS`    | `10`   | Pause entre deux pages consécutives de `user.getRecentTracks`. `0` désactive la pause (déconseillé sur de gros historiques).                       |
+| `LASTFM_FUZZY_MAX_DISTANCE`    | `0`    | Distance Levenshtein max pour le fallback fuzzy de matching (artiste + titre). `0` = désactivé. **`2` recommandé pour les imports one-shot** (rattrape les typos sans excès de faux-positifs). Coûteux : O(N) par scrobble unmatched. |
+| `LASTFM_MATCH_CACHE_TTL_DAYS`  | `30`   | TTL (jours) des entrées **négatives** du cache de résolution `lastfm_match_cache`. Les positives sont éternelles (invalidées par les mutations d'alias). `0` = ne purge jamais (purge manuelle via `app:lastfm:cache:clear`). |
+
+## Lidarr
+
+Vide = bouton « + Lidarr » masqué partout. Voir
+[`LIDARR.md`](LIDARR.md) pour le workflow.
+
+| Variable                     | Défaut   | Description                                                                                                 |
+|------------------------------|----------|-------------------------------------------------------------------------------------------------------------|
+| `LIDARR_URL`                 | (vide)   | Base URL de Lidarr (ex. `http://lidarr:8686`). Vide = intégration off.                                       |
+| `LIDARR_API_KEY`             | (vide)   | API key Lidarr (`Settings → General → Security`).                                                           |
+| `LIDARR_ROOT_FOLDER_PATH`    | `/music` | Chemin où Lidarr place les nouveaux artistes (doit exister dans Lidarr).                                    |
+| `LIDARR_QUALITY_PROFILE_ID`  | `1`      | Id d'un Quality Profile Lidarr existant.                                                                    |
+| `LIDARR_METADATA_PROFILE_ID` | `1`      | Id d'un Metadata Profile Lidarr existant.                                                                   |
+| `LIDARR_MONITOR`             | `all`    | Stratégie de monitoring d'album : `all`, `future`, `missing`, `existing`, `first`, `latest`, `none`.        |
+
+## Historique des runs
+
+| Variable                       | Défaut | Description                                                                                                                            |
+|--------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `RUN_HISTORY_RETENTION_DAYS`   | `90`   | Rétention des lignes de la table `run_history`. La commande `app:history:purge` supprime les rows plus vieilles. Voir [`CRON.md`](CRON.md). |
+
+## Cover art
+
+| Variable             | Défaut         | Description                                                                                                                |
+|----------------------|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| `COVERS_CACHE_PATH`  | `/app/var/covers` | Cache disque des miniatures album/artiste, alimenté par le proxy `/cover/*`. En prod, monter un volume Docker dédié.    |
+
+## Queue beets
+
+| Variable             | Défaut | Description                                                                                                                |
+|----------------------|--------|----------------------------------------------------------------------------------------------------------------------------|
+| `BEETS_QUEUE_PATH`   | (vide) | Chemin (côté conteneur) d'un fichier dans lequel l'app appendit les chemins absolus des tracks à tagger via `/tagging/missing-mbid`. Vide = bouton « Pousser dans la queue beets » masqué. Voir [`TAGGING.md`](TAGGING.md#queue-beets-intégration-semi-automatique). |
+
+## Widget Homepage (gethomepage.dev)
+
+| Variable             | Défaut | Description                                                                                                                |
+|----------------------|--------|----------------------------------------------------------------------------------------------------------------------------|
+| `HOMEPAGE_API_TOKEN` | (vide) | Bearer token consommé par `/api/status` pour le mode **enrichi** (compteurs, dernier run, statut conteneur). Vide = seul le mode healthcheck no-auth est servi. Générer avec `openssl rand -hex 32`. Voir [`HOMEPAGE.md`](HOMEPAGE.md). |
+
+## Notifications
+
+Greffe `App\Notifier\Notifier` sur `RunHistoryRecorder` — pousse une
+notification à chaque fin de run cron. Vide partout = feature
+désactivée. Voir [`NOTIFICATIONS.md`](NOTIFICATIONS.md) pour le détail
+des drivers et la page de test sur `/settings`.
+
+| Variable                       | Défaut  | Description                                                                                                       |
+|--------------------------------|---------|-------------------------------------------------------------------------------------------------------------------|
+| `NOTIFY_DRIVERS`               | (vide)  | CSV des canaux actifs : `gotify`, `slack`, `discord`, `pushover`. Plusieurs valeurs autorisées (broadcast).        |
+| `NOTIFY_ON`                    | `error` | `error` (échecs seulement) ou `all` (succès aussi).                                                               |
+| `NOTIFY_GOTIFY_URL`            | (vide)  | URL de base de votre instance Gotify (ex. `https://gotify.example.com`).                                          |
+| `NOTIFY_GOTIFY_TOKEN`          | (vide)  | Application token Gotify.                                                                                         |
+| `NOTIFY_GOTIFY_PRIORITY`       | `5`     | Priorité par défaut (1..10). Bumpée à au moins 8 sur erreur.                                                      |
+| `NOTIFY_SLACK_WEBHOOK_URL`     | (vide)  | Webhook incoming Slack (Apps → Incoming Webhooks).                                                                |
+| `NOTIFY_DISCORD_WEBHOOK_URL`   | (vide)  | Webhook channel Discord (Server Settings → Integrations → Webhooks). Content tronqué à 1900 chars (cap Discord 2000). |
+| `NOTIFY_PUSHOVER_TOKEN`        | (vide)  | Application token Pushover.                                                                                       |
+| `NOTIFY_PUSHOVER_USER`         | (vide)  | User ou group key Pushover.                                                                                       |
+
+## Vérifier la configuration
+
+Une fois le conteneur démarré, l'UI expose plusieurs sondes :
+
+- `/api/status` (no-auth) — code HTTP 200 si la DB Navidrome est
+  accessible et la DB locale du tool migrée, sinon 503. Pratique en
+  `healthcheck` Docker.
+- `/api/status?token=…` (mode enrichi) — payload JSON avec compteurs
+  + dernier run + statut conteneur Navidrome. Utile pour valider
+  l'auth Homepage et l'observabilité.
+- Card « Conteneur Navidrome » sur le dashboard si
+  `NAVIDROME_CONTAINER_NAME` est renseigné (UP/DOWN + boutons).
+
+## Ajouter une nouvelle variable
+
+Pour rester cohérent avec le reste du code, toute nouvelle variable
+doit être déclarée dans **les cinq endroits** listés en haut, plus
+dans `config/services.yaml` (sous `parameters:`) si elle est
+consommée par un service via `%env(...)%`. Cf. [`CLAUDE.md`](../CLAUDE.md#9-quand-tu-fais-évoluer-ce-projet)
+pour la checklist complète.

--- a/docs/HOMEPAGE.md
+++ b/docs/HOMEPAGE.md
@@ -1,0 +1,100 @@
+# Widget Homepage (gethomepage.dev)
+
+Endpoint JSON `/api/status` consommable par le widget
+[Custom API](https://gethomepage.dev/widgets/services/customapi/) de
+[Homepage](https://gethomepage.dev/). Sert aussi de healthcheck Docker.
+
+## Deux modes d'accès
+
+| Sans token (no-auth)                                     | Avec token (`HOMEPAGE_API_TOKEN`)                                  |
+|----------------------------------------------------------|--------------------------------------------------------------------|
+| `GET /api/status`                                        | `GET /api/status?token=…` ou `Authorization: Bearer …`             |
+| Payload minimal `{status, navidrome_db}`                 | Payload enrichi : compteurs, dernier run, statut conteneur         |
+| Codes HTTP 200 (ok) / 503 (degraded) — Docker friendly   | Code HTTP 200 ; 401 si token erroné, 404 si feature désactivée     |
+
+Le mode no-auth reste toujours dispo : c'est ce qui permet de l'utiliser
+comme `healthcheck` Docker sans exposer de secret. Le mode enrichi est
+opt-in via `HOMEPAGE_API_TOKEN`.
+
+## Activer le mode enrichi
+
+Générer un token et l'injecter dans l'environnement du conteneur :
+
+```bash
+openssl rand -hex 32       # copier dans HOMEPAGE_API_TOKEN
+```
+
+Puis configurer le widget Homepage (`services.yaml`) :
+
+```yaml
+- Navidrome Tools:
+    icon: navidrome.png
+    href: https://navidrome-tools.example.com
+    widget:
+      type: customapi
+      url: https://navidrome-tools.example.com/api/status?token={{HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}}
+      refreshInterval: 60000
+      mappings:
+        - field: scrobbles_total
+          label: Scrobbles
+          format: number
+        - field: unmatched_total
+          label: Unmatched
+          format: number
+        - field: { last_run: status }
+          label: Dernier run
+        - field: { last_run: started_at }
+          label: À
+          format: relativeDate
+```
+
+Et déclarer la variable Homepage côté docker-compose :
+
+```yaml
+environment:
+  HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN: ${HOMEPAGE_VAR_NAVIDROME_TOOLS_TOKEN}
+```
+
+## Payload enrichi
+
+```json
+{
+  "status": "ok",
+  "navidrome_db": true,
+  "scrobbles_total": 142387,
+  "unmatched_total": 312,
+  "missing_mbid": 47,
+  "navidrome_container": "running",
+  "last_run": {
+    "type": "lastfm-import",
+    "reference": "me",
+    "label": "Last.fm import (me)",
+    "status": "success",
+    "started_at": "2026-05-03T08:00:01+00:00",
+    "finished_at": "2026-05-03T08:03:05+00:00",
+    "duration_ms": 184230
+  }
+}
+```
+
+- `status` — `ok` / `degraded`.
+- `navidrome_db` — booléen, accès à la SQLite Navidrome.
+- `navidrome_container` — enum `ContainerStatus` :
+  `disabled` / `running` / `stopped` / `notfound` / `unknown`.
+- `last_run` — null quand `run_history` est vide.
+
+## Healthcheck Docker
+
+Sans `HOMEPAGE_API_TOKEN`, l'endpoint reste un healthcheck pratique :
+
+```yaml
+healthcheck:
+  test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/status"]
+  interval: 30s
+  timeout: 5s
+  retries: 3
+```
+
+Le payload no-auth reste minimal (`{status, navidrome_db}`), donc
+aucune information sensible n'est exposée même si l'endpoint est
+joignable depuis l'extérieur.

--- a/docs/LASTFM.md
+++ b/docs/LASTFM.md
@@ -1,0 +1,302 @@
+# Last.fm — import, matching, rematch, alias, sync loved
+
+Toute l'intégration Last.fm : récupération de l'historique de
+scrobbles, matching sur la lib Navidrome, audit par-track, alias
+manuel & artiste, re-match a posteriori, et synchronisation
+loved ↔ starred.
+
+> Configuration : voir [`ENVIRONMENT.md`](ENVIRONMENT.md#lastfm).
+> Schedule cron : voir [`CRON.md`](CRON.md).
+
+## Workflow en deux étapes
+
+L'import Last.fm est **découplé** :
+
+1. **Récupération** (`app:lastfm:import` ou section 1 de
+   `/lastfm/import`) — lit l'historique via `user.getRecentTracks` et
+   stocke chaque scrobble dans `lastfm_import_buffer`. **Aucune
+   écriture côté Navidrome** : Navidrome peut tourner.
+2. **Traitement** (`app:lastfm:process` ou section 2 de
+   `/lastfm/import`) — draine le buffer : matching cascade,
+   insertion dans `scrobbles` côté Navidrome, audit dans
+   `lastfm_import_track`, suppression du buffer.
+   **Navidrome doit être arrêté** (écriture concurrente sur la SQLite
+   = risque de corruption du WAL).
+
+Cette séparation permet de fetcher régulièrement (cron léger,
+Navidrome up) puis de processer ponctuellement (manuel ou cron
+`--auto-stop`).
+
+## Via l'UI web
+
+`/lastfm/import` présente les deux étapes côte à côte. Le compteur du
+buffer (« N scrobbles en attente ») est aussi exposé sur le
+**dashboard** (card santé), avec un lien direct.
+
+### Section 1 — Récupérer depuis Last.fm
+
+- Identifiant Last.fm + API key. Tous deux peuvent venir de
+  l'environnement (`LASTFM_USER` pré-remplit, `LASTFM_API_KEY` est
+  utilisée si le champ est vide).
+- Filtres `date_min` / `date_max` optionnels (`YYYY-MM-DD`).
+- Limite de sécurité `max_scrobbles` (défaut 5 000) pour éviter les
+  timeouts HTTP.
+- Case **Dry-run** : parcourt l'API sans rien écrire dans le buffer
+  (utile pour valider la connectivité / l'API key).
+
+Le re-fetch d'une fenêtre déjà importée est **idempotent** : la
+contrainte unique sur `(lastfm_user, played_at, artist, title)`
+rejette les doublons et le rapport remonte un compteur
+`already_buffered`.
+
+### Section 2 — Traiter le buffer
+
+Affiche le compteur du buffer + l'état du conteneur Navidrome.
+Bouton « ▶ Traiter le buffer » dispo une fois Navidrome arrêté
+(pré-flight via `NavidromeContainerManager`). Redirige vers le détail
+du run `lastfm-process` qui liste l'audit par-track avec filtre par
+statut.
+
+## Via CLI
+
+```bash
+# Étape 1 — peut tourner Navidrome up
+php bin/console app:lastfm:import [<lastfm-user>] [--api-key=YOUR_KEY] \
+    [--date-min=YYYY-MM-DD] [--date-max=YYYY-MM-DD] \
+    [--dry-run] [--max-scrobbles=N]
+
+# Étape 2 — Navidrome doit être arrêté (ou --auto-stop)
+php bin/console app:lastfm:process [--dry-run] [--limit=N] \
+    [--tolerance=60] [--force] [--auto-stop]
+```
+
+Username et API key peuvent être omis si `LASTFM_USER` /
+`LASTFM_API_KEY` sont dans l'environnement.
+
+`--auto-stop` orchestre stop → process → restart de Navidrome
+(cf. [`CRON.md`](CRON.md#stop--start-automatique-de-navidrome)).
+
+## Cascade de matching
+
+Le matcher (`App\LastFm\ScrobbleMatcher`) essaie les paliers ci-dessous
+**dans l'ordre**, et s'arrête au premier match :
+
+0. **Alias manuel** (`lastfm_alias`) : si une entrée existe pour le
+   couple `(artist, title)` normalisé, elle court-circuite tout. Cible
+   vide = scrobble compté en `skipped` (utile pour les podcasts).
+0bis. **Cache de résolution** (`lastfm_match_cache`) : hit positif →
+   réponse immédiate ; hit négatif non-stale → unmatched immédiat
+   (on évite de re-frapper la lib + l'API). Les négatifs expirent au
+   bout de `LASTFM_MATCH_CACHE_TTL_DAYS` jours (défaut 30), purgés au
+   démarrage de chaque import / rematch. Les positifs sont éternels
+   et invalidés par les mutations d'alias.
+   CLI : `bin/console app:lastfm:cache:clear [--negative-only]`.
+1. **MusicBrainz ID** si Last.fm le fournit (le plus fiable).
+2. **Triplet** `(artist, title, album)` normalisé — départage les
+   morceaux qui existent sur plusieurs albums (single + version album
+   + compilation).
+3. **Couple** `(artist, title)` normalisé, avec tie-break
+   `album_artist = artist` puis `id ASC`. Inclut un fallback
+   « featuring asymétrique » : si le titre Last.fm contient un
+   marqueur `(feat. X)` mais que Navidrome stocke le featuring côté
+   artiste, retente avec `artist LIKE ':a feat %'` etc.
+4. **Last.fm `track.getInfo`** : si la cascade locale échoue,
+   interroge Last.fm pour (a) un MBID officiel quand le scrobble n'en
+   avait pas, (b) une graphie corrigée du couple via
+   `autocorrect=1`. Résultats positifs comme négatifs passent par le
+   cache → une seule frappe API par couple distinct.
+5. **Fallback fuzzy** Levenshtein artist+title, opt-in via
+   `LASTFM_FUZZY_MAX_DISTANCE`. **Recommandé pour les imports
+   one-shot** : `2` rattrape les typos type `Du riiechst so gut`
+   → `Du riechst so gut` ou `Tchaïkovski` → `Tchaikovsky` avec peu de
+   faux-positifs. Coûteux : O(N) par scrobble unmatched, à laisser à
+   `0` sur de très grosses libs en mode cron.
+
+**Normalisation utilisée** à toutes les étapes : lowercase + trim +
+décomposition Unicode NFKD + strip des diacritiques (Beyoncé ↔
+Beyonce) + strip de la ponctuation (AC/DC ↔ ACDC) + collapse des
+espaces. Les helpers `stripFeaturedArtists()` /
+`stripFeaturingFromTitle()` / `stripVersionMarkers()` retirent en plus
+les suffixes parasites côté Last.fm (`feat. X`, `(Radio Edit)`,
+`- Remastered 2011`, `(Live at …)`, `(Acoustic)`, etc.).
+
+## Déduplication
+
+Un scrobble n'est pas réinséré s'il existe déjà dans la table
+`scrobbles` Navidrome une ligne avec le même `media_file_id` et un
+`submission_time` à `±--tolerance` secondes (60 par défaut). Cela
+absorbe les petits décalages d'horloge entre clients de scrobble.
+
+## Pré-requis
+
+- **Navidrome ≥ 0.55** (table `scrobbles` requise — sinon
+  `app:lastfm:process` échoue avec un message explicite).
+- **Accès en écriture** sur la SQLite Navidrome pour
+  `app:lastfm:process` et `app:lastfm:rematch` uniquement. La phase
+  fetch n'a pas besoin d'écrire.
+
+## Backup automatique avant écriture
+
+Quand vous lancez `app:lastfm:process --auto-stop` ou
+`app:lastfm:rematch --auto-stop`, le tool snapshote `navidrome.db`
+(+ siblings `-wal` / `-shm`) en `<dbPath>.backup-<unix_ts>` **avant**
+d'écrire. Rétention configurable via `NAVIDROME_DB_BACKUP_RETENTION`
+(défaut 3). Restauration en une commande si quoi que ce soit tourne
+mal :
+
+```bash
+# Lister les backups (du plus récent au plus ancien)
+ls -lht /srv/navidrome/data/navidrome.db.backup-*
+
+# Rollback
+cp /srv/navidrome/data/navidrome.db.backup-<unix_ts> \
+   /srv/navidrome/data/navidrome.db
+docker compose start navidrome
+```
+
+Une commande aide à lister / restaurer :
+`php bin/console app:navidrome:db:restore [--list]`.
+
+## Alias manuels (track-level)
+
+Page **`/lastfm/aliases`** (menu Last.fm → Alias morceaux). Pour
+chaque alias :
+
+- **Source** : `(artiste, titre)` Last.fm.
+- **Cible** : `media_file_id` Navidrome (ou vide pour skip).
+
+Court-circuite la cascade dès le palier 0. Utile pour les morceaux
+mal taggés que vous ne pouvez pas (ou ne voulez pas) corriger côté
+audio.
+
+## Alias d'artiste
+
+Page **`/lastfm/artist-aliases`** (menu Last.fm → Alias artistes).
+Quand un artiste a été **renommé** (« La Ruda Salska » → « La Ruda »),
+ou existe sous plusieurs **variantes** (romanisations, conventions
+« The X » / « X, The »). Plutôt qu'un alias track par morceau, un seul
+alias `source → cible` couvre tout le catalogue.
+
+Le matcher consulte la table **après** l'alias track-level (qui garde
+la priorité absolue) mais **avant** la cascade MBID / triplet /
+couple : il réécrit le nom d'artiste dans le `LastFmScrobble` puis
+laisse les heuristiques habituelles tourner.
+
+Un bouton « 🎭 Aliaser artiste » apparaît sur `/lastfm/unmatched`
+pour créer rapidement un alias depuis un scrobble non matché. Lancer
+ensuite **« Re-tenter le matching cumulé »** (cf. plus bas) pour
+ré-essayer rétrospectivement tous les scrobbles concernés.
+
+## Liste cumulée des unmatched
+
+Page **`/lastfm/unmatched`** (menu Last.fm → Unmatched (titres)) :
+agrège tous les scrobbles non matchés de toutes les runs passées par
+`(artist, title, album)` avec compteur de scrobbles. Filtres en GET
+sur `artist`, `title`, `album` (substring case-insensitive), pagination
+50/page.
+
+Par ligne :
+
+- **✏️ Mapper** — ouvre le formulaire d'alias manuel pré-rempli.
+- **🎭 Aliaser artiste** — ouvre le formulaire d'alias d'artiste.
+- **+ Lidarr** — envoie l'artiste à Lidarr (si configuré).
+- Statut Lidarr (✓ déjà / ✗ absent / —) par ligne.
+
+Deux vues complémentaires reliées par une barre d'onglets en haut de
+chaque page :
+
+- **`/lastfm/unmatched/artists`** — agrège par artiste seul. Idéal
+  pour repérer les artistes complètement absents : un seul clic
+  « + Lidarr » couvre tous les morceaux manquants.
+- **`/lastfm/unmatched/albums`** — agrège par `(artist, album)`.
+  Lidarr ne supporte pas l'ajout d'un album hors contexte artiste :
+  le bouton « + Lidarr » ajoute donc l'artiste de l'album ; le
+  téléchargement dépend de la stratégie de monitoring Lidarr
+  (`LIDARR_MONITOR`).
+
+## Re-match des unmatched
+
+Quand on ajoute des morceaux à Navidrome après un import (ou qu'on
+déploie une nouvelle heuristique de matching), les scrobbles déjà
+marqués `unmatched` dans `lastfm_import_track` peuvent être ré-essayés
+**sans retélécharger** l'historique Last.fm. La cascade courante
+(alias → MBID → triplet → couple 4-paliers → fuzzy) est ré-appliquée
+et les scrobbles trouvés sont insérés dans Navidrome (idempotent :
+`scrobbleExistsNear` évite les doublons).
+
+### CLI
+
+```bash
+php bin/console app:lastfm:rematch [--dry-run] [--run-id=N] \
+    [--limit=N] [--random] [--force] [--auto-stop]
+```
+
+- `--dry-run` : compte sans écrire.
+- `--run-id=N` : limite au run #N.
+- `--limit=0` (défaut) = pas de limite.
+- `--random` : mélange l'ordre avant d'appliquer `--limit` (utile
+  pour échantillonner un sous-ensemble — sinon on retraite toujours
+  les mêmes morceaux en tête de table).
+
+### Web
+
+- Sur `/history/{id}` d'un run `lastfm-process` (ou `lastfm-import`
+  legacy) : bouton « 🔁 Re-tenter le matching de ce run » si le run a
+  au moins 1 unmatched.
+- Sur `/lastfm/import` : carte « Re-tenter le matching cumulé » avec
+  le compteur global d'unmatched et un bouton de re-match global.
+
+⚠️ Navidrome doit être arrêté pendant le rematch (mêmes contraintes
+que `app:lastfm:process` : écriture dans la table `scrobbles`).
+
+## Connexion Last.fm authentifiée
+
+Certaines actions Last.fm — notamment la sync loved ↔ starred — exigent
+une **session authentifiée**, pas juste l'API key publique utilisée
+par l'import.
+
+1. Récupérer la **API secret** sur la même page que la API key et la
+   configurer dans l'environnement :
+   ```env
+   LASTFM_API_KEY=votre-api-key
+   LASTFM_API_SECRET=votre-api-secret
+   ```
+2. Se connecter à Navidrome Tools puis aller sur `/lastfm/connect` :
+   l'app redirige vers Last.fm pour consentement, puis renvoie sur
+   `/settings` avec une session persistée localement (table `setting`,
+   clés `lastfm.session_key` / `lastfm.session_user`).
+3. `/settings` affiche un badge ✓/✗ et un bouton « Déconnecter » pour
+   révoquer la session locale (la révocation côté Last.fm se fait sur
+   <https://www.last.fm/settings/applications>).
+
+L'**URL de callback** est construite automatiquement à partir de
+l'URL publique de votre instance. En prod, votre déploiement Docker
+doit donc être derrière un domaine résolvable par Last.fm (HTTPS
+recommandé).
+
+## Sync loved ↔ starred
+
+Une fois la connexion authentifiée faite, la page `/lastfm/love-sync`
+propage les ajouts dans les deux sens entre les morceaux ❤ Last.fm
+et les morceaux ★ Navidrome :
+
+- **lf → nd** : un morceau loved sur Last.fm est starré dans Navidrome
+  (s'il est résolu via MBID, alias manuel ou couple `(artist, title)`).
+- **nd → lf** : un morceau starred dans Navidrome est loved sur Last.fm.
+- **adds-only** : la v1 ne déstarre / délove jamais — la propagation
+  des suppressions est tracée dans une issue séparée.
+
+Idempotente : un re-run immédiat ne fait rien tant que les deux
+ensembles sont alignés.
+
+### CLI
+
+```bash
+php bin/console app:lastfm:sync-loved [--direction=both|lf-to-nd|nd-to-lf] [--dry-run]
+```
+
+### Loved sans match
+
+Les morceaux loved Last.fm sans correspondance dans la lib Navidrome
+apparaissent dans le rapport avec un bouton « ✏️ Mapper » qui
+pré-remplit le formulaire d'alias manuel `/lastfm/aliases/new`.

--- a/docs/LIDARR.md
+++ b/docs/LIDARR.md
@@ -1,0 +1,67 @@
+# Intégration Lidarr
+
+Boutons « + Lidarr » contextuels pour pousser un artiste manquant à
+[Lidarr](https://lidarr.audio/) en un clic, partout où un scrobble
+unmatched est listé.
+
+## Configuration
+
+Voir [`ENVIRONMENT.md`](ENVIRONMENT.md#lidarr) pour la liste complète
+des variables. Vide = bouton masqué proprement (intégration off).
+
+Minimum requis :
+
+```env
+LIDARR_URL=http://lidarr:8686
+LIDARR_API_KEY=...                # Lidarr → Settings → General → Security
+LIDARR_ROOT_FOLDER_PATH=/music    # doit exister côté Lidarr
+LIDARR_QUALITY_PROFILE_ID=1       # id d'un Quality Profile existant
+LIDARR_METADATA_PROFILE_ID=1      # id d'un Metadata Profile existant
+LIDARR_MONITOR=all                # all|future|missing|existing|first|latest|none
+```
+
+## Où apparaît le bouton
+
+- **`/lastfm/unmatched`** (titres, artistes, albums — les trois vues).
+- **`/lastfm/love-sync`** dans la section « Loved sans match ».
+- **`/lastfm/import` → détail run** dans le tableau par-track des
+  unmatched.
+
+Par ligne, le tool affiche aussi :
+
+- **Last.fm ↗** — lien vers la page artiste publique sur Last.fm.
+- **Navidrome ↗** — si l'artiste existe déjà dans Navidrome (lookup
+  par nom normalisé), lien direct vers sa fiche dans l'app Navidrome.
+- **Statut Lidarr** — ✓ déjà / ✗ absent / — (intégration off),
+  pré-calculé pour la page entière via
+  `LidarrClient::indexExistingArtists()`.
+
+## Fonctionnement
+
+Au clic sur **+ Lidarr**, le service `AddArtistToLidarrService` :
+
+1. Cherche l'artiste sur MusicBrainz via l'endpoint Lidarr
+   `/api/v1/artist/lookup` (l'API key Lidarr permet d'éviter les
+   rate-limits MB).
+2. Prend le premier hit (Lidarr ordonne par pertinence) et POST
+   `/api/v1/artist` en demandant `searchForMissingAlbums: true`.
+3. Si Lidarr répond que l'artiste existe déjà
+   (`LidarrConflictException`), l'UI affiche un flash info
+   « déjà présent » au lieu d'une erreur.
+
+Tous les paramètres sont configurés une fois pour toutes via les env
+vars — pas d'UI de configuration côté tool.
+
+## Cas particulier : « ajouter par album »
+
+Lidarr ne supporte pas l'ajout d'un album hors contexte d'un artiste
+existant. Quand vous cliquez « + Lidarr » sur une ligne de
+`/lastfm/unmatched/albums`, le tool ajoute donc **l'artiste** de
+l'album ; le téléchargement effectif de cet album dépend de la
+stratégie de monitoring Lidarr (`LIDARR_MONITOR`) :
+
+- `all` — tous les albums de l'artiste seront monitorés (par défaut).
+- `missing` — seulement les albums absents du disque.
+- `first` / `latest` — premier ou dernier album seulement.
+- `none` — l'artiste est ajouté sans rien monitorer (vous activez à la
+  main dans Lidarr).

--- a/docs/NOTIFICATIONS.md
+++ b/docs/NOTIFICATIONS.md
@@ -1,0 +1,97 @@
+# Notifications de fin de run
+
+À chaque fin de traitement enveloppé par `RunHistoryRecorder` (backup
+DB Navidrome, fetch Last.fm, process buffer, rematch, sync loved,
+compute stats, purge history…), l'app peut pousser une notification
+vers un ou plusieurs canaux. Le payload inclut le type du run, le
+label humain, le status (`success` / `error`), la durée, les
+métriques et, en cas d'échec, le message d'erreur tronqué.
+
+> Configuration : voir [`ENVIRONMENT.md`](ENVIRONMENT.md) (variables
+> `NOTIFY_*`).
+> Page de test sur `/settings`.
+
+## Canaux supportés
+
+- **Gotify** — instance self-hosted, POST sur `${URL}/message?token=…`.
+- **Slack** — webhook incoming (`https://hooks.slack.com/services/…`).
+- **Discord** — webhook channel (Server Settings → Integrations).
+- **Pushover** — token applicatif + user/group key
+  ([pushover.net](https://pushover.net/)).
+
+CSV dans `NOTIFY_DRIVERS` pour activer plusieurs canaux en broadcast
+(ex. `gotify,slack`).
+
+## Filtre `NOTIFY_ON`
+
+- `error` (défaut) — n'envoie que les échecs (status `error` sur le
+  `RunHistory`).
+- `all` — notifie aussi les succès. Utile pour valider un nouveau
+  pipeline d'observabilité ou suivre les durées d'un job en
+  production ; déconseillé sur un cron qui tourne toutes les 15 min
+  (spam).
+
+## Tester depuis l'UI
+
+La page **`/settings`** expose une card « Notifications » qui :
+
+- liste chaque driver enregistré avec un ✓/— pour « listé dans
+  `NOTIFY_DRIVERS` » et « configuré (credentials OK) » ;
+- affiche le filtre `NOTIFY_ON` courant ;
+- propose deux boutons « Envoyer un test (succès) » / « Envoyer un
+  test (erreur) » qui dispatchent immédiatement en **bypassant**
+  `NOTIFY_ON` (sinon le test « succès » ne partirait pas quand le
+  filtre vaut `error`) ;
+- remonte en flash multi-types le détail par driver (`sent`,
+  `skipped:not-listed`, `skipped:not-configured`, `error:<message>`)
+  — pratique pour repérer un canal mal configuré sans aller fouiller
+  les logs.
+
+## Isolation des drivers
+
+L'orchestrateur catche chaque appel à `send()` : une erreur de
+transport sur un canal est loggée via PSR-3 mais n'empêche pas les
+autres canaux de partir, **et n'interrompt jamais le job lui-même**.
+Un cron casse-cou peut quand même se brancher sur Pushover sans
+risquer d'aborter un import Last.fm si Pushover répond 502.
+
+## Étendre — ajouter un nouveau canal
+
+Créer une classe dans `src/Notifier/Driver/` qui implémente
+`App\Notifier\NotifierDriverInterface` :
+
+```php
+public function getName(): string;        // 'ntfy', 'telegram', …
+public function isConfigured(): bool;     // crédits présents ?
+public function send(Notification $n): void;
+```
+
+Le `_instanceof` dans `config/services.yaml` la tag automatiquement
+`app.notifier_driver`, donc il suffit de :
+
+1. Déclarer les paramètres de configuration du driver dans
+   `services.yaml` (URL, token, etc.) ;
+2. Ajouter les env vars correspondantes dans
+   [les 5 endroits habituels](ENVIRONMENT.md#ajouter-une-nouvelle-variable) ;
+3. L'activer en l'ajoutant à `NOTIFY_DRIVERS`.
+
+Aucun changement nécessaire dans `RunHistoryRecorder` ou
+`Notifier::notify()` — le tag fait le reste.
+
+## Payload envoyé
+
+Pour chaque driver, le `Notification` DTO expose :
+
+- `type` — type du run (`lastfm-fetch`, `lastfm-process`, `playlist`,
+  `stats`, …).
+- `label` — libellé humain (ex. `Last.fm fetch — me`).
+- `status` — `success` / `error`.
+- `durationMs` — durée du job, formatée en `1m15s` / `750ms` / `2.5s`.
+- `errorMessage` — null sur succès, message d'erreur tronqué à 500
+  caractères sur échec.
+- `metrics` — paires clé-valeur (ex. `considered=100 inserted=42`).
+- `runId` — id du `RunHistory`, peut servir à construire un deep link
+  vers `/history/{id}` dans un driver custom.
+
+Le titre généré (`title()`) préfixe par `[OK]` ou `[ERROR]` selon le
+status — facile à filtrer côté side rules Slack ou Gotify.

--- a/docs/PLAYLISTS.md
+++ b/docs/PLAYLISTS.md
@@ -1,0 +1,107 @@
+# Playlists — création et gestion
+
+Tout ce qui touche aux playlists Navidrome : génération depuis une
+définition, gestion des playlists existantes, schéma Navidrome lu en
+arrière-plan.
+
+## Création de playlists
+
+Toutes les playlists sont créées via l'**API Subsonic** de Navidrome
+(`createPlaylist.view`). Le tool **n'écrit jamais directement** dans la
+SQLite Navidrome pour cette opération. Avantages :
+
+- aucun risque de corruption ou de conflit de lock,
+- fonctionne même si Navidrome tourne en parallèle,
+- la DB Navidrome peut rester montée `:ro` côté tool.
+
+L'option « remplacer la playlist existante » utilise
+`getPlaylists.view` + `deletePlaylist.view` pour retirer l'ancienne du
+même nom appartenant au même utilisateur, puis recrée la nouvelle.
+
+## Définitions de playlist
+
+Une **définition** = ligne dans `playlist_definition` (DB locale du
+tool) qui combine :
+
+- un **générateur** (= un plugin PHP, cf. [`PLUGINS.md`](PLUGINS.md)),
+- des **paramètres** (stockés en JSON, schéma défini par le générateur),
+- un **modèle de nom** (`{date}`, `{month}`, `{year}`, `{label}`,
+  `{name}`, `{preset}`, `{param:nom}`),
+- une **limite** (nombre de morceaux),
+- un **flag activé / désactivé**.
+
+8 générateurs livrés out-of-the-box : `top-last-days`,
+`top-last-month`, `top-last-year`, `top-all-time`, `never-played`,
+`top-month-yago`, `top-years-ago`, `songs-you-used-to-love` (high
+`play_count` + dernier play > N mois).
+
+## Preview avant publication
+
+La page `/playlist/{id}/preview` montre la liste résultante avant
+toute écriture côté Navidrome :
+
+- compteur de tracks générés,
+- colonnes : titre, artiste, album, durée, play count **sur la fenêtre
+  du générateur** (pas le lifetime),
+- bouton « Exporter M3U » pour récupérer la liste avant même de la
+  créer côté Navidrome,
+- bouton « Publier dans Navidrome » qui appelle Subsonic
+  `createPlaylist`.
+
+La colonne « Plays » reflète bien la fenêtre temporelle déclarée par
+le générateur (`PlaylistGeneratorInterface::getActiveWindow()`),
+consommée par `NavidromeRepository::summarize($ids, $from, $to)`.
+
+## Gestion des playlists existantes
+
+Page **`/playlists`** (lien « Playlists » dans la nav) : liste toutes
+les playlists Navidrome avec leurs métadonnées (nombre de morceaux,
+durée, dates création/modification, owner, public/privé). Cases à
+cocher + bouton « Supprimer la sélection » pour la suppression en
+masse. Bouton « M3U » par ligne pour télécharger la playlist au format
+M3U Extended (lisible par VLC / mpv / foobar2000).
+
+Page détail **`/playlists/{id}`** : affiche le contenu (titre,
+artiste, album, durée, play count, statut starred ★) et permet :
+
+- **Renommer** la playlist (`updatePlaylist.view`).
+- **Dupliquer** la playlist sous le nom `X (copie)`.
+- **Supprimer** la playlist (avec nettoyage automatique du
+  `lastSubsonicPlaylistId` des `PlaylistDefinition` rattachées).
+- **Star / unstar individuel** d'un morceau (icône ★/☆).
+- **Bulk star / unstar** : « ★ Tout starrer » / « ☆ Tout dé-starrer »,
+  un seul appel API.
+- **Retirer un morceau** de la playlist (`updatePlaylist.view` avec
+  `songIndexToRemove`).
+- **Détecter les morceaux morts** (présents dans la playlist mais
+  absents de `media_file`) et les purger en un clic.
+- **Statistiques** : durée totale, nombre starré, % jamais joués, top
+  10 artistes, top 10 albums, distribution par année (mini bar chart).
+- **Exporter en M3U**.
+
+Toutes les écritures passent par l'API Subsonic — aucune écriture
+directe dans la DB Navidrome (qui peut donc rester montée `:ro`).
+
+## Schéma Navidrome utilisé (lecture seule)
+
+| Table          | Colonnes lues                                                |
+|----------------|--------------------------------------------------------------|
+| `media_file`   | id, title, album, artist, album_artist, duration, year       |
+| `annotation`   | user_id, item_id, item_type, play_count, play_date           |
+| `user`         | id, user_name (résolution `NAVIDROME_USER` → user_id Subsonic) |
+| `scrobbles`    | media_file_id, user_id, submission_time (Navidrome ≥ 0.55)   |
+
+Si la table `scrobbles` n'existe pas, le tool retombe sur
+`annotation.play_date`, qui ne contient que la date du **dernier**
+play. Les tops « par fenêtre temporelle » deviennent donc
+approximatifs ; un bandeau d'avertissement est affiché dans l'UI dans
+ce cas.
+
+### Pourquoi pas une migration Doctrine côté tool ?
+
+Le tool **ne touche jamais au schéma Navidrome**. La détection de la
+table `scrobbles` se fait à l'ouverture de la connexion DBAL via
+`mediaFileColumns()` / `hasScrobblesTable()`, sans rien créer. Le
+seul cas où le tool écrit dans la DB Navidrome est l'insertion de
+lignes dans `scrobbles` lors des imports / rematch Last.fm, et là on
+respecte strictement le schéma natif de Navidrome 0.55+.

--- a/docs/STATS.md
+++ b/docs/STATS.md
@@ -1,0 +1,111 @@
+# Statistiques d'écoute
+
+Sept pages stats accessibles via le menu déroulant **Statistiques**.
+Toutes les pages requièrent la table `scrobbles` Navidrome (≥ 0.55) et
+affichent un bandeau si elle n'est pas trouvée.
+
+| Route                          | Contenu                                                                                                  |
+|--------------------------------|----------------------------------------------------------------------------------------------------------|
+| `/stats`                       | Vue d'ensemble par période (7d / 30d / last-month / last-year / all-time), cachée dans `stats_snapshot`. |
+| `/stats/tops`                  | Tops sur fenêtre `[from, to]` arbitraire : 50 artistes / 100 albums / 500 morceaux, filtre par client.   |
+| `/stats/compare`               | Comparaison côte à côte de deux périodes : top artistes / morceaux fusionnés avec deltas.                |
+| `/stats/charts`                | Trois graphiques Chart.js : écoutes par mois, top 5 artistes au fil du temps, distribution par jour.     |
+| `/stats/heatmap`               | Deux heatmaps HTML/CSS : jour×heure (90 derniers jours) et année×jour façon GitHub contribs.             |
+| `/stats/lastfm-history`        | 100 derniers scrobbles cachés en local pour le user Last.fm (table `lastfm_history`).                    |
+| `/stats/navidrome-history`     | Pendant symétrique, snapshot des 100 derniers scrobbles côté Navidrome (table `navidrome_history`).      |
+| `/wrapped/{year}`              | Rétrospective annuelle façon Spotify Wrapped.                                                            |
+
+## /stats — Vue d'ensemble
+
+Pour chaque période (7d / 30d / last-month / last-year / all-time) :
+
+- total plays sur la fenêtre,
+- nombre de morceaux distincts joués,
+- top 10 artistes,
+- top 50 morceaux.
+
+Cachée dans la table `stats_snapshot` (une row par période × type).
+Refresh manuel via bouton sur la page, ou en cron via
+`app:stats:compute` (cf. [`CRON.md`](CRON.md)).
+
+## /stats/tops — Tops sur fenêtre arbitraire
+
+Date-picker `from` / `to` + filtre client (DSub / Symfonium / web /
+…). Cache dans `top_snapshot` keyé par `(window_from, window_to,
+client)`. Les bornes sont arrondies au jour côté contrôleur
+(`TopsService::normalizeWindow()`) pour réutiliser un snapshot entre
+clics rapprochés.
+
+**Bouton « + Créer playlist Navidrome »** sur le top morceaux :
+crée une playlist Navidrome via Subsonic `createPlaylist` avec les N
+premiers IDs (N borné à 500, configurable depuis l'UI). La création
+trace le run dans `/history` sous le type `playlist`.
+
+Refresh manuel via le bouton, ou en cron via
+`app:stats:tops:compute --from=… --to=… [--client=…]` (cf.
+[`CRON.md`](CRON.md)).
+
+## /stats/compare — Diff entre deux périodes
+
+Deux date-pickers (« période A » / « période B ») et un sélecteur
+de granularité (artistes / morceaux). Le tableau fusionne les deux
+tops par id (tracks) / nom (artists) et affiche pour chaque entrée :
+
+- les rangs de la période A et B,
+- un delta : `=` (rang inchangé), `↑N` (gain de N rangs), `↓N`
+  (perte), `nouveau` (présent en B seulement), `disparu` (en A
+  seulement).
+
+Implémenté par `StatsCompareService` — pas de cache, recalcul à
+chaque ouverture (rapide tant que les snapshots sont à jour).
+
+## /stats/charts — Graphiques Chart.js
+
+Trois charts :
+
+1. **Plays par mois** — bar chart sur les 24 derniers mois.
+2. **Top 5 artistes timeline** — line chart, courbe par artiste, mois
+   par mois.
+3. **Distribution jour de la semaine** — bar chart sur l'ensemble de
+   l'historique.
+
+Chart.js est chargé via CDN jsdelivr dans le block `stylesheets`.
+Pas de toolchain front, pas de bundle.
+
+## /stats/heatmap — Heatmaps HTML/CSS
+
+Deux heatmaps en pur CSS (pas de JS, pas de canvas) :
+
+- **Jour × heure** sur les 90 derniers jours — utile pour voir vos
+  habitudes d'écoute par tranche horaire.
+- **Année × jour** façon GitHub contribs, avec sélecteur d'année.
+
+## /wrapped/{year} — Rétrospective annuelle
+
+Cachée dans `stats_snapshot` (key `wrapped-<year>`). `WrappedService::compute()`
+agrège :
+
+- top 25 artistes + top 50 morceaux de l'année,
+- new artists (jamais écoutés avant cette année),
+- streak (plus long enchaînement de jours consécutifs avec au moins
+  un scrobble),
+- mois le plus actif,
+- durée totale estimée (extrapolation depuis la durée des top tracks),
+- compteur de morceaux distincts.
+
+Refresh manuel par le bouton sur la page.
+
+## /stats/lastfm-history & /stats/navidrome-history
+
+Deux pages symétriques qui snapshotent en local les 100 derniers
+scrobbles côté Last.fm (resp. côté Navidrome) :
+
+- **Last.fm history** (`lastfm_history`) : permet de jeter un œil aux
+  scrobbles récents sans rouvrir l'UI Last.fm. Refresh manuel via
+  bouton — frappe `user.getRecentTracks`.
+- **Navidrome history** (`navidrome_history`) : snapshot équivalent
+  côté `scrobbles` Navidrome, avec lien direct vers la fiche morceau
+  côté Navidrome pour chaque ligne.
+
+Aucune des deux pages n'est mise à jour automatiquement — c'est de la
+**capture sur demande**, pas un tableau live.

--- a/docs/TAGGING.md
+++ b/docs/TAGGING.md
@@ -1,0 +1,84 @@
+# Tagging — tracks sans MBID
+
+La page **`/tagging/missing-mbid`** (menu **Tagging**) liste les
+morceaux Navidrome dont les colonnes `mbz_track_id` ET
+`mbz_recording_id` sont vides. Sans MBID, le palier le plus fiable de
+la cascade de matching Last.fm est inutilisable, et l'outil retombe
+sur les paliers (artiste, titre, album) + fuzzy, plus fragiles.
+
+## Architecture read-only sur /music
+
+L'architecture est volontairement **read-only** : navidrome-tools
+**n'écrit jamais** dans vos fichiers audio. Le volume `/music` peut
+rester monté `:ro` côté tool. Le workflow est :
+
+1. **Audit** sur la page : filtres artiste/album, pagination, voir
+   les chemins absolus.
+2. **Export** vers un tagger externe (CSV ou queue beets).
+3. **Rescan Navidrome** une fois le tagging fini pour pousser les
+   nouveaux MBIDs dans `media_file.mbz_track_id`.
+
+## Workflow CSV
+
+Bouton **« ⬇ Export CSV »** : télécharge la liste des chemins
+filtrés (id, path, artist, album, title…) que vous piper dans un
+tagger sur la machine où le dossier de musique est en
+lecture/écriture.
+
+### Exemple avec beets
+
+```bash
+# extrait la colonne path et nourris beet
+tail -n +2 missing-mbid-2026-05-02.csv \
+  | awk -F'"' '{print $4}' \
+  | xargs -d '\n' beet import -A --quiet
+```
+
+### Exemple avec MusicBrainz Picard
+
+1. Ouvrir Picard.
+2. Drag-and-drop le dossier de musique entier (Picard tolère les
+   fichiers déjà taggés).
+3. Lancer **Scan**, puis **Save**.
+
+## Queue beets (intégration semi-automatique)
+
+Si vous préférez ne pas copier-coller le CSV à chaque fois,
+configurez `BEETS_QUEUE_PATH` (ex. `/shared/beets-queue.txt`). La page
+expose alors un bouton **« 📋 Pousser dans la queue beets »** qui
+appendit les chemins filtrés dans ce fichier sous `flock` (sûr en
+concurrence).
+
+Côté hôte beets, monter le même volume et lancer un cron qui consomme
+la queue :
+
+```bash
+# /etc/cron.d/beets-queue : toutes les 15 min
+*/15 * * * * beets   ( flock -x 9 ; \
+   [ -s /shared/beets-queue.txt ] || exit 0 ; \
+   mv /shared/beets-queue.txt /shared/beets-queue.processing ; \
+ ) 9>/shared/beets-queue.lock && \
+ beet import -A --quiet $(cat /shared/beets-queue.processing) && \
+ rm /shared/beets-queue.processing
+```
+
+Avec ce pattern, navidrome-tools ne touche **que** le fichier de
+queue (RW), `/music` reste `:ro`. Le push est tracé dans `/history`
+sous le type `beets-queue-push` et le bandeau de la page affiche la
+taille courante de la queue.
+
+## Rescan Navidrome
+
+Bouton **« ↻ Rescan Navidrome »** : déclenche `startScan` via
+Subsonic une fois le tagging fini. Les nouveaux MBIDs apparaissent
+dans `media_file.mbz_track_id` sans attendre le scan planifié. Logué
+dans `/history` sous le type `navidrome-rescan`.
+
+CLI équivalente : `php bin/console app:navidrome:rescan` (utilisable
+en cron si vous voulez forcer un rescan régulier — ex. après un push
+beets nocturne).
+
+## Card dashboard
+
+Le dashboard affiche un compteur **« Tracks sans MBID »** avec un
+raccourci vers la page. Passe en gris quand le compteur vaut 0.


### PR DESCRIPTION
## Summary

This PR reorganizes the README.md documentation by extracting detailed sections into dedicated markdown files in a new `docs/` folder, making the documentation more modular and maintainable while improving navigation.

## Key Changes

- **Extracted documentation sections** from README.md into dedicated files:
  - `docs/DOCKER.md` — Docker deployment and integration
  - `docs/ENVIRONMENT.md` — Complete environment variables reference
  - `docs/DEVELOPMENT.md` — Local development setup (Lando and native)
  - `docs/CRON.md` — Recurring jobs and run history
  - `docs/LASTFM.md` — Last.fm import, matching, rematch, alias, sync
  - `docs/STATS.md` — Statistics pages and features
  - `docs/PLAYLISTS.md` — Playlist creation and management
  - `docs/LIDARR.md` — Lidarr integration
  - `docs/TAGGING.md` — Missing MBID tagging workflow
  - `docs/HOMEPAGE.md` — Homepage widget integration

- **Restructured README.md**:
  - Simplified introduction with project rename note
  - Reorganized features into concise bullet points
  - Added documentation index table linking to all docs/
  - Kept only essential quickstart Docker instructions
  - Removed redundant environment variables table (moved to ENVIRONMENT.md)
  - Removed detailed cron examples (moved to CRON.md)
  - Removed development setup instructions (moved to DEVELOPMENT.md)

- **Updated cross-references**:
  - DOCKER.md now points to ENVIRONMENT.md instead of README.md
  - All docs link to each other appropriately
  - CLAUDE.md updated to reflect documentation structure

## Implementation Details

- Documentation is now organized by feature/topic rather than by format
- Each doc file is self-contained with its own context and cross-references
- The README.md serves as a landing page with feature overview and quickstart
- Detailed configuration, development, and operational guides are in dedicated files
- This structure makes it easier to maintain, update, and navigate documentation

https://claude.ai/code/session_01LpmStp5BEXFabXHkzJ2fAf