### PR TITLE
fix(ui): migrer Tailwind v3 Play CDN → @tailwindcss/browser v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ et le projet adhère à [Semantic Versioning 2.0](https://semver.org/lang/fr/).
 
 ## [Unreleased]
 
+### Fixed
+- **Styling de l'UI cassé en prod** : le Play CDN
+  `https://cdn.tailwindcss.com` (Tailwind v3) ne sert plus rien — la
+  page de login (et toutes les autres) s'affichait sans aucune utility
+  class, seuls les overrides du `<style>` inline du `base.html.twig`
+  s'appliquaient. Le `<script>` pointe désormais vers
+  `https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4` (Tailwind v4
+  officiel, qui remplace le Play CDN déprécié) et les utilities
+  renommées par v4 ont été propagées dans les templates :
+  `rounded` → `rounded-sm`, `rounded-sm` → `rounded-xs`,
+  `shadow` → `shadow-sm`, `flex-shrink-0` → `shrink-0`. L'override
+  inline `.shadow` du dark theme suit le rename
+  (`.shadow-sm { box-shadow: … }`).
+
 ### Added
 - **Notifications de fin de run (Gotify / Slack / Discord / Pushover)** :
   greffe optionnelle sur `RunHistoryRecorder` qui pushe une

--- a/templates/_macros/cover.html.twig
+++ b/templates/_macros/cover.html.twig
@@ -7,7 +7,7 @@
   Usage:
     {% from "_macros/cover.html.twig" import cover_with_fallback %}
     {{ cover_with_fallback('artist', row.artist_id, row.artist, 32) }}
-    {{ cover_with_fallback('album', row.album_id, row.album, 64, 'rounded') }}
+    {{ cover_with_fallback('album', row.album_id, row.album, 64, 'rounded-sm') }}
 #}
 
 {% macro cover_with_fallback(type, id, name, size = 128, classes = '') %}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -73,7 +73,7 @@
                                 aria-haspopup="true">
                             {{ section.label }} <span class="text-xs">▾</span>
                         </button>
-                        <div class="absolute right-0 top-full mt-1 {{ section.width }} bg-slate-800 text-slate-100 rounded shadow-lg invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition py-1 z-30">
+                        <div class="absolute right-0 top-full mt-1 {{ section.width }} bg-slate-800 text-slate-100 rounded-sm shadow-lg invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition py-1 z-30">
                             {% for group in section.groups %}
                                 {% if group.heading %}
                                     {% if not loop.first %}
@@ -99,10 +99,10 @@
             <div class="max-w-6xl mx-auto px-4 py-2 flex flex-col text-sm">
                 {% for section in sections %}
                     {% if section.type == 'link' %}
-                        <a href="{{ path(section.route) }}" class="block py-2 hover:bg-slate-800 px-2 rounded">{{ section.label }}</a>
+                        <a href="{{ path(section.route) }}" class="block py-2 hover:bg-slate-800 px-2 rounded-sm">{{ section.label }}</a>
                     {% else %}
                         <details class="group">
-                            <summary class="py-2 px-2 rounded hover:bg-slate-800 cursor-pointer flex items-center justify-between list-none">
+                            <summary class="py-2 px-2 rounded-sm hover:bg-slate-800 cursor-pointer flex items-center justify-between list-none">
                                 <span>{{ section.label }}</span>
                                 <span class="text-xs transition group-open:rotate-180">▾</span>
                             </summary>
@@ -112,7 +112,7 @@
                                         <div class="px-2 pt-2 pb-1 text-xs uppercase tracking-wide text-slate-400">{{ group.heading }}</div>
                                     {% endif %}
                                     {% for item in group.items %}
-                                        <a href="{{ path(item.route) }}" class="block py-2 px-2 rounded hover:bg-slate-800">{{ item.label }}</a>
+                                        <a href="{{ path(item.route) }}" class="block py-2 px-2 rounded-sm hover:bg-slate-800">{{ item.label }}</a>
                                     {% endfor %}
                                 {% endfor %}
                             </div>

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Accueil{% endblock %} - Navidrome Tools{% if app_version %} {{ app_version }}{% endif %}</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
     <style>
         /* Album/artist cover thumbnails — used by templates/_macros/cover.html.twig.
            Tailwind via CDN doesn't include these utility classes by default. */
@@ -78,8 +78,9 @@
         code { background-color: #0f172a !important; color: #f1f5f9 !important;
                padding: 1px 4px; border-radius: 3px; }
 
-        /* Shadow on dark needs a stronger contrast */
-        .shadow { box-shadow: 0 1px 3px 0 rgba(0,0,0,0.5), 0 1px 2px -1px rgba(0,0,0,0.5) !important; }
+        /* Shadow on dark needs a stronger contrast. Tailwind v4 renamed
+           `shadow` → `shadow-sm`, so target the new name. */
+        .shadow-sm { box-shadow: 0 1px 3px 0 rgba(0,0,0,0.5), 0 1px 2px -1px rgba(0,0,0,0.5) !important; }
     </style>
     {% block stylesheets %}{% endblock %}
 </head>
@@ -102,7 +103,7 @@
             {% if app.user %}
                 <button type="button"
                         id="burger-toggle"
-                        class="md:hidden inline-flex items-center justify-center w-10 h-10 rounded hover:bg-slate-800"
+                        class="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-sm hover:bg-slate-800"
                         aria-label="Ouvrir le menu"
                         aria-controls="mobile-nav"
                         aria-expanded="false">
@@ -124,7 +125,7 @@
     <main class="flex-1 max-w-6xl w-full mx-auto px-4 py-6">
         {% for type, messages in app.flashes %}
             {% for message in messages %}
-                <div class="mb-4 px-4 py-3 rounded border
+                <div class="mb-4 px-4 py-3 rounded-sm border
                     {% if type == 'success' %}bg-emerald-50 border-emerald-300 text-emerald-800
                     {% elseif type == 'error' %}bg-rose-50 border-rose-300 text-rose-800
                     {% else %}bg-sky-50 border-sky-300 text-sky-800{% endif %}">

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -11,17 +11,17 @@
                 modèle de nom : <code class="text-xs bg-slate-100 px-1">{{ default_template }}</code>
             </p>
         </div>
-        <a href="{{ path('app_playlist_new') }}" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded text-sm">
+        <a href="{{ path('app_playlist_new') }}" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-sm text-sm">
             + Nouvelle définition
         </a>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3 mb-6 text-sm">
-        <div class="rounded border p-3 {{ health.navidrome_db ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
+        <div class="rounded-sm border p-3 {{ health.navidrome_db ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
             <div class="font-medium">DB Navidrome</div>
             <div>{{ health.navidrome_db ? '✓ accessible' : '✗ inaccessible (vérifier NAVIDROME_DB_PATH)' }}</div>
         </div>
-        <div class="rounded border p-3 {{ health.has_scrobbles ? 'bg-emerald-50 border-emerald-300' : 'bg-amber-50 border-amber-300' }}">
+        <div class="rounded-sm border p-3 {{ health.has_scrobbles ? 'bg-emerald-50 border-emerald-300' : 'bg-amber-50 border-amber-300' }}">
             <div class="font-medium">Table <code>scrobbles</code></div>
             <div>
                 {% if health.has_scrobbles %}
@@ -32,7 +32,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="rounded border p-3 {{ health.subsonic ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
+        <div class="rounded-sm border p-3 {{ health.subsonic ? 'bg-emerald-50 border-emerald-300' : 'bg-rose-50 border-rose-300' }}">
             <div class="font-medium">API Subsonic</div>
             <div>{{ health.subsonic ? '✓ ping OK' : '✗ injoignable (vérifier NAVIDROME_URL/USER/PASSWORD)' }}</div>
         </div>
@@ -42,7 +42,7 @@
                 : ct == 'stopped' ? 'bg-slate-50 border-slate-300'
                 : ct == 'notfound' ? 'bg-rose-50 border-rose-300'
                 : 'bg-amber-50 border-amber-300' %}
-            <div class="rounded border p-3 {{ ct_classes }}">
+            <div class="rounded-sm border p-3 {{ ct_classes }}">
                 <div class="font-medium">Conteneur Navidrome</div>
                 <div class="flex items-center justify-between gap-2 mt-1">
                     <div>
@@ -61,12 +61,12 @@
                             <form method="post" action="{{ path('app_navidrome_container_stop') }}" class="inline"
                                   onsubmit="return confirm('Arrêter le conteneur Navidrome ?');">
                                 <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">
-                                <button type="submit" class="text-xs px-2 py-1 rounded bg-rose-600 hover:bg-rose-700 text-white">⏸ Stop</button>
+                                <button type="submit" class="text-xs px-2 py-1 rounded-sm bg-rose-600 hover:bg-rose-700 text-white">⏸ Stop</button>
                             </form>
                         {% elseif ct == 'stopped' or ct == 'notfound' %}
                             <form method="post" action="{{ path('app_navidrome_container_start') }}" class="inline">
                                 <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">
-                                <button type="submit" class="text-xs px-2 py-1 rounded bg-emerald-600 hover:bg-emerald-700 text-white">▶ Start</button>
+                                <button type="submit" class="text-xs px-2 py-1 rounded-sm bg-emerald-600 hover:bg-emerald-700 text-white">▶ Start</button>
                             </form>
                         {% else %}
                             <span class="text-xs text-amber-700" title="Vérifier le mount /var/run/docker.sock">socket KO</span>
@@ -75,7 +75,7 @@
                 </div>
             </div>
         {% endif %}
-        <div class="rounded border p-3 {% if health.missing_mbid_count is null %}bg-slate-50 border-slate-300{% elseif health.missing_mbid_count == 0 %}bg-emerald-50 border-emerald-300{% else %}bg-amber-50 border-amber-300{% endif %}">
+        <div class="rounded-sm border p-3 {% if health.missing_mbid_count is null %}bg-slate-50 border-slate-300{% elseif health.missing_mbid_count == 0 %}bg-emerald-50 border-emerald-300{% else %}bg-amber-50 border-amber-300{% endif %}">
             <div class="font-medium">Tracks sans MBID</div>
             <div>
                 {% if health.missing_mbid_count is null %}
@@ -88,7 +88,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="rounded border p-3 {{ health.lastfm_buffer_count == 0 ? 'bg-slate-50 border-slate-300' : 'bg-amber-50 border-amber-300' }}">
+        <div class="rounded-sm border p-3 {{ health.lastfm_buffer_count == 0 ? 'bg-slate-50 border-slate-300' : 'bg-amber-50 border-amber-300' }}">
             <div class="font-medium">Buffer Last.fm</div>
             <div>
                 {% if health.lastfm_buffer_count == 0 %}
@@ -99,7 +99,7 @@
                 {% endif %}
             </div>
         </div>
-        <div class="rounded border p-3 {{ health.lastfm_unmatched_count == 0 ? 'bg-slate-50 border-slate-300' : 'bg-amber-50 border-amber-300' }}">
+        <div class="rounded-sm border p-3 {{ health.lastfm_unmatched_count == 0 ? 'bg-slate-50 border-slate-300' : 'bg-amber-50 border-amber-300' }}">
             <div class="font-medium">Scrobbles non matchés</div>
             <div>
                 {% if health.lastfm_unmatched_count == 0 %}
@@ -113,7 +113,7 @@
     </div>
 
     {# ---------- Recent runs ---------- #}
-    <div class="bg-white shadow rounded overflow-hidden mb-6">
+    <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-6">
         <div class="flex items-center justify-between px-3 py-2 bg-slate-100 border-b">
             <h2 class="text-sm font-semibold text-slate-700">Derniers runs</h2>
             <a href="{{ path('app_history') }}" class="text-xs text-sky-700 hover:underline">Voir tout l'historique →</a>
@@ -142,7 +142,7 @@
                             {% set badge = entry.status == 'success' ? 'bg-emerald-100 text-emerald-800'
                                 : entry.status == 'error' ? 'bg-rose-100 text-rose-800'
                                 : 'bg-amber-100 text-amber-800' %}
-                            <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ entry.status }}</span>
+                            <span class="text-xs px-2 py-0.5 rounded-sm {{ badge }}">{{ entry.status }}</span>
                         </td>
                         <td class="px-3 py-1.5 text-xs text-slate-500">{{ entry.startedAt|date('Y-m-d H:i:s') }}</td>
                         <td class="px-3 py-1.5 text-right text-xs text-slate-500">
@@ -165,15 +165,15 @@
     </div>
 
     {# ---------- Filters bar ---------- #}
-    <form method="get" class="bg-white shadow rounded p-3 mb-4 flex flex-wrap items-end gap-3 text-sm">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-3 mb-4 flex flex-wrap items-end gap-3 text-sm">
         <div class="flex-1 min-w-[200px]">
             <label class="block text-xs uppercase text-slate-500" for="filter-q">Recherche</label>
             <input type="search" name="q" id="filter-q" value="{{ filters.q }}"
-                   placeholder="Filtrer par nom…" class="w-full border rounded px-2 py-1">
+                   placeholder="Filtrer par nom…" class="w-full border rounded-sm px-2 py-1">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500" for="filter-enabled">Statut</label>
-            <select name="enabled" id="filter-enabled" class="border rounded px-2 py-1">
+            <select name="enabled" id="filter-enabled" class="border rounded-sm px-2 py-1">
                 <option value="" {{ filters.enabled is null ? 'selected' : '' }}>— tous —</option>
                 <option value="1" {{ filters.enabled == true ? 'selected' : '' }}>Actives uniquement</option>
                 <option value="0" {{ filters.enabled is same as(false) ? 'selected' : '' }}>Désactivées uniquement</option>
@@ -181,17 +181,17 @@
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500" for="filter-sort">Tri</label>
-            <select name="sort" id="filter-sort" class="border rounded px-2 py-1">
+            <select name="sort" id="filter-sort" class="border rounded-sm px-2 py-1">
                 <option value="name" {{ filters.sort == 'name' ? 'selected' : '' }}>Par nom</option>
                 <option value="last_run" {{ filters.sort == 'last_run' ? 'selected' : '' }}>Dernier run</option>
             </select>
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white">Filtrer</button>
         <a href="{{ path('app_dashboard') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 
     {% if rows is empty %}
-        <div class="bg-white shadow rounded p-8 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-8 text-center text-slate-500">
             {% if filters.q or filters.enabled is not null %}
                 Aucune définition pour ces filtres. <a href="{{ path('app_dashboard') }}" class="text-emerald-700 hover:underline">Réinitialiser</a>.
             {% else %}
@@ -199,7 +199,7 @@
             {% endif %}
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left">
                 <tr>
@@ -253,7 +253,7 @@
                         <td class="px-3 py-2">
                             <form method="post" action="{{ path('app_playlist_toggle', {id: def.id}) }}" class="inline">
                                 <input type="hidden" name="_token" value="{{ csrf_token('toggle' ~ def.id) }}">
-                                <button type="submit" class="text-xs px-2 py-1 rounded
+                                <button type="submit" class="text-xs px-2 py-1 rounded-sm
                                     {% if def.enabled %}bg-emerald-100 text-emerald-800 hover:bg-emerald-200
                                     {% else %}bg-slate-200 text-slate-700 hover:bg-slate-300{% endif %}">
                                     {{ def.enabled ? 'ON' : 'OFF' }}

--- a/templates/discover/artists.html.twig
+++ b/templates/discover/artists.html.twig
@@ -8,7 +8,7 @@
 
         <form method="post" action="{{ path('app_discover_artists_refresh') }}">
             <input type="hidden" name="_token" value="{{ csrf_token('discover_refresh') }}">
-            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm">
                 ↻ Rafraîchir
             </button>
         </form>
@@ -21,13 +21,13 @@
     </p>
 
     {% if not api_key_configured %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             <strong>LASTFM_API_KEY</strong> n'est pas configuré. Cette page nécessite une clé d'API Last.fm.
         </div>
     {% endif %}
 
     {% if snapshot is null %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 text-sm">
             Aucune suggestion en cache. Clique sur <strong>Rafraîchir</strong> pour interroger Last.fm
             (cela peut prendre 30 secondes — un appel API par artiste seed).
         </div>
@@ -40,13 +40,13 @@
         </p>
 
         {% if snapshot.data.items is empty %}
-            <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded p-4 text-sm">
+            <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded-sm p-4 text-sm">
                 Pas de suggestion neuve : Last.fm ne trouve que des artistes déjà dans ta lib.
             </div>
         {% else %}
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                 {% for item in snapshot.data.items %}
-                    <div class="bg-white shadow rounded p-4 flex flex-col gap-2">
+                    <div class="bg-white shadow-sm rounded-sm p-4 flex flex-col gap-2">
                         <div class="flex items-start justify-between gap-2">
                             <div class="font-semibold text-base">{{ item.name }}</div>
                             <div class="text-xs text-slate-400 whitespace-nowrap">
@@ -70,7 +70,7 @@
                                         <input type="hidden" name="_redirect_discover" value="1">
                                         <input type="hidden" name="_token" value="{{ csrf_token('lidarr_add') }}">
                                         <button type="submit"
-                                                class="text-xs px-2 py-1 rounded bg-amber-50 border border-amber-300 text-amber-800 hover:bg-amber-100">
+                                                class="text-xs px-2 py-1 rounded-sm bg-amber-50 border border-amber-300 text-amber-800 hover:bg-amber-100">
                                             + Lidarr
                                         </button>
                                     </form>

--- a/templates/history/detail.html.twig
+++ b/templates/history/detail.html.twig
@@ -9,7 +9,7 @@
 
     <h1 class="text-2xl font-semibold mb-4">Run #{{ entry.id }} — {{ entry.label }}</h1>
 
-    <div class="bg-white shadow rounded p-6 max-w-3xl space-y-3 text-sm">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl space-y-3 text-sm">
         <div><strong>Type :</strong> <span class="font-mono">{{ entry.type }}</span></div>
         <div><strong>Référence :</strong> <span class="font-mono">{{ entry.reference }}</span></div>
         <div>
@@ -18,7 +18,7 @@
                 : entry.status == 'error' ? 'bg-rose-100 text-rose-800'
                 : entry.status == 'running' ? 'bg-sky-100 text-sky-800'
                 : 'bg-amber-100 text-amber-800' %}
-            <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ entry.status }}</span>
+            <span class="text-xs px-2 py-0.5 rounded-sm {{ badge }}">{{ entry.status }}</span>
         </div>
         <div><strong>Démarré :</strong> {{ entry.startedAt|date('Y-m-d H:i:s') }}</div>
         <div><strong>Terminé :</strong> {% if entry.finishedAt %}{{ entry.finishedAt|date('Y-m-d H:i:s') }}{% else %}—{% endif %}</div>
@@ -27,21 +27,21 @@
         {% if entry.metrics %}
             <div>
                 <strong>Métriques :</strong>
-                <pre class="mt-1 bg-slate-100 rounded p-3 text-xs overflow-x-auto">{{ entry.metrics|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
+                <pre class="mt-1 bg-slate-100 rounded-sm p-3 text-xs overflow-x-auto">{{ entry.metrics|json_encode(constant('JSON_PRETTY_PRINT')) }}</pre>
             </div>
         {% endif %}
 
         {% if entry.message %}
             <div>
                 <strong>Message :</strong>
-                <pre class="mt-1 bg-slate-100 rounded p-3 text-xs overflow-x-auto whitespace-pre-wrap">{{ entry.message }}</pre>
+                <pre class="mt-1 bg-slate-100 rounded-sm p-3 text-xs overflow-x-auto whitespace-pre-wrap">{{ entry.message }}</pre>
             </div>
         {% endif %}
     </div>
 
     {# ---------- Summary card for Last.fm imports ---------- #}
     {% if summary is not null %}
-        <div class="bg-white shadow rounded p-6 mt-6 max-w-3xl">
+        <div class="bg-white shadow-sm rounded-sm p-6 mt-6 max-w-3xl">
             <h2 class="text-lg font-semibold mb-1">Synthèse</h2>
             <p class="text-sm text-slate-500 mb-4">
                 <strong>{{ summary.fetched|number_format(0, '.', ' ') }}</strong>
@@ -49,7 +49,7 @@
             </p>
 
             {% if summary.fetched > 0 %}
-                <div class="flex h-3 rounded overflow-hidden bg-slate-100 mb-4" title="Répartition des scrobbles">
+                <div class="flex h-3 rounded-sm overflow-hidden bg-slate-100 mb-4" title="Répartition des scrobbles">
                     <div class="bg-emerald-500" style="width: {{ summary.inserted.pct }}%"></div>
                     <div class="bg-slate-400" style="width: {{ summary.duplicates.pct }}%"></div>
                     <div class="bg-amber-500" style="width: {{ summary.unmatched.pct }}%"></div>
@@ -59,22 +59,22 @@
 
             <ul class="text-sm grid grid-cols-1 sm:grid-cols-2 gap-y-1 max-w-md">
                 <li>
-                    <span class="inline-block w-3 h-3 bg-emerald-500 rounded-sm mr-2 align-middle"></span>
+                    <span class="inline-block w-3 h-3 bg-emerald-500 rounded-xs mr-2 align-middle"></span>
                     Insérés : <strong>{{ summary.inserted.n|number_format(0, '.', ' ') }}</strong>
                     <span class="text-slate-500">({{ summary.inserted.pct }}%)</span>
                 </li>
                 <li>
-                    <span class="inline-block w-3 h-3 bg-slate-400 rounded-sm mr-2 align-middle"></span>
+                    <span class="inline-block w-3 h-3 bg-slate-400 rounded-xs mr-2 align-middle"></span>
                     Doublons : <strong>{{ summary.duplicates.n|number_format(0, '.', ' ') }}</strong>
                     <span class="text-slate-500">({{ summary.duplicates.pct }}%)</span>
                 </li>
                 <li>
-                    <span class="inline-block w-3 h-3 bg-amber-500 rounded-sm mr-2 align-middle"></span>
+                    <span class="inline-block w-3 h-3 bg-amber-500 rounded-xs mr-2 align-middle"></span>
                     Non matchés : <strong>{{ summary.unmatched.n|number_format(0, '.', ' ') }}</strong>
                     <span class="text-slate-500">({{ summary.unmatched.pct }}%)</span>
                 </li>
                 <li>
-                    <span class="inline-block w-3 h-3 bg-sky-400 rounded-sm mr-2 align-middle"></span>
+                    <span class="inline-block w-3 h-3 bg-sky-400 rounded-xs mr-2 align-middle"></span>
                     Ignorés : <strong>{{ summary.skipped.n|number_format(0, '.', ' ') }}</strong>
                     <span class="text-slate-500">({{ summary.skipped.pct }}%)</span>
                 </li>
@@ -89,26 +89,26 @@
 
     {# ---------- Rematch CLI hint for runs with unmatched ---------- #}
     {% if entry.type in ['lastfm-process', 'lastfm-import'] and (status_counts.unmatched ?? 0) > 0 %}
-        <div class="bg-white shadow rounded p-6 mt-6 max-w-3xl">
+        <div class="bg-white shadow-sm rounded-sm p-6 mt-6 max-w-3xl">
             <h2 class="text-lg font-semibold mb-1">Re-tenter le matching</h2>
             <p class="text-sm text-slate-500 mb-3">
                 {{ status_counts.unmatched }} scrobble{{ status_counts.unmatched > 1 ? 's' : '' }}
                 non matché{{ status_counts.unmatched > 1 ? 's' : '' }} dans ce run. Lancez le rematch
                 en CLI (Navidrome doit être arrêté ou utilisez <code>--auto-stop</code>) :
             </p>
-            <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto"><code>php bin/console app:lastfm:rematch --auto-stop --run-id={{ entry.id }}</code></pre>
+            <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto"><code>php bin/console app:lastfm:rematch --auto-stop --run-id={{ entry.id }}</code></pre>
         </div>
     {% endif %}
 
     {# ---------- Per-track section for Last.fm imports ---------- #}
     {% if entry.type in ['lastfm-process', 'lastfm-import'] and (status_counts|default({})) is not empty %}
-        <div class="bg-white shadow rounded p-6 mt-6 max-w-5xl">
+        <div class="bg-white shadow-sm rounded-sm p-6 mt-6 max-w-5xl">
             <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
                 <div>
                     <h2 class="text-lg font-semibold">Morceaux de l'import</h2>
                     <p class="text-xs text-slate-500 mt-1">
                         {% for k, label in track_statuses %}
-                            <span class="inline-block px-2 py-0.5 rounded mr-1
+                            <span class="inline-block px-2 py-0.5 rounded-sm mr-1
                                 {% if k == 'inserted' %}bg-emerald-100 text-emerald-800
                                 {% elseif k == 'duplicate' %}bg-slate-200 text-slate-700
                                 {% else %}bg-amber-100 text-amber-800{% endif %}">
@@ -121,7 +121,7 @@
                 <form method="get" action="{{ path('app_history_detail', {id: entry.id}) }}" class="flex flex-wrap items-end gap-2 text-sm">
                     <div>
                         <label class="block text-xs uppercase text-slate-500">Statut</label>
-                        <select name="status" class="border rounded px-2 py-1">
+                        <select name="status" class="border rounded-sm px-2 py-1">
                             <option value="" {{ status_filter == '' ? 'selected' : '' }}>— tous —</option>
                             {% for k, label in track_statuses %}
                                 <option value="{{ k }}" {{ status_filter == k ? 'selected' : '' }}>
@@ -133,9 +133,9 @@
                     <div>
                         <label class="block text-xs uppercase text-slate-500">Recherche</label>
                         <input type="search" name="q" value="{{ q_filter }}" placeholder="Artiste / titre…"
-                               class="border rounded px-2 py-1">
+                               class="border rounded-sm px-2 py-1">
                     </div>
-                    <button type="submit" class="px-3 py-1 rounded bg-slate-900 text-white">Filtrer</button>
+                    <button type="submit" class="px-3 py-1 rounded-sm bg-slate-900 text-white">Filtrer</button>
                 </form>
             </div>
 
@@ -165,7 +165,7 @@
                             <tr>
                                 <td class="px-3 py-1.5 text-slate-400">{{ loop.index }}</td>
                                 <td class="px-3 py-1.5">
-                                    <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ t.status }}</span>
+                                    <span class="text-xs px-2 py-0.5 rounded-sm {{ badge }}">{{ t.status }}</span>
                                 </td>
                                 <td class="px-3 py-1.5 text-xs text-slate-500" title="{{ t.playedAt|date('Y-m-d H:i:s') }}">
                                     {{ t.playedAt|date('Y-m-d H:i') }}
@@ -185,7 +185,7 @@
                                 <td class="px-3 py-1.5 text-right whitespace-nowrap">
                                     {% if t.status == 'unmatched' %}
                                         <a href="{{ path('app_lastfm_alias_new', {source_artist: t.artist, source_title: t.title}) }}"
-                                           class="text-xs px-2 py-0.5 rounded bg-slate-700 text-white hover:bg-slate-800"
+                                           class="text-xs px-2 py-0.5 rounded-sm bg-slate-700 text-white hover:bg-slate-800"
                                            title="Créer un alias manuel pour ce scrobble">✏️ Mapper</a>
                                     {% endif %}
                                 </td>
@@ -205,7 +205,7 @@
 
     {# ---------- Unmatched artists section for Last.fm imports ---------- #}
     {% if entry.type in ['lastfm-process', 'lastfm-import'] and unmatched_artists is not empty %}
-        <div class="bg-white shadow rounded p-6 mt-6 max-w-5xl">
+        <div class="bg-white shadow-sm rounded-sm p-6 mt-6 max-w-5xl">
             <h2 class="text-lg font-semibold mb-1">
                 Artistes non matchés (top {{ unmatched_artists|length }})
             </h2>
@@ -215,12 +215,12 @@
             </p>
 
             {% if not lidarr_configured %}
-                <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+                <div class="mb-4 p-3 rounded-sm bg-amber-50 text-amber-800 text-sm">
                     Configurer <code>LIDARR_URL</code> et <code>LIDARR_API_KEY</code>
                     pour activer les actions Lidarr.
                 </div>
             {% elseif not lidarr_reachable %}
-                <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+                <div class="mb-4 p-3 rounded-sm bg-rose-50 text-rose-800 text-sm">
                     Lidarr injoignable — actions désactivées.
                 </div>
             {% endif %}
@@ -249,11 +249,11 @@
                                 {% if not lidarr_configured or not lidarr_reachable %}
                                     <span class="text-xs text-slate-400">—</span>
                                 {% elseif row.lidarr_url %}
-                                    <span class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800">
+                                    <span class="text-xs px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800">
                                         ✓ déjà dans Lidarr
                                     </span>
                                 {% else %}
-                                    <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">
+                                    <span class="text-xs px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700">
                                         ✗ absent
                                     </span>
                                 {% endif %}
@@ -261,7 +261,7 @@
                             <td class="px-3 py-1.5">
                                 {% if lidarr_configured and lidarr_reachable and row.lidarr_url %}
                                     <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
-                                       class="text-xs px-2 py-1 rounded bg-sky-600 text-white hover:bg-sky-700">
+                                       class="text-xs px-2 py-1 rounded-sm bg-sky-600 text-white hover:bg-sky-700">
                                         Fiche Lidarr
                                     </a>
                                 {% elseif lidarr_configured and lidarr_reachable %}
@@ -272,13 +272,13 @@
                                         <input type="hidden" name="artist" value="{{ row.artist }}">
                                         <input type="hidden" name="_redirect_run_id" value="{{ entry.id }}">
                                         <button type="submit"
-                                                class="text-xs px-2 py-1 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                                class="text-xs px-2 py-1 rounded-sm bg-emerald-600 text-white hover:bg-emerald-700">
                                             + Lidarr
                                         </button>
                                     </form>
                                 {% else %}
                                     <button type="button" disabled
-                                            class="text-xs px-2 py-1 rounded bg-slate-200 text-slate-400 cursor-not-allowed">
+                                            class="text-xs px-2 py-1 rounded-sm bg-slate-200 text-slate-400 cursor-not-allowed">
                                         + Lidarr
                                     </button>
                                 {% endif %}

--- a/templates/history/index.html.twig
+++ b/templates/history/index.html.twig
@@ -10,10 +10,10 @@
         </div>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 flex flex-wrap items-end gap-3">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
         <div>
             <label class="block text-xs uppercase text-slate-500">Type</label>
-            <select name="type" class="border rounded px-2 py-1 text-sm">
+            <select name="type" class="border rounded-sm px-2 py-1 text-sm">
                 <option value="">— tous —</option>
                 {% for k, label in types %}
                     <option value="{{ k }}" {{ filters.type == k ? 'selected' : '' }}>{{ label }}</option>
@@ -22,7 +22,7 @@
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500">Statut</label>
-            <select name="status" class="border rounded px-2 py-1 text-sm">
+            <select name="status" class="border rounded-sm px-2 py-1 text-sm">
                 <option value="">— tous —</option>
                 {% for k, label in statuses %}
                     <option value="{{ k }}" {{ filters.status == k ? 'selected' : '' }}>{{ label }}</option>
@@ -32,18 +32,18 @@
         <div class="flex-1 min-w-[200px]">
             <label class="block text-xs uppercase text-slate-500">Recherche</label>
             <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par libellé…"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
         <a href="{{ path('app_history') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 
     {% if items is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucune entrée pour ce filtre.
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -65,7 +65,7 @@
                             {% set badge = entry.status == 'success' ? 'bg-emerald-100 text-emerald-800'
                                 : entry.status == 'error' ? 'bg-rose-100 text-rose-800'
                                 : 'bg-amber-100 text-amber-800' %}
-                            <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ entry.status }}</span>
+                            <span class="text-xs px-2 py-0.5 rounded-sm {{ badge }}">{{ entry.status }}</span>
                         </td>
                         <td class="px-3 py-1.5 text-xs text-slate-500">{{ entry.startedAt|date('Y-m-d H:i:s') }}</td>
                         <td class="px-3 py-1.5 text-right text-xs text-slate-500">
@@ -90,12 +90,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_history', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_history', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/lastfm/_unmatched_tabs.html.twig
+++ b/templates/lastfm/_unmatched_tabs.html.twig
@@ -1,4 +1,4 @@
-<nav class="bg-white shadow rounded mb-4 flex flex-wrap text-sm overflow-hidden">
+<nav class="bg-white shadow-sm rounded-sm mb-4 flex flex-wrap text-sm overflow-hidden">
     <a href="{{ path('app_lastfm_unmatched') }}"
        class="px-4 py-2 border-r {{ current_tab == 'tracks' ? 'bg-slate-900 text-white' : 'text-slate-700 hover:bg-slate-100' }}">
         Par titre

--- a/templates/lastfm/aliases/form.html.twig
+++ b/templates/lastfm/aliases/form.html.twig
@@ -17,18 +17,18 @@
         spécifique. Consulté avant toutes les heuristiques de matching.
     </p>
 
-    <div class="bg-white shadow rounded p-6 max-w-2xl">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl">
         {{ form_start(form) }}
             <div class="space-y-4">
                 <div>
                     {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
-                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
                     <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
                     {{ form_errors(form.source_artist) }}
                 </div>
                 <div>
                     {{ form_label(form.source_title, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
-                    {{ form_widget(form.source_title, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    {{ form_widget(form.source_title, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
                     {{ form_errors(form.source_title) }}
                 </div>
 
@@ -42,14 +42,14 @@
 
                 <div>
                     {{ form_label(form.target_media_file_id, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
-                    {{ form_widget(form.target_media_file_id, {attr: {class: 'w-full border rounded px-2 py-1 text-sm font-mono'}}) }}
+                    {{ form_widget(form.target_media_file_id, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm font-mono'}}) }}
                     <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_media_file_id) }}</p>
                     {{ form_errors(form.target_media_file_id) }}
                 </div>
             </div>
 
             <div class="flex items-center gap-3 mt-6">
-                <button type="submit" class="px-4 py-2 rounded bg-slate-900 text-white text-sm">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
                     {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias' }}
                 </button>
                 <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-slate-500 hover:underline">

--- a/templates/lastfm/aliases/index.html.twig
+++ b/templates/lastfm/aliases/index.html.twig
@@ -11,21 +11,21 @@
             </p>
         </div>
         <a href="{{ path('app_lastfm_alias_new') }}"
-           class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">+ Nouvel alias</a>
+           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias</a>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 flex flex-wrap items-end gap-3">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
         <div class="flex-1 min-w-[200px]">
             <label class="block text-xs uppercase text-slate-500">Recherche</label>
             <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste ou titre source…"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
         <a href="{{ path('app_lastfm_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 
     {% if aliases is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             {% if filters.q %}
                 Aucun alias ne correspond à « {{ filters.q }} ».
             {% else %}
@@ -34,7 +34,7 @@
             {% endif %}
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -52,7 +52,7 @@
                         <td class="px-3 py-1.5">{{ alias.sourceTitle }}</td>
                         <td class="px-3 py-1.5 font-mono text-xs">
                             {% if alias.skip %}
-                                <span class="px-2 py-0.5 rounded bg-amber-100 text-amber-800">IGNORÉ</span>
+                                <span class="px-2 py-0.5 rounded-sm bg-amber-100 text-amber-800">IGNORÉ</span>
                             {% else %}
                                 {{ alias.targetMediaFileId }}
                             {% endif %}
@@ -78,12 +78,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/lastfm/artist_aliases/form.html.twig
+++ b/templates/lastfm/artist_aliases/form.html.twig
@@ -19,25 +19,25 @@
         « The X » / « X, The ».
     </p>
 
-    <div class="bg-white shadow rounded p-6 max-w-2xl">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl">
         {{ form_start(form) }}
             <div class="space-y-4">
                 <div>
                     {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
-                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
                     <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
                     {{ form_errors(form.source_artist) }}
                 </div>
                 <div>
                     {{ form_label(form.target_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
-                    {{ form_widget(form.target_artist, {attr: {class: 'w-full border rounded px-2 py-1 text-sm'}}) }}
+                    {{ form_widget(form.target_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
                     <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_artist) }}</p>
                     {{ form_errors(form.target_artist) }}
                 </div>
             </div>
 
             <div class="flex items-center gap-3 mt-6">
-                <button type="submit" class="px-4 py-2 rounded bg-slate-900 text-white text-sm">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
                     {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias artiste' }}
                 </button>
                 <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-slate-500 hover:underline">

--- a/templates/lastfm/artist_aliases/index.html.twig
+++ b/templates/lastfm/artist_aliases/index.html.twig
@@ -14,21 +14,21 @@
             </p>
         </div>
         <a href="{{ path('app_lastfm_artist_alias_new') }}"
-           class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">+ Nouvel alias artiste</a>
+           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias artiste</a>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 flex flex-wrap items-end gap-3">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
         <div class="flex-1 min-w-[200px]">
             <label class="block text-xs uppercase text-slate-500">Recherche</label>
             <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste source ou cible…"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
         <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 
     {% if aliases is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             {% if filters.q %}
                 Aucun alias artiste ne correspond à « {{ filters.q }} ».
             {% else %}
@@ -37,7 +37,7 @@
             {% endif %}
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -73,12 +73,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -22,10 +22,10 @@
     </div>
 
     {# ---------- État ---------- #}
-    <div class="bg-white shadow rounded p-6 max-w-3xl mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl mb-6">
         <h2 class="text-lg font-semibold mb-3">État</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
-            <div class="bg-slate-50 rounded p-3">
+            <div class="bg-slate-50 rounded-sm p-3">
                 <div class="text-xs uppercase text-slate-500">Buffer en attente</div>
                 <div class="text-2xl font-semibold">{{ buffer_count|number_format(0, '.', ' ') }}</div>
                 <div class="text-xs text-slate-500 mt-1">
@@ -33,7 +33,7 @@
                     {% if buffer_count > 0 %}prêt{{ buffer_count > 1 ? 's' : '' }} à être traité{{ buffer_count > 1 ? 's' : '' }}{% endif %}
                 </div>
             </div>
-            <div class="bg-slate-50 rounded p-3">
+            <div class="bg-slate-50 rounded-sm p-3">
                 <div class="text-xs uppercase text-slate-500">Non matchés cumulés</div>
                 <div class="text-2xl font-semibold">{{ unmatched_cumulative|number_format(0, '.', ' ') }}</div>
                 <div class="text-xs text-slate-500 mt-1">
@@ -59,7 +59,7 @@
     </div>
 
     {# ---------- 1. Fetch ---------- #}
-    <div class="bg-white shadow rounded p-6 max-w-3xl mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl mb-6">
         <h2 class="text-lg font-semibold mb-1">1. Récupérer depuis Last.fm</h2>
         <p class="text-sm text-slate-500 mb-3">
             Lit l'historique Last.fm et stocke chaque scrobble dans le buffer local.
@@ -68,16 +68,16 @@
         </p>
 
         <div class="text-xs uppercase text-slate-500 mt-2 mb-1">Localement (Symfony serve / Docker)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:import{% if default_lastfm_user %} {{ default_lastfm_user }}{% else %} USERNAME{% endif %} \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:import{% if default_lastfm_user %} {{ default_lastfm_user }}{% else %} USERNAME{% endif %} \
     [--api-key=KEY] [--date-min=YYYY-MM-DD] [--date-max=YYYY-MM-DD] \
     [--max-scrobbles=N] [--dry-run]</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Docker Compose</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
     php bin/console app:lastfm:import{% if default_lastfm_user %} {{ default_lastfm_user }}{% else %} USERNAME{% endif %}</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Lando (dev)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:import{% if default_lastfm_user %} {{ default_lastfm_user }}{% else %} USERNAME{% endif %}</code></pre>
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:import{% if default_lastfm_user %} {{ default_lastfm_user }}{% else %} USERNAME{% endif %}</code></pre>
 
         <p class="text-xs text-slate-500 mt-3">
             <code>LASTFM_USER</code> et <code>LASTFM_API_KEY</code> servent de défaut quand les options ne sont pas fournies.
@@ -85,7 +85,7 @@
     </div>
 
     {# ---------- 2. Process ---------- #}
-    <div class="bg-white shadow rounded p-6 max-w-3xl mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl mb-6">
         <h2 class="text-lg font-semibold mb-1">2. Traiter le buffer</h2>
         <p class="text-sm text-slate-500 mb-3">
             Stream du buffer (par <code>played_at</code> ASC), cascade de matching, insertion dans la table
@@ -99,15 +99,15 @@
         </p>
 
         <div class="text-xs uppercase text-slate-500 mt-2 mb-1">Localement</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:process --auto-stop \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:process --auto-stop \
     [--limit=N] [--tolerance=60] [--dry-run]</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Docker Compose (cron)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
     php bin/console app:lastfm:process --auto-stop</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Lando (dev)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:process --auto-stop</code></pre>
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:process --auto-stop</code></pre>
 
         <p class="text-xs text-slate-500 mt-3">
             Sans <code>--auto-stop</code>, la commande échoue si Navidrome tourne (pré-flight).
@@ -116,7 +116,7 @@
     </div>
 
     {# ---------- 3. Rematch ---------- #}
-    <div class="bg-white shadow rounded p-6 max-w-3xl mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl mb-6">
         <h2 class="text-lg font-semibold mb-1">3. Re-matcher les unmatched</h2>
         <p class="text-sm text-slate-500 mb-3">
             Ré-applique la cascade de matching aux rows <code>lastfm_import_track</code> en status
@@ -126,14 +126,14 @@
         </p>
 
         <div class="text-xs uppercase text-slate-500 mt-2 mb-1">Tous les unmatched cumulés</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:rematch --auto-stop \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:rematch --auto-stop \
     [--limit=N] [--tolerance=60] [--random] [--dry-run]</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Limiter à un run précis</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:rematch --auto-stop --run-id=&lt;ID&gt;</code></pre>
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:rematch --auto-stop --run-id=&lt;ID&gt;</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Docker Compose / Lando</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto"><code>docker compose exec -T navidrome-tools-web \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto"><code>docker compose exec -T navidrome-tools-web \
     php bin/console app:lastfm:rematch --auto-stop
 
 lando symfony app:lastfm:rematch --auto-stop</code></pre>

--- a/templates/lastfm/love_sync.html.twig
+++ b/templates/lastfm/love_sync.html.twig
@@ -12,28 +12,28 @@
         </p>
     </div>
 
-    <div class="bg-white shadow rounded p-4 mb-4 flex items-center justify-between">
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-4 flex items-center justify-between">
         {% if not auth_configured %}
             <span class="text-sm text-amber-700">
                 Configurez <code>LASTFM_API_KEY</code> et <code>LASTFM_API_SECRET</code> avant de continuer.
             </span>
         {% elseif session_user %}
             <span class="text-sm">
-                <span class="inline-block px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 text-xs">✓ connecté</span>
+                <span class="inline-block px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 text-xs">✓ connecté</span>
                 <code class="ml-1">{{ session_user }}</code>
             </span>
             <a href="{{ path('app_settings') }}" class="text-xs text-sky-700 hover:underline">Réglages</a>
         {% else %}
             <span class="text-sm">
-                <span class="inline-block px-2 py-0.5 rounded bg-slate-200 text-slate-700 text-xs">✗ non connecté</span>
+                <span class="inline-block px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700 text-xs">✗ non connecté</span>
                 — connectez-vous d'abord à Last.fm.
             </span>
             <a href="{{ path('app_lastfm_connect') }}"
-               class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Se connecter</a>
+               class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Se connecter</a>
         {% endif %}
     </div>
 
-    <div class="bg-white shadow rounded p-6 max-w-3xl mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-3xl mb-6">
         <h2 class="text-lg font-semibold mb-1">Lancer la synchro</h2>
         <p class="text-sm text-slate-500 mb-3">
             La commande lit les loved Last.fm de l'utilisateur connecté et les starred Navidrome,
@@ -43,15 +43,15 @@
         </p>
 
         <div class="text-xs uppercase text-slate-500 mt-2 mb-1">Localement</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:sync-loved \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>php bin/console app:lastfm:sync-loved \
     [--direction=both|lf-to-nd|nd-to-lf] [--dry-run]</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Docker Compose (cron)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto mb-2"><code>docker compose exec -T navidrome-tools-web \
     php bin/console app:lastfm:sync-loved --direction=both</code></pre>
 
         <div class="text-xs uppercase text-slate-500 mt-3 mb-1">Lando (dev)</div>
-        <pre class="bg-slate-900 text-slate-100 rounded px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:sync-loved --direction=both</code></pre>
+        <pre class="bg-slate-900 text-slate-100 rounded-sm px-3 py-2 text-xs overflow-x-auto"><code>lando symfony app:lastfm:sync-loved --direction=both</code></pre>
 
         <p class="text-xs text-slate-500 mt-3">
             Direction par défaut : <code>both</code>. <code>--dry-run</code> calcule la diff sans rien écrire.

--- a/templates/lastfm/unmatched.html.twig
+++ b/templates/lastfm/unmatched.html.twig
@@ -18,45 +18,45 @@
         </div>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
         <div>
             <label class="block text-xs uppercase text-slate-500">Artiste</label>
             <input type="search" name="artist" value="{{ filters.artist }}" placeholder="ex. Gentleman"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500">Titre</label>
             <input type="search" name="title" value="{{ filters.title }}" placeholder="ex. Berlin"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500">Album</label>
             <input type="search" name="album" value="{{ filters.album }}" placeholder="ex. Rainbow Warrior"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div class="flex gap-2">
-            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
             <a href="{{ path('app_lastfm_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         </div>
     </form>
 
     {% if not lidarr_configured %}
-        <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-amber-50 text-amber-800 text-sm">
             Lidarr n'est pas configuré (<code>LIDARR_URL</code> / <code>LIDARR_API_KEY</code>) —
             les actions Lidarr sont désactivées.
         </div>
     {% elseif not lidarr_reachable %}
-        <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-rose-50 text-rose-800 text-sm">
             Lidarr injoignable — actions désactivées le temps qu'il revienne.
         </div>
     {% endif %}
 
     {% if rows is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun scrobble non matché pour ce filtre 🎉
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -92,19 +92,19 @@
                                 <span class="text-xs text-slate-400">—</span>
                             {% elseif row.lidarr_url %}
                                 <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
-                                   class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
+                                   class="text-xs px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
                                     ✓ déjà
                                 </a>
                             {% else %}
-                                <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">✗ absent</span>
+                                <span class="text-xs px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700">✗ absent</span>
                             {% endif %}
                         </td>
                         <td class="px-3 py-1.5 text-right whitespace-nowrap">
                             <a href="{{ path('app_lastfm_alias_new', {source_artist: row.artist, source_title: row.title}) }}"
-                               class="text-xs px-2 py-0.5 rounded bg-slate-700 text-white hover:bg-slate-800 mr-1"
+                               class="text-xs px-2 py-0.5 rounded-sm bg-slate-700 text-white hover:bg-slate-800 mr-1"
                                title="Créer un alias manuel pour ce scrobble">✏️ Mapper</a>
                             <a href="{{ path('app_lastfm_artist_alias_new', {source_artist: row.artist}) }}"
-                               class="text-xs px-2 py-0.5 rounded bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
+                               class="text-xs px-2 py-0.5 rounded-sm bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
                                title="Aliaser ce nom d'artiste vers son nom canonique côté Navidrome">🎭 Aliaser artiste</a>
                             {% if lidarr_configured and lidarr_reachable and not row.lidarr_url %}
                                 <form method="post" action="{{ path('app_lidarr_add_artist') }}"
@@ -114,7 +114,7 @@
                                     <input type="hidden" name="artist" value="{{ row.artist }}">
                                     <input type="hidden" name="_redirect_unmatched" value="1">
                                     <button type="submit"
-                                            class="text-xs px-2 py-0.5 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                            class="text-xs px-2 py-0.5 rounded-sm bg-emerald-600 text-white hover:bg-emerald-700">
                                         + Lidarr
                                     </button>
                                 </form>
@@ -130,12 +130,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_lastfm_unmatched', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_lastfm_unmatched', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/lastfm/unmatched_albums.html.twig
+++ b/templates/lastfm/unmatched_albums.html.twig
@@ -18,40 +18,40 @@
         </div>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
         <div>
             <label class="block text-xs uppercase text-slate-500">Artiste</label>
             <input type="search" name="artist" value="{{ filters.artist }}" placeholder="ex. Gentleman"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500">Album</label>
             <input type="search" name="album" value="{{ filters.album }}" placeholder="ex. Confidence"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div class="flex gap-2">
-            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
             <a href="{{ path('app_lastfm_unmatched_albums') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         </div>
     </form>
 
     {% if not lidarr_configured %}
-        <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-amber-50 text-amber-800 text-sm">
             Lidarr n'est pas configuré (<code>LIDARR_URL</code> / <code>LIDARR_API_KEY</code>) —
             les actions Lidarr sont désactivées.
         </div>
     {% elseif not lidarr_reachable %}
-        <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-rose-50 text-rose-800 text-sm">
             Lidarr injoignable — actions désactivées le temps qu'il revienne.
         </div>
     {% endif %}
 
     {% if rows is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun album non matché pour ce filtre 🎉
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -87,16 +87,16 @@
                                 <span class="text-xs text-slate-400">—</span>
                             {% elseif row.lidarr_url %}
                                 <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
-                                   class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
+                                   class="text-xs px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
                                     ✓ déjà
                                 </a>
                             {% else %}
-                                <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">✗ absent</span>
+                                <span class="text-xs px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700">✗ absent</span>
                             {% endif %}
                         </td>
                         <td class="px-3 py-1.5 text-right whitespace-nowrap">
                             <a href="{{ path('app_lastfm_artist_alias_new', {source_artist: row.artist}) }}"
-                               class="text-xs px-2 py-0.5 rounded bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
+                               class="text-xs px-2 py-0.5 rounded-sm bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
                                title="Aliaser ce nom d'artiste vers son nom canonique côté Navidrome">🎭 Aliaser artiste</a>
                             {% if lidarr_configured and lidarr_reachable and not row.lidarr_url %}
                                 <form method="post" action="{{ path('app_lidarr_add_artist') }}"
@@ -106,7 +106,7 @@
                                     <input type="hidden" name="artist" value="{{ row.artist }}">
                                     <input type="hidden" name="_redirect_unmatched" value="albums">
                                     <button type="submit"
-                                            class="text-xs px-2 py-0.5 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                            class="text-xs px-2 py-0.5 rounded-sm bg-emerald-600 text-white hover:bg-emerald-700">
                                         + Lidarr
                                     </button>
                                 </form>
@@ -122,12 +122,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_lastfm_unmatched_albums', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_lastfm_unmatched_albums', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/lastfm/unmatched_artists.html.twig
+++ b/templates/lastfm/unmatched_artists.html.twig
@@ -17,35 +17,35 @@
         </div>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
         <div class="sm:col-span-2">
             <label class="block text-xs uppercase text-slate-500">Artiste</label>
             <input type="search" name="artist" value="{{ filters.artist }}" placeholder="ex. Gentleman"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div class="flex gap-2">
-            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
             <a href="{{ path('app_lastfm_unmatched_artists') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         </div>
     </form>
 
     {% if not lidarr_configured %}
-        <div class="mb-4 p-3 rounded bg-amber-50 text-amber-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-amber-50 text-amber-800 text-sm">
             Lidarr n'est pas configuré (<code>LIDARR_URL</code> / <code>LIDARR_API_KEY</code>) —
             les actions Lidarr sont désactivées.
         </div>
     {% elseif not lidarr_reachable %}
-        <div class="mb-4 p-3 rounded bg-rose-50 text-rose-800 text-sm">
+        <div class="mb-4 p-3 rounded-sm bg-rose-50 text-rose-800 text-sm">
             Lidarr injoignable — actions désactivées le temps qu'il revienne.
         </div>
     {% endif %}
 
     {% if rows is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun artiste non matché pour ce filtre 🎉
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -76,16 +76,16 @@
                                 <span class="text-xs text-slate-400">—</span>
                             {% elseif row.lidarr_url %}
                                 <a href="{{ row.lidarr_url }}" target="_blank" rel="noopener"
-                                   class="text-xs px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
+                                   class="text-xs px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 hover:bg-emerald-200">
                                     ✓ déjà
                                 </a>
                             {% else %}
-                                <span class="text-xs px-2 py-0.5 rounded bg-slate-200 text-slate-700">✗ absent</span>
+                                <span class="text-xs px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700">✗ absent</span>
                             {% endif %}
                         </td>
                         <td class="px-3 py-1.5 text-right whitespace-nowrap">
                             <a href="{{ path('app_lastfm_artist_alias_new', {source_artist: row.artist}) }}"
-                               class="text-xs px-2 py-0.5 rounded bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
+                               class="text-xs px-2 py-0.5 rounded-sm bg-indigo-600 text-white hover:bg-indigo-700 mr-1"
                                title="Aliaser ce nom d'artiste vers son nom canonique côté Navidrome">🎭 Aliaser artiste</a>
                             {% if lidarr_configured and lidarr_reachable and not row.lidarr_url %}
                                 <form method="post" action="{{ path('app_lidarr_add_artist') }}"
@@ -95,7 +95,7 @@
                                     <input type="hidden" name="artist" value="{{ row.artist }}">
                                     <input type="hidden" name="_redirect_unmatched" value="artists">
                                     <button type="submit"
-                                            class="text-xs px-2 py-0.5 rounded bg-emerald-600 text-white hover:bg-emerald-700">
+                                            class="text-xs px-2 py-0.5 rounded-sm bg-emerald-600 text-white hover:bg-emerald-700">
                                         + Lidarr
                                     </button>
                                 </form>
@@ -111,12 +111,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_lastfm_unmatched_artists', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_lastfm_unmatched_artists', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/playlist/form.html.twig
+++ b/templates/playlist/form.html.twig
@@ -17,7 +17,7 @@
         </p>
     {% endif %}
 
-    <div class="bg-white shadow rounded p-6 max-w-2xl">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl">
         {{ form_start(form, {attr: {class: 'space-y-4'}}) }}
             {{ form_row(form.name) }}
             {{ form_row(form.generatorKey) }}
@@ -43,8 +43,8 @@
             </div>
 
             <div class="flex justify-end gap-2 pt-4 border-t">
-                <a href="{{ path('app_dashboard') }}" class="px-4 py-2 text-sm rounded border">Annuler</a>
-                <button type="submit" class="px-4 py-2 text-sm rounded bg-emerald-600 hover:bg-emerald-700 text-white">
+                <a href="{{ path('app_dashboard') }}" class="px-4 py-2 text-sm rounded-sm border">Annuler</a>
+                <button type="submit" class="px-4 py-2 text-sm rounded-sm bg-emerald-600 hover:bg-emerald-700 text-white">
                     {{ is_new ? 'Créer' : 'Enregistrer' }}
                 </button>
             </div>

--- a/templates/playlist/preview.html.twig
+++ b/templates/playlist/preview.html.twig
@@ -22,10 +22,10 @@
         </div>
         <div class="flex items-center gap-2">
             <a href="{{ path('app_playlist_preview_export_m3u', {id: def.id}) }}"
-               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-2 rounded">Exporter M3U</a>
+               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-2 rounded-sm">Exporter M3U</a>
             <form method="post" action="{{ path('app_playlist_run', {id: def.id}) }}">
                 <input type="hidden" name="_token" value="{{ csrf_token('run' ~ def.id) }}">
-                <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded text-sm">
+                <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-2 rounded-sm text-sm">
                     Créer dans Navidrome
                 </button>
             </form>
@@ -33,17 +33,17 @@
     </div>
 
     {% if error %}
-        <div class="bg-rose-50 border border-rose-300 text-rose-800 rounded p-4 mb-4">
+        <div class="bg-rose-50 border border-rose-300 text-rose-800 rounded-sm p-4 mb-4">
             {{ error }}
         </div>
     {% endif %}
 
     {% if tracks is empty and not error %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4">
             Aucun morceau trouvé pour cette définition.
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left">
                 <tr>

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -14,7 +14,7 @@
     </div>
 
     {% if playlists is empty %}
-        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded p-6 text-center text-sm">
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
             Aucune playlist n'a été trouvée. Créez-en une via les
             <a href="{{ path('app_dashboard') }}" class="text-sky-700 hover:underline">définitions</a>
             ou directement dans Navidrome.
@@ -22,14 +22,14 @@
     {% else %}
         <form method="post" action="{{ path('app_playlists_bulk_delete') }}"
               onsubmit="return confirm('Supprimer les playlists sélectionnées ?');"
-              class="bg-white border border-slate-200 rounded">
+              class="bg-white border border-slate-200 rounded-sm">
             <input type="hidden" name="_token" value="{{ csrf_token('bulk-delete') }}">
 
             <div class="flex items-center justify-between px-4 py-2 border-b bg-slate-50 text-sm">
                 <div class="text-slate-600">
                     Cochez les playlists pour les supprimer en lot (action irréversible).
                 </div>
-                <button type="submit" class="bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded text-xs">
+                <button type="submit" class="bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded-sm text-xs">
                     Supprimer la sélection
                 </button>
             </div>
@@ -70,15 +70,15 @@
                             <td class="px-3 py-2 text-xs text-slate-500">{{ p.created ? p.created|slice(0, 10) : '—' }}</td>
                             <td class="px-3 py-2 text-xs text-slate-500">{{ p.changed ? p.changed|slice(0, 10) : '—' }}</td>
                             <td class="px-3 py-2 text-xs">
-                                <span class="px-1.5 py-0.5 rounded {{ p.public ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-600' }}">
+                                <span class="px-1.5 py-0.5 rounded-sm {{ p.public ? 'bg-emerald-100 text-emerald-800' : 'bg-slate-100 text-slate-600' }}">
                                     {{ p.public ? 'Publique' : 'Privée' }}
                                 </span>
                             </td>
                             <td class="px-3 py-2 text-right whitespace-nowrap">
                                 <a href="{{ path('app_playlists_show', {id: p.id}) }}"
-                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded">Voir</a>
+                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded-sm">Voir</a>
                                 <a href="{{ path('app_playlists_export_m3u', {id: p.id}) }}"
-                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded">M3U</a>
+                                   class="text-xs bg-slate-100 hover:bg-slate-200 px-2 py-1 rounded-sm">M3U</a>
                             </td>
                         </tr>
                     {% endfor %}

--- a/templates/playlist_management/show.html.twig
+++ b/templates/playlist_management/show.html.twig
@@ -26,25 +26,25 @@
         </div>
         <div class="flex items-center gap-2">
             <a href="{{ path('app_playlists_export_m3u', {id: playlist.id}) }}"
-               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Exporter M3U</a>
+               class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded-sm">Exporter M3U</a>
             <form method="post" action="{{ path('app_playlists_duplicate', {id: playlist.id}) }}" class="inline">
                 <input type="hidden" name="_token" value="{{ csrf_token('duplicate' ~ playlist.id) }}">
-                <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Dupliquer</button>
+                <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded-sm">Dupliquer</button>
             </form>
         </div>
     </div>
 
     {# Stats card #}
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6 text-sm">
-        <div class="rounded border bg-white p-3">
+        <div class="rounded-sm border bg-white p-3">
             <div class="text-xs text-slate-500">Durée totale</div>
             <div class="text-lg font-semibold">{{ (stats.totalDuration // 60) }} min</div>
         </div>
-        <div class="rounded border bg-white p-3">
+        <div class="rounded-sm border bg-white p-3">
             <div class="text-xs text-slate-500">Morceaux starrés</div>
             <div class="text-lg font-semibold">{{ stats.starredCount }} / {{ stats.trackCount }}</div>
         </div>
-        <div class="rounded border bg-white p-3">
+        <div class="rounded-sm border bg-white p-3">
             <div class="text-xs text-slate-500">Jamais joués</div>
             <div class="text-lg font-semibold">
                 {{ stats.neverPlayedCount }}
@@ -53,7 +53,7 @@
                 </span>
             </div>
         </div>
-        <div class="rounded border bg-white p-3 {{ missingIds is not empty ? 'border-amber-300 bg-amber-50' : '' }}">
+        <div class="rounded-sm border bg-white p-3 {{ missingIds is not empty ? 'border-amber-300 bg-amber-50' : '' }}">
             <div class="text-xs text-slate-500">Morceaux morts</div>
             <div class="text-lg font-semibold {{ missingIds is not empty ? 'text-amber-700' : '' }}">
                 {{ missingIds|length }}
@@ -72,7 +72,7 @@
     {# Top artists / albums + year distribution side-by-side #}
     {% if stats.topArtists is not empty or stats.yearDistribution is not empty %}
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6 text-sm">
-            <div class="rounded border bg-white p-3">
+            <div class="rounded-sm border bg-white p-3">
                 <div class="font-medium mb-2">Top artistes</div>
                 {% if stats.topArtists is empty %}
                     <div class="text-xs text-slate-400">—</div>
@@ -84,7 +84,7 @@
                     </ul>
                 {% endif %}
             </div>
-            <div class="rounded border bg-white p-3">
+            <div class="rounded-sm border bg-white p-3">
                 <div class="font-medium mb-2">Top albums</div>
                 {% if stats.topAlbums is empty %}
                     <div class="text-xs text-slate-400">—</div>
@@ -99,7 +99,7 @@
                     </ul>
                 {% endif %}
             </div>
-            <div class="rounded border bg-white p-3">
+            <div class="rounded-sm border bg-white p-3">
                 <div class="font-medium mb-2">Distribution par année</div>
                 {% if stats.yearDistribution is empty %}
                     <div class="text-xs text-slate-400">—</div>
@@ -109,7 +109,7 @@
                         {% for year, count in stats.yearDistribution %}
                             <li class="flex items-center gap-2">
                                 <span class="w-12 text-slate-500">{{ year }}</span>
-                                <span class="h-2 bg-sky-400 rounded" style="width: {{ (count / maxCount * 100)|round }}%"></span>
+                                <span class="h-2 bg-sky-400 rounded-sm" style="width: {{ (count / maxCount * 100)|round }}%"></span>
                                 <span class="text-slate-500">{{ count }}</span>
                             </li>
                         {% endfor %}
@@ -123,40 +123,40 @@
     {% endif %}
 
     {# Rename + delete + bulk star toolbar #}
-    <div class="bg-white border border-slate-200 rounded p-3 mb-4 flex flex-wrap gap-3 items-center">
+    <div class="bg-white border border-slate-200 rounded-sm p-3 mb-4 flex flex-wrap gap-3 items-center">
         <form method="post" action="{{ path('app_playlists_rename', {id: playlist.id}) }}"
               class="flex items-center gap-2 flex-1 min-w-0">
             <input type="hidden" name="_token" value="{{ csrf_token('rename' ~ playlist.id) }}">
             <input type="text" name="name" value="{{ playlist.name }}" required maxlength="200"
-                   class="border rounded px-2 py-1 text-sm flex-1 min-w-0">
-            <button type="submit" class="text-sm bg-sky-600 hover:bg-sky-700 text-white px-3 py-1.5 rounded">Renommer</button>
+                   class="border rounded-sm px-2 py-1 text-sm flex-1 min-w-0">
+            <button type="submit" class="text-sm bg-sky-600 hover:bg-sky-700 text-white px-3 py-1.5 rounded-sm">Renommer</button>
         </form>
 
         <form method="post" action="{{ path('app_playlists_star_all', {id: playlist.id}) }}"
               onsubmit="return {{ playlist.songCount > 50 ? 'confirm(\'Starrer ' ~ playlist.songCount ~ ' morceaux ?\')' : 'true' }};">
             <input type="hidden" name="_token" value="{{ csrf_token('star-all' ~ playlist.id) }}">
-            <button type="submit" class="text-sm bg-amber-100 hover:bg-amber-200 text-amber-800 px-3 py-1.5 rounded">★ Tout starrer</button>
+            <button type="submit" class="text-sm bg-amber-100 hover:bg-amber-200 text-amber-800 px-3 py-1.5 rounded-sm">★ Tout starrer</button>
         </form>
         <form method="post" action="{{ path('app_playlists_star_all', {id: playlist.id}) }}">
             <input type="hidden" name="_token" value="{{ csrf_token('star-all' ~ playlist.id) }}">
             <input type="hidden" name="unstar" value="1">
-            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">☆ Tout dé-starrer</button>
+            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded-sm">☆ Tout dé-starrer</button>
         </form>
 
         <form method="post" action="{{ path('app_playlists_delete', {id: playlist.id}) }}"
               onsubmit="return confirm('Supprimer définitivement « {{ playlist.name }} » côté Navidrome ?');">
             <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ playlist.id) }}">
-            <button type="submit" class="text-sm bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded">Supprimer</button>
+            <button type="submit" class="text-sm bg-rose-600 hover:bg-rose-700 text-white px-3 py-1.5 rounded-sm">Supprimer</button>
         </form>
     </div>
 
     {# Tracks table #}
     {% if playlist.tracks is empty %}
-        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded p-6 text-center text-sm">
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
             Cette playlist est vide.
         </div>
     {% else %}
-        <table class="w-full text-sm bg-white border border-slate-200 rounded overflow-hidden">
+        <table class="w-full text-sm bg-white border border-slate-200 rounded-sm overflow-hidden">
             <thead class="bg-slate-100 text-slate-600">
                 <tr>
                     <th class="px-3 py-2 w-8 text-center">★</th>
@@ -212,12 +212,12 @@
     {% endif %}
 
     {# Search-to-add — Subsonic search3, filters out songs already in the playlist #}
-    <div class="mt-6 bg-white border border-slate-200 rounded p-3">
+    <div class="mt-6 bg-white border border-slate-200 rounded-sm p-3">
         <h2 class="font-medium text-sm mb-2">Ajouter un morceau</h2>
         <form method="get" action="{{ path('app_playlists_show', {id: playlist.id}) }}" class="flex items-center gap-2">
             <input type="text" name="q" value="{{ searchQuery }}" placeholder="Titre, artiste, album…" minlength="2"
-                   class="border rounded px-2 py-1 text-sm flex-1 min-w-0">
-            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded">Rechercher</button>
+                   class="border rounded-sm px-2 py-1 text-sm flex-1 min-w-0">
+            <button type="submit" class="text-sm bg-slate-100 hover:bg-slate-200 px-3 py-1.5 rounded-sm">Rechercher</button>
             {% if searchQuery is not empty %}
                 <a href="{{ path('app_playlists_show', {id: playlist.id}) }}" class="text-xs text-slate-500 hover:underline">Effacer</a>
             {% endif %}
@@ -252,7 +252,7 @@
                                         <input type="hidden" name="_token" value="{{ csrf_token('add-track' ~ playlist.id) }}">
                                         <input type="hidden" name="songId" value="{{ r.id }}">
                                         <input type="hidden" name="q" value="{{ searchQuery }}">
-                                        <button type="submit" class="text-xs bg-emerald-100 hover:bg-emerald-200 text-emerald-800 px-2 py-1 rounded">+ Ajouter</button>
+                                        <button type="submit" class="text-xs bg-emerald-100 hover:bg-emerald-200 text-emerald-800 px-2 py-1 rounded-sm">+ Ajouter</button>
                                     </form>
                                 </td>
                             </tr>

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -3,11 +3,11 @@
 {% block title %}Connexion{% endblock %}
 
 {% block body %}
-    <div class="max-w-md mx-auto bg-white shadow rounded p-6 mt-12">
+    <div class="max-w-md mx-auto bg-white shadow-sm rounded-sm p-6 mt-12">
         <h1 class="text-xl font-semibold mb-4">Connexion</h1>
 
         {% if error %}
-            <div class="mb-4 px-3 py-2 bg-rose-50 border border-rose-300 text-rose-800 rounded text-sm">
+            <div class="mb-4 px-3 py-2 bg-rose-50 border border-rose-300 text-rose-800 rounded-sm text-sm">
                 {{ error.messageKey|trans(error.messageData, 'security') }}
             </div>
         {% endif %}
@@ -16,15 +16,15 @@
             <div>
                 <label for="username" class="block text-sm font-medium mb-1">Identifiant</label>
                 <input type="text" id="username" name="_username" value="{{ last_username }}" autofocus required
-                       class="w-full border rounded px-3 py-2">
+                       class="w-full border rounded-sm px-3 py-2">
             </div>
             <div>
                 <label for="password" class="block text-sm font-medium mb-1">Mot de passe</label>
                 <input type="password" id="password" name="_password" required
-                       class="w-full border rounded px-3 py-2">
+                       class="w-full border rounded-sm px-3 py-2">
             </div>
             <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
-            <button type="submit" class="w-full bg-slate-900 text-white py-2 rounded hover:bg-slate-700">
+            <button type="submit" class="w-full bg-slate-900 text-white py-2 rounded-sm hover:bg-slate-700">
                 Se connecter
             </button>
         </form>

--- a/templates/settings/index.html.twig
+++ b/templates/settings/index.html.twig
@@ -5,20 +5,20 @@
 {% block body %}
     <h1 class="text-2xl font-semibold mb-4">Réglages globaux</h1>
 
-    <form method="post" class="bg-white shadow rounded p-6 max-w-xl space-y-4">
+    <form method="post" class="bg-white shadow-sm rounded-sm p-6 max-w-xl space-y-4">
         <input type="hidden" name="_token" value="{{ csrf_token('settings') }}">
 
         <div>
             <label for="default_limit" class="block text-sm font-medium mb-1">Nombre de morceaux par défaut</label>
             <input type="number" min="1" max="1000" id="default_limit" name="default_limit"
-                   value="{{ default_limit }}" class="w-full border rounded px-3 py-2">
+                   value="{{ default_limit }}" class="w-full border rounded-sm px-3 py-2">
             <p class="text-xs text-slate-500 mt-1">Utilisé lorsqu'une définition n'override pas la valeur.</p>
         </div>
 
         <div>
             <label for="default_template" class="block text-sm font-medium mb-1">Modèle de nom par défaut</label>
             <input type="text" id="default_template" name="default_template"
-                   value="{{ default_template }}" class="w-full border rounded px-3 py-2 font-mono text-sm">
+                   value="{{ default_template }}" class="w-full border rounded-sm px-3 py-2 font-mono text-sm">
             <p class="text-xs text-slate-500 mt-1">
                 Variables : <code>{date}</code>, <code>{datetime}</code>, <code>{month}</code>, <code>{year}</code>,
                 <code>{label}</code>, <code>{name}</code>, <code>{preset}</code>, <code>{param:nom}</code>.
@@ -26,22 +26,22 @@
         </div>
 
         <div class="flex justify-end">
-            <button type="submit" class="px-4 py-2 text-sm rounded bg-emerald-600 hover:bg-emerald-700 text-white">
+            <button type="submit" class="px-4 py-2 text-sm rounded-sm bg-emerald-600 hover:bg-emerald-700 text-white">
                 Enregistrer
             </button>
         </div>
     </form>
 
-    <div class="bg-white shadow rounded p-6 max-w-xl mt-6 space-y-3">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mt-6 space-y-3">
         <h2 class="text-lg font-semibold">Connexion Last.fm authentifiée</h2>
         {% if not lastfm_auth_configured %}
-            <p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded px-3 py-2">
+            <p class="text-sm text-amber-700 bg-amber-50 border border-amber-200 rounded-sm px-3 py-2">
                 Renseignez <code>LASTFM_API_KEY</code> et <code>LASTFM_API_SECRET</code> dans la
                 configuration pour activer la sync loved ↔ starred.
             </p>
         {% elseif lastfm_session_user %}
             <p class="text-sm">
-                <span class="inline-block px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 text-xs">✓ connecté</span>
+                <span class="inline-block px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 text-xs">✓ connecté</span>
                 en tant que <code>{{ lastfm_session_user }}</code>.
             </p>
             <div class="flex items-center gap-3 text-sm">
@@ -55,15 +55,15 @@
             </div>
         {% else %}
             <p class="text-sm">
-                <span class="inline-block px-2 py-0.5 rounded bg-slate-200 text-slate-700 text-xs">✗ non connecté</span>
+                <span class="inline-block px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700 text-xs">✗ non connecté</span>
                 — la sync loved ↔ starred reste indisponible tant que la connexion n'est pas faite.
             </p>
             <a href="{{ path('app_lastfm_connect') }}"
-               class="inline-block px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Se connecter à Last.fm</a>
+               class="inline-block px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Se connecter à Last.fm</a>
         {% endif %}
     </div>
 
-    <div class="bg-white shadow rounded p-6 max-w-xl mt-6 space-y-3">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mt-6 space-y-3">
         <h2 class="text-lg font-semibold">Notifications</h2>
         {% if notifier_drivers is empty %}
             <p class="text-sm text-slate-600">
@@ -72,9 +72,9 @@
         {% else %}
             <p class="text-sm">
                 État : {% if notifier_enabled %}
-                    <span class="inline-block px-2 py-0.5 rounded bg-emerald-100 text-emerald-800 text-xs">✓ actif</span>
+                    <span class="inline-block px-2 py-0.5 rounded-sm bg-emerald-100 text-emerald-800 text-xs">✓ actif</span>
                 {% else %}
-                    <span class="inline-block px-2 py-0.5 rounded bg-slate-200 text-slate-700 text-xs">✗ désactivé</span>
+                    <span class="inline-block px-2 py-0.5 rounded-sm bg-slate-200 text-slate-700 text-xs">✗ désactivé</span>
                 {% endif %}
                 — filtre <code>NOTIFY_ON</code> : <code>{{ notifier_on }}</code>
                 {% if notifier_on == 'error' %}<span class="text-slate-500">(uniquement les échecs)</span>
@@ -108,12 +108,12 @@
                 <input type="hidden" name="_token" value="{{ csrf_token('settings_test_notification') }}">
                 <button type="submit" name="kind" value="success"
                         {% if not notifier_enabled %}disabled{% endif %}
-                        class="px-3 py-1.5 text-sm rounded bg-emerald-600 hover:bg-emerald-700 text-white disabled:bg-slate-300 disabled:cursor-not-allowed">
+                        class="px-3 py-1.5 text-sm rounded-sm bg-emerald-600 hover:bg-emerald-700 text-white disabled:bg-slate-300 disabled:cursor-not-allowed">
                     Envoyer un test (succès)
                 </button>
                 <button type="submit" name="kind" value="error"
                         {% if not notifier_enabled %}disabled{% endif %}
-                        class="px-3 py-1.5 text-sm rounded bg-rose-600 hover:bg-rose-700 text-white disabled:bg-slate-300 disabled:cursor-not-allowed">
+                        class="px-3 py-1.5 text-sm rounded-sm bg-rose-600 hover:bg-rose-700 text-white disabled:bg-slate-300 disabled:cursor-not-allowed">
                     Envoyer un test (erreur)
                 </button>
                 {% if not notifier_enabled %}
@@ -129,7 +129,7 @@
         {% endif %}
     </div>
 
-    <div class="bg-white shadow rounded p-6 max-w-xl mt-6 border border-rose-200 space-y-3">
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mt-6 border border-rose-200 space-y-3">
         <h2 class="text-lg font-semibold text-rose-800">Zone dangereuse</h2>
         <p class="text-sm text-slate-700">
             Vide complètement la base locale du tool : buffer Last.fm, audit par-track,
@@ -155,10 +155,10 @@
                     Tapez <code>WIPE</code> pour confirmer
                 </label>
                 <input type="text" id="wipe_confirm" name="confirm" autocomplete="off"
-                       class="w-full border rounded px-3 py-2 font-mono text-sm" required pattern="WIPE">
+                       class="w-full border rounded-sm px-3 py-2 font-mono text-sm" required pattern="WIPE">
             </div>
             <div class="flex justify-end">
-                <button type="submit" class="px-4 py-2 text-sm rounded bg-rose-600 hover:bg-rose-700 text-white">
+                <button type="submit" class="px-4 py-2 text-sm rounded-sm bg-rose-600 hover:bg-rose-700 text-white">
                     Vider la base tools
                 </button>
             </div>

--- a/templates/stats/charts.html.twig
+++ b/templates/stats/charts.html.twig
@@ -14,15 +14,15 @@
     </div>
 
     {% if not has_scrobbles %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             La table <code>scrobbles</code> de Navidrome est introuvable. Les graphiques nécessitent Navidrome ≥ 0.55.
         </div>
     {% endif %}
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-6 flex flex-wrap items-end gap-3">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-6 flex flex-wrap items-end gap-3">
         <div>
             <label class="block text-xs uppercase text-slate-500" for="months">Fenêtre (mois)</label>
-            <select name="months" id="months" class="border rounded px-2 py-1 text-sm" onchange="this.form.submit()">
+            <select name="months" id="months" class="border rounded-sm px-2 py-1 text-sm" onchange="this.form.submit()">
                 {% for m in allowed_months %}
                     <option value="{{ m }}" {{ m == months ? 'selected' : '' }}>{{ m }} mois</option>
                 {% endfor %}
@@ -31,14 +31,14 @@
     </form>
 
     <div class="grid grid-cols-1 gap-6">
-        <div class="bg-white shadow rounded p-5">
+        <div class="bg-white shadow-sm rounded-sm p-5">
             <h2 class="font-semibold text-sm mb-3">Écoutes par mois ({{ months }} mois)</h2>
             <div class="h-64">
                 <canvas id="chart-plays-month"></canvas>
             </div>
         </div>
 
-        <div class="bg-white shadow rounded p-5">
+        <div class="bg-white shadow-sm rounded-sm p-5">
             <h2 class="font-semibold text-sm mb-3">Top 5 artistes au fil du temps</h2>
             <div class="grid grid-cols-1 md:grid-cols-[1fr,200px] gap-4 items-center">
                 <div class="h-72">
@@ -47,7 +47,7 @@
                 <ul class="text-sm space-y-2">
                     {% for a in top_artists %}
                         <li class="flex items-center gap-2">
-                            <span class="inline-block w-3 h-3 rounded-full flex-shrink-0"
+                            <span class="inline-block w-3 h-3 rounded-full shrink-0"
                                   style="background:{{ top_artists_palette[loop.index0 % top_artists_palette|length] }}"></span>
                             {{ cover_with_fallback('artist', a.artist_id, a.artist, 28) }}
                             <span class="truncate">
@@ -60,14 +60,14 @@
             </div>
         </div>
 
-        <div class="bg-white shadow rounded p-5">
+        <div class="bg-white shadow-sm rounded-sm p-5">
             <h2 class="font-semibold text-sm mb-3">Distribution par jour de la semaine (90 derniers jours)</h2>
             <div class="h-64">
                 <canvas id="chart-dow"></canvas>
             </div>
         </div>
 
-        <div class="bg-white shadow rounded p-5">
+        <div class="bg-white shadow-sm rounded-sm p-5">
             <h2 class="font-semibold text-sm mb-3">Diversité d'écoute ({{ months }} mois)</h2>
             <p class="text-xs text-slate-500 mb-3">
                 Ratio artistes uniques par écoute, mois par mois. Plus c'est haut, plus tu explores ;

--- a/templates/stats/compare.html.twig
+++ b/templates/stats/compare.html.twig
@@ -8,10 +8,10 @@
         <a href="{{ path('app_stats') }}" class="text-sm text-slate-500 hover:underline">← Vue d'ensemble</a>
     </div>
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-6 flex flex-wrap items-end gap-4">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-6 flex flex-wrap items-end gap-4">
         <div>
             <label class="block text-xs uppercase text-slate-500" for="period1">Période 1</label>
-            <select name="period1" id="period1" class="border rounded px-2 py-1 text-sm">
+            <select name="period1" id="period1" class="border rounded-sm px-2 py-1 text-sm">
                 {% for k, label in periods %}
                     <option value="{{ k }}" {{ k == period1 ? 'selected' : '' }}>{{ label }}</option>
                 {% endfor %}
@@ -20,17 +20,17 @@
         <div class="text-2xl text-slate-400 pt-5">vs</div>
         <div>
             <label class="block text-xs uppercase text-slate-500" for="period2">Période 2</label>
-            <select name="period2" id="period2" class="border rounded px-2 py-1 text-sm">
+            <select name="period2" id="period2" class="border rounded-sm px-2 py-1 text-sm">
                 {% for k, label in periods %}
                     <option value="{{ k }}" {{ k == period2 ? 'selected' : '' }}>{{ label }}</option>
                 {% endfor %}
             </select>
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Comparer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Comparer</button>
     </form>
 
     {% if error %}
-        <div class="bg-rose-50 border border-rose-300 text-rose-800 rounded p-4 mb-6">{{ error }}</div>
+        <div class="bg-rose-50 border border-rose-300 text-rose-800 rounded-sm p-4 mb-6">{{ error }}</div>
     {% endif %}
 
     {% if result %}
@@ -50,7 +50,7 @@
             {% endif %}
             {% if args %}
                 <a href="{{ path('app_playlist_new', args) }}"
-                   class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100 mt-2">
+                   class="inline-flex items-center gap-1 text-xs px-2 py-1 rounded-sm bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100 mt-2">
                     + Playlist depuis « {{ label }} »
                 </a>
             {% endif %}
@@ -60,7 +60,7 @@
         {# Summary cards #}
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
             {% for snap in [result.period1, result.period2] %}
-                <div class="bg-white shadow rounded p-5">
+                <div class="bg-white shadow-sm rounded-sm p-5">
                     <div class="text-xs uppercase text-slate-500">{{ snap.label }}</div>
                     <div class="mt-2 flex items-baseline gap-6">
                         <div>
@@ -88,12 +88,12 @@
             {% set text = status == 'nouveau' ? 'NEW'
                 : status == 'disparu' ? 'gone'
                 : (delta > 0 ? '+' ~ delta : delta) %}
-            <span class="text-xs px-2 py-0.5 rounded {{ badge }}">{{ arrow }} {{ text }}</span>
+            <span class="text-xs px-2 py-0.5 rounded-sm {{ badge }}">{{ arrow }} {{ text }}</span>
         {% endmacro %}
         {% import _self as ui %}
 
         {# Top artists #}
-        <div class="bg-white shadow rounded overflow-hidden mb-6">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-6">
             <div class="px-4 py-3 border-b bg-slate-50">
                 <h2 class="font-semibold text-sm">Top artistes</h2>
             </div>
@@ -122,7 +122,7 @@
         </div>
 
         {# Top tracks #}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <div class="px-4 py-3 border-b bg-slate-50">
                 <h2 class="font-semibold text-sm">Top morceaux</h2>
             </div>

--- a/templates/stats/forgotten_artists.html.twig
+++ b/templates/stats/forgotten_artists.html.twig
@@ -5,10 +5,10 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
-        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
-        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Heatmap</a>
-        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Wrapped</a>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Heatmap</a>
+        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Wrapped</a>
     </div>
 
     <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
@@ -22,32 +22,32 @@
     </p>
 
     {% if not has_scrobbles %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             La table <code>scrobbles</code> de Navidrome est introuvable. Cette page nécessite Navidrome ≥ 0.55.
         </div>
     {% endif %}
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-6 flex flex-wrap items-end gap-4">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-6 flex flex-wrap items-end gap-4">
         <div>
             <label class="block text-xs uppercase text-slate-500" for="min_plays">Plays minimum</label>
             <input type="number" name="min_plays" id="min_plays" value="{{ min_plays }}" min="1"
-                   class="border rounded px-2 py-1 text-sm w-24">
+                   class="border rounded-sm px-2 py-1 text-sm w-24">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500" for="idle_months">Inactif depuis</label>
-            <select name="idle_months" id="idle_months" class="border rounded px-2 py-1 text-sm">
+            <select name="idle_months" id="idle_months" class="border rounded-sm px-2 py-1 text-sm">
                 {% for m in allowed_idle_months %}
                     <option value="{{ m }}" {{ m == idle_months ? 'selected' : '' }}>{{ m }} mois</option>
                 {% endfor %}
             </select>
         </div>
-        <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+        <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm">
             Filtrer
         </button>
     </form>
 
     {% if has_scrobbles %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between">
                 <h2 class="font-semibold text-sm">{{ artists|length }} artiste(s)</h2>
             </div>

--- a/templates/stats/heatmap.html.twig
+++ b/templates/stats/heatmap.html.twig
@@ -9,13 +9,13 @@
     </div>
 
     {% if not has_scrobbles %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             La table <code>scrobbles</code> de Navidrome est introuvable. Les heatmaps nécessitent Navidrome ≥ 0.55.
         </div>
     {% endif %}
 
     {# ---------- Day × hour heatmap (last 90 days) ---------- #}
-    <div class="bg-white shadow rounded p-5 mb-6 overflow-x-auto">
+    <div class="bg-white shadow-sm rounded-sm p-5 mb-6 overflow-x-auto">
         <h2 class="font-semibold text-sm mb-3">
             Jour × heure — 90 derniers jours
             <span class="text-xs text-slate-500">(max : {{ max_hour|number_format(0, '.', ' ') }} écoutes)</span>
@@ -51,7 +51,7 @@
     </div>
 
     {# ---------- Year × day heatmap (GitHub-style) ---------- #}
-    <div class="bg-white shadow rounded p-5">
+    <div class="bg-white shadow-sm rounded-sm p-5">
         <div class="flex items-center justify-between mb-3 flex-wrap gap-3">
             <h2 class="font-semibold text-sm">
                 Année {{ year }} — jour par jour
@@ -59,7 +59,7 @@
             </h2>
             <form method="get" class="flex items-center gap-2 text-sm">
                 <label for="year">Année :</label>
-                <select name="year" id="year" onchange="this.form.submit()" class="border rounded px-2 py-1">
+                <select name="year" id="year" onchange="this.form.submit()" class="border rounded-sm px-2 py-1">
                     {% for y in available_years %}
                         <option value="{{ y }}" {{ y == year ? 'selected' : '' }}>{{ y }}</option>
                     {% endfor %}
@@ -99,7 +99,7 @@
                                 {% if cell %}
                                     {% set ratio = max_daily > 0 ? cell.plays / max_daily : 0 %}
                                     {% set opacity = ratio > 0 ? (0.15 + ratio * 0.85) : 0 %}
-                                    <div class="w-3 h-3 rounded-sm"
+                                    <div class="w-3 h-3 rounded-xs"
                                          style="background-color: {{ cell.plays > 0 ? 'rgba(16, 185, 129, ' ~ opacity ~ ')' : '#e5e7eb' }};"
                                          title="{{ cell.date }} : {{ cell.plays }} écoutes"></div>
                                 {% else %}

--- a/templates/stats/incomplete_metadata.html.twig
+++ b/templates/stats/incomplete_metadata.html.twig
@@ -5,9 +5,9 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
-        <a href="{{ path('app_stats_forgotten_artists') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Artistes oubliés</a>
-        <a href="{{ path('app_tagging_missing_mbid') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Morceaux sans MBID</a>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_forgotten_artists') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Artistes oubliés</a>
+        <a href="{{ path('app_tagging_missing_mbid') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Morceaux sans MBID</a>
     </div>
 
     <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
@@ -23,11 +23,11 @@
     </p>
 
     {% if not available %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             La base Navidrome n'est pas accessible.
         </div>
     {% elseif by_artist is empty %}
-        <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded p-4 text-sm">
+        <div class="bg-emerald-50 border border-emerald-300 text-emerald-800 rounded-sm p-4 text-sm">
             🎉 Aucun album sans <code>mbz_album_id</code> dans le top {{ 200 }}. Soit ta lib est
             bien taggée, soit la colonne <code>mbz_album_id</code> n'existe pas (Navidrome très ancien).
         </div>
@@ -38,7 +38,7 @@
 
         <div class="space-y-4">
             {% for group in by_artist %}
-                <div class="bg-white shadow rounded overflow-hidden">
+                <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                     <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between">
                         <h2 class="font-semibold text-sm">
                             {{ group.artist }}

--- a/templates/stats/index.html.twig
+++ b/templates/stats/index.html.twig
@@ -5,10 +5,10 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
-        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
-        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Heatmap</a>
-        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Wrapped</a>
+        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Heatmap</a>
+        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Wrapped</a>
     </div>
 
     <div class="flex items-start justify-between mb-6 flex-wrap gap-3">
@@ -17,7 +17,7 @@
         <form method="get" action="{{ path('app_stats') }}" class="flex items-center gap-2 flex-wrap">
             <label for="period" class="text-sm">Période :</label>
             <select name="period" id="period" onchange="this.form.submit()"
-                    class="border rounded px-2 py-1 text-sm">
+                    class="border rounded-sm px-2 py-1 text-sm">
                 {% for key, label in periods %}
                     <option value="{{ key }}" {{ key == period ? 'selected' : '' }}>{{ label }}</option>
                 {% endfor %}
@@ -26,7 +26,7 @@
             {% if clients is not empty %}
                 <label for="client" class="text-sm">Client :</label>
                 <select name="client" id="client" onchange="this.form.submit()"
-                        class="border rounded px-2 py-1 text-sm">
+                        class="border rounded-sm px-2 py-1 text-sm">
                     <option value="">Tous</option>
                     {% for c in clients %}
                         <option value="{{ c }}" {{ c == client ? 'selected' : '' }}>{{ c }}</option>
@@ -40,7 +40,7 @@
             <input type="hidden" name="period" value="{{ period }}">
             {% if client %}<input type="hidden" name="client" value="{{ client }}">{% endif %}
             <input type="hidden" name="_token" value="{{ csrf_token('stats_refresh_' ~ refreshKey) }}">
-            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm">
                 ↻ Rafraîchir
             </button>
         </form>
@@ -63,14 +63,14 @@
     {% if newPlaylistArgs %}
         <div class="mb-6">
             <a href="{{ path('app_playlist_new', newPlaylistArgs) }}"
-               class="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100">
+               class="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-sm bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100">
                 <span>+ Créer une playlist depuis ce top</span>
             </a>
         </div>
     {% endif %}
 
     {% if stale %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             Aucune donnée en cache pour cette période. Cliquez sur <strong>Rafraîchir</strong> pour la calculer.
         </div>
     {% else %}
@@ -84,18 +84,18 @@
         </p>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Total d'écoutes</div>
                 <div class="text-3xl font-semibold mt-1">{{ snapshot.data.total_plays|number_format(0, '.', ' ') }}</div>
             </div>
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Morceaux distincts écoutés</div>
                 <div class="text-3xl font-semibold mt-1">{{ snapshot.data.distinct_tracks|number_format(0, '.', ' ') }}</div>
             </div>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <div class="bg-white shadow rounded overflow-hidden">
+            <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50">
                     <h2 class="font-semibold text-sm">Top 10 artistes</h2>
                 </div>
@@ -123,7 +123,7 @@
                 {% endif %}
             </div>
 
-            <div class="bg-white shadow rounded overflow-hidden">
+            <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50">
                     <h2 class="font-semibold text-sm">Top 50 morceaux</h2>
                 </div>

--- a/templates/stats/lastfm_history.html.twig
+++ b/templates/stats/lastfm_history.html.twig
@@ -5,12 +5,12 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
-        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
-        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
-        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Heatmap</a>
-        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Wrapped</a>
-        <a href="{{ path('app_stats_navidrome_history') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Historique Navidrome</a>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Heatmap</a>
+        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Wrapped</a>
+        <a href="{{ path('app_stats_navidrome_history') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Historique Navidrome</a>
     </div>
 
     <div class="flex items-start justify-between mb-6 flex-wrap gap-3">
@@ -35,8 +35,8 @@
             <form method="get" action="{{ path('app_stats_lastfm_history') }}" class="flex items-center gap-2">
                 <label for="user" class="text-xs uppercase text-slate-500">User Last.fm</label>
                 <input type="text" name="user" id="user" value="{{ user }}"
-                       class="border rounded px-2 py-1 text-sm w-40">
-                <button type="submit" class="px-3 py-1 rounded bg-slate-100 hover:bg-slate-200 text-sm">Voir</button>
+                       class="border rounded-sm px-2 py-1 text-sm w-40">
+                <button type="submit" class="px-3 py-1 rounded-sm bg-slate-100 hover:bg-slate-200 text-sm">Voir</button>
             </form>
 
             <form method="post" action="{{ path('app_stats_lastfm_history_refresh') }}">
@@ -44,7 +44,7 @@
                 <input type="hidden" name="_token" value="{{ csrf_token('lastfm_history_refresh') }}">
                 <button type="submit"
                         {{ not api_key_configured ? 'disabled' : '' }}
-                        class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                        class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                         title="{{ api_key_configured ? 'Récupère les 100 derniers scrobbles via l\'API Last.fm' : 'LASTFM_API_KEY non défini' }}">
                     ↻ Rafraîchir depuis Last.fm
                 </button>
@@ -53,7 +53,7 @@
     </div>
 
     {% if user and not api_key_configured %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-4 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-4 text-sm">
             <strong>LASTFM_API_KEY</strong> n'est pas défini dans l'environnement. Configurez-le pour
             pouvoir rafraîchir l'historique. Une clé est gratuite sur
             <a href="https://www.last.fm/api/account/create" class="underline">last.fm/api/account/create</a>.
@@ -61,11 +61,11 @@
     {% endif %}
 
     {% if user and entries is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun scrobble en cache pour <strong>{{ user }}</strong>. Cliquez sur « Rafraîchir » pour interroger l'API.
         </div>
     {% elseif user %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>

--- a/templates/stats/navidrome_history.html.twig
+++ b/templates/stats/navidrome_history.html.twig
@@ -5,12 +5,12 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
-        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
-        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
-        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Heatmap</a>
-        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Wrapped</a>
-        <a href="{{ path('app_stats_lastfm_history') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Historique Last.fm</a>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats_heatmap') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Heatmap</a>
+        <a href="{{ path('app_wrapped_default') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Wrapped</a>
+        <a href="{{ path('app_stats_lastfm_history') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Historique Last.fm</a>
     </div>
 
     <div class="flex items-start justify-between mb-6 flex-wrap gap-3">
@@ -30,7 +30,7 @@
             <input type="hidden" name="_token" value="{{ csrf_token('navidrome_history_refresh') }}">
             <button type="submit"
                     {{ not has_scrobbles ? 'disabled' : '' }}
-                    class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                     title="{{ has_scrobbles ? 'Recharge depuis la table scrobbles de Navidrome' : 'Table scrobbles inaccessible' }}">
                 ↻ Rafraîchir depuis Navidrome
             </button>
@@ -38,17 +38,17 @@
     </div>
 
     {% if not has_scrobbles %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-4 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-4 text-sm">
             La table <code>scrobbles</code> n'est pas disponible (Navidrome ≥ 0.55 requis).
         </div>
     {% endif %}
 
     {% if entries is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun snapshot en cache. Cliquez sur « Rafraîchir » pour le générer.
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>

--- a/templates/stats/tops.html.twig
+++ b/templates/stats/tops.html.twig
@@ -5,9 +5,9 @@
 {% block body %}
     <div class="flex flex-wrap items-center gap-3 text-xs mb-4">
         <span class="text-slate-500">Voir aussi :</span>
-        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
-        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
-        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded bg-slate-100 hover:bg-slate-200">Graphiques</a>
+        <a href="{{ path('app_stats') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Vue d'ensemble</a>
+        <a href="{{ path('app_stats_compare') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Comparer 2 périodes</a>
+        <a href="{{ path('app_stats_charts') }}" class="px-2 py-1 rounded-sm bg-slate-100 hover:bg-slate-200">Graphiques</a>
     </div>
 
     <h1 class="text-2xl font-semibold mb-2">Tops sur fenêtre libre</h1>
@@ -20,22 +20,22 @@
     {% set fromStr = from|date('Y-m-d') %}
     {% set toStr = to|date('Y-m-d')|date_modify('-1 day')|date('Y-m-d') %}
 
-    <div class="bg-white shadow rounded p-4 mb-6">
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
         <form method="get" action="{{ path('app_stats_tops') }}" class="flex flex-wrap items-end gap-3">
             <div>
                 <label class="block text-xs text-slate-500 mb-1" for="from">Du</label>
                 <input type="date" id="from" name="from" value="{{ fromStr }}"
-                       class="border rounded px-2 py-1 text-sm">
+                       class="border rounded-sm px-2 py-1 text-sm">
             </div>
             <div>
                 <label class="block text-xs text-slate-500 mb-1" for="to">Au</label>
                 <input type="date" id="to" name="to" value="{{ toStr }}"
-                       class="border rounded px-2 py-1 text-sm">
+                       class="border rounded-sm px-2 py-1 text-sm">
             </div>
             {% if clients is not empty %}
                 <div>
                     <label class="block text-xs text-slate-500 mb-1" for="client">Client</label>
-                    <select name="client" id="client" class="border rounded px-2 py-1 text-sm">
+                    <select name="client" id="client" class="border rounded-sm px-2 py-1 text-sm">
                         <option value="">Tous</option>
                         {% for c in clients %}
                             <option value="{{ c }}" {{ c == client ? 'selected' : '' }}>{{ c }}</option>
@@ -43,7 +43,7 @@
                     </select>
                 </div>
             {% endif %}
-            <button type="submit" class="bg-slate-800 hover:bg-slate-900 text-white px-3 py-1.5 rounded text-sm">
+            <button type="submit" class="bg-slate-800 hover:bg-slate-900 text-white px-3 py-1.5 rounded-sm text-sm">
                 Voir
             </button>
         </form>
@@ -61,14 +61,14 @@
             <input type="hidden" name="to" value="{{ toStr }}">
             {% if client %}<input type="hidden" name="client" value="{{ client }}">{% endif %}
             <input type="hidden" name="_token" value="{{ csrf_token('tops_' ~ from.timestamp ~ '_' ~ to.timestamp ~ '_' ~ (client ?? '')) }}">
-            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+            <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm">
                 ↻ {{ snapshot ? 'Recalculer' : 'Calculer' }}
             </button>
         </form>
     </div>
 
     {% if snapshot is null %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-4 mb-6 text-sm">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-4 mb-6 text-sm">
             Aucune donnée en cache pour cette fenêtre. Cliquez sur <strong>Calculer</strong>.
         </div>
     {% else %}
@@ -77,11 +77,11 @@
         </p>
 
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Total d'écoutes</div>
                 <div class="text-3xl font-semibold mt-1">{{ snapshot.data.total_plays|number_format(0, '.', ' ') }}</div>
             </div>
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Morceaux distincts écoutés</div>
                 <div class="text-3xl font-semibold mt-1">{{ snapshot.data.distinct_tracks|number_format(0, '.', ' ') }}</div>
             </div>
@@ -89,7 +89,7 @@
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
             {# ---------- Top artists ---------- #}
-            <div class="bg-white shadow rounded overflow-hidden">
+            <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50">
                     <h2 class="font-semibold text-sm">Top {{ limits.artists }} artistes</h2>
                 </div>
@@ -120,7 +120,7 @@
             </div>
 
             {# ---------- Top albums ---------- #}
-            <div class="bg-white shadow rounded overflow-hidden">
+            <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50">
                     <h2 class="font-semibold text-sm">Top {{ limits.albums }} albums</h2>
                 </div>
@@ -154,7 +154,7 @@
             </div>
 
             {# ---------- Top tracks + create-playlist action ---------- #}
-            <div class="bg-white shadow rounded overflow-hidden">
+            <div class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50 flex items-center justify-between gap-2">
                     <h2 class="font-semibold text-sm">Top {{ limits.tracks }} morceaux</h2>
                 </div>
@@ -169,16 +169,16 @@
                         <div class="flex flex-col">
                             <label for="count" class="text-slate-600 mb-1">Nb morceaux</label>
                             <input type="number" id="count" name="count" min="1" max="{{ limits.tracks }}" value="50"
-                                   class="border rounded px-2 py-1 w-24">
+                                   class="border rounded-sm px-2 py-1 w-24">
                         </div>
                         <div class="flex flex-col flex-1 min-w-[180px]">
                             <label for="name" class="text-slate-600 mb-1">Nom (optionnel)</label>
                             <input type="text" id="name" name="name"
                                    placeholder="Top X morceaux {{ fromStr }} → {{ toStr }}"
-                                   class="border rounded px-2 py-1">
+                                   class="border rounded-sm px-2 py-1">
                         </div>
                         <button type="submit"
-                                class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded">
+                                class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm">
                             + Créer playlist Navidrome
                         </button>
                     </form>
@@ -218,7 +218,7 @@
     {% endif %}
 
     {% if recent is not empty %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <div class="px-4 py-3 border-b bg-slate-50">
                 <h2 class="font-semibold text-sm">Dernières fenêtres calculées</h2>
             </div>

--- a/templates/tagging/missing_mbid.html.twig
+++ b/templates/tagging/missing_mbid.html.twig
@@ -19,14 +19,14 @@
         <form method="post" action="{{ path('app_tagging_missing_mbid_rescan') }}"
               onsubmit="return confirm('Déclencher un rescan Navidrome maintenant ?');">
             <input type="hidden" name="_token" value="{{ csrf_token('missing_mbid_rescan') }}">
-            <button type="submit" class="px-3 py-1.5 rounded bg-emerald-600 text-white text-sm hover:bg-emerald-700">
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-emerald-600 text-white text-sm hover:bg-emerald-700">
                 ↻ Rescan Navidrome
             </button>
         </form>
     </div>
 
     {% if beets_queue_configured %}
-        <div class="mb-4 p-3 rounded bg-sky-50 border border-sky-200 text-sm flex items-center justify-between gap-3 flex-wrap">
+        <div class="mb-4 p-3 rounded-sm bg-sky-50 border border-sky-200 text-sm flex items-center justify-between gap-3 flex-wrap">
             <div class="text-sky-900">
                 Queue beets active —
                 {% if beets_queue_pending is null or beets_queue_pending == 0 %}
@@ -40,24 +40,24 @@
         </div>
     {% endif %}
 
-    <form method="get" class="bg-white shadow rounded p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 grid grid-cols-1 sm:grid-cols-4 gap-3 items-end">
         <div>
             <label class="block text-xs uppercase text-slate-500">Artiste</label>
             <input type="search" name="artist" value="{{ filters.artist|default('') }}" placeholder="ex. Daft Punk"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div>
             <label class="block text-xs uppercase text-slate-500">Album</label>
             <input type="search" name="album" value="{{ filters.album|default('') }}" placeholder="ex. Discovery"
-                   class="w-full border rounded px-2 py-1 text-sm">
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
         <div class="flex gap-2">
-            <button type="submit" class="px-3 py-1.5 rounded bg-slate-900 text-white text-sm">Filtrer</button>
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
             <a href="{{ path('app_tagging_missing_mbid') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         </div>
         <div class="text-right flex flex-col gap-1">
             <a href="{{ path('app_tagging_missing_mbid_export', filters|merge({limit: 5000})) }}"
-               class="inline-block px-3 py-1.5 rounded bg-slate-700 text-white text-sm hover:bg-slate-800"
+               class="inline-block px-3 py-1.5 rounded-sm bg-slate-700 text-white text-sm hover:bg-slate-800"
                title="Télécharge les 5 000 premiers chemins (filtres appliqués) au format CSV">
                 ⬇ Export CSV
             </a>
@@ -71,7 +71,7 @@
             <input type="hidden" name="artist" value="{{ filters.artist|default('') }}">
             <input type="hidden" name="album" value="{{ filters.album|default('') }}">
             <input type="hidden" name="limit" value="5000">
-            <button type="submit" class="px-3 py-1.5 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700">
+            <button type="submit" class="px-3 py-1.5 rounded-sm bg-indigo-600 text-white text-sm hover:bg-indigo-700">
                 📋 Pousser dans la queue beets
             </button>
             <span class="text-xs text-slate-500">
@@ -82,11 +82,11 @@
     {% endif %}
 
     {% if rows is empty %}
-        <div class="bg-white shadow rounded p-6 text-center text-slate-500">
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
             Aucun track sans MBID pour ce filtre 🎉
         </div>
     {% else %}
-        <div class="bg-white shadow rounded overflow-hidden">
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
             <table class="w-full text-sm">
                 <thead class="bg-slate-100 text-slate-600 text-left text-xs">
                 <tr>
@@ -119,12 +119,12 @@
             <div class="flex items-center justify-center gap-2 mt-4 text-sm">
                 {% if page > 1 %}
                     <a href="{{ path('app_tagging_missing_mbid', filters|merge({page: page - 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">‹ Précédent</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
                 {% endif %}
                 <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
                 {% if page < total_pages %}
                     <a href="{{ path('app_tagging_missing_mbid', filters|merge({page: page + 1})) }}"
-                       class="px-3 py-1 rounded border hover:bg-slate-100">Suivant ›</a>
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/wrapped/show.html.twig
+++ b/templates/wrapped/show.html.twig
@@ -11,7 +11,7 @@
         <div class="flex items-center gap-2">
             <form method="get" action="{{ path('app_wrapped_default') }}" class="inline">
                 <select name="year" onchange="window.location.href = '{{ path('app_wrapped', {year: 9999}) }}'.replace('9999', this.value)"
-                        class="border rounded px-2 py-1 text-sm">
+                        class="border rounded-sm px-2 py-1 text-sm">
                     {% for y in available_years %}
                         <option value="{{ y }}" {{ y == year ? 'selected' : '' }}>Wrapped {{ y }}</option>
                     {% endfor %}
@@ -19,7 +19,7 @@
             </form>
             <form method="post" action="{{ path('app_wrapped_refresh', {year: year}) }}">
                 <input type="hidden" name="_token" value="{{ csrf_token('wrapped_refresh_' ~ year) }}">
-                <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded text-sm">
+                <button type="submit" class="bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1.5 rounded-sm text-sm">
                     ↻ {{ snapshot ? 'Recalculer' : 'Calculer' }}
                 </button>
             </form>
@@ -27,7 +27,7 @@
     </div>
 
     {% if not snapshot %}
-        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded p-6 text-center">
+        <div class="bg-amber-50 border border-amber-300 text-amber-800 rounded-sm p-6 text-center">
             <p class="text-lg font-semibold mb-2">Aucun Wrapped en cache pour {{ year }}</p>
             <p class="text-sm">Cliquez sur <strong>« Calculer »</strong> pour générer la rétrospective. L'opération prend quelques secondes selon le volume de scrobbles.</p>
         </div>
@@ -58,19 +58,19 @@
         {% if yearsAgo > 0 %}
             <div class="mb-6">
                 <a href="{{ path('app_playlist_new', {generator_key: 'top-years-ago', 'parameters[years]': yearsAgo, name: 'Top ' ~ year}) }}"
-                   class="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100">
+                   class="inline-flex items-center gap-2 text-xs px-3 py-1.5 rounded-sm bg-emerald-50 border border-emerald-300 text-emerald-800 hover:bg-emerald-100">
                     + Créer une playlist « Top {{ year }} »
                 </a>
             </div>
         {% endif %}
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Plus longue série</div>
                 <div class="text-3xl font-semibold mt-1">{{ d.wrapped_streak_days }} jours</div>
                 <div class="text-xs text-slate-500 mt-1">consécutifs avec au moins une écoute</div>
             </div>
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Mois le plus actif</div>
                 {% if d.wrapped_most_active_month %}
                     <div class="text-3xl font-semibold mt-1">{{ d.wrapped_most_active_month.month }}</div>
@@ -79,7 +79,7 @@
                     <div class="text-3xl font-semibold mt-1">—</div>
                 {% endif %}
             </div>
-            <div class="bg-white shadow rounded p-5">
+            <div class="bg-white shadow-sm rounded-sm p-5">
                 <div class="text-xs uppercase text-slate-500">Nouvelles découvertes</div>
                 <div class="text-3xl font-semibold mt-1">{{ d.wrapped_new_artists|length }} artistes</div>
                 <div class="text-xs text-slate-500 mt-1">jamais écoutés avant {{ year }}</div>
@@ -87,7 +87,7 @@
         </div>
 
         {# ------------------- TOP ARTISTS ------------------- #}
-        <section class="bg-white shadow rounded overflow-hidden mb-6">
+        <section class="bg-white shadow-sm rounded-sm overflow-hidden mb-6">
             <div class="px-4 py-3 border-b bg-slate-50">
                 <h2 class="font-semibold text-sm">Top {{ d.top_artists|length }} artistes</h2>
             </div>
@@ -98,8 +98,8 @@
                         <span class="flex-1 font-medium">{{ row.artist }}</span>
                         <span class="text-slate-500">{{ row.plays|number_format(0, '.', ' ') }} écoutes</span>
                         {% set bar_pct = d.top_artists[0].plays > 0 ? (row.plays / d.top_artists[0].plays * 100)|round : 0 %}
-                        <span class="hidden sm:block w-32 h-2 bg-slate-100 rounded">
-                            <span class="block h-2 bg-emerald-500 rounded" style="width: {{ bar_pct }}%"></span>
+                        <span class="hidden sm:block w-32 h-2 bg-slate-100 rounded-sm">
+                            <span class="block h-2 bg-emerald-500 rounded-sm" style="width: {{ bar_pct }}%"></span>
                         </span>
                     </li>
                 {% endfor %}
@@ -107,7 +107,7 @@
         </section>
 
         {# ------------------- TOP TRACKS ------------------- #}
-        <section class="bg-white shadow rounded overflow-hidden mb-6">
+        <section class="bg-white shadow-sm rounded-sm overflow-hidden mb-6">
             <div class="px-4 py-3 border-b bg-slate-50">
                 <h2 class="font-semibold text-sm">Top {{ d.top_tracks|length }} morceaux</h2>
             </div>
@@ -142,7 +142,7 @@
 
         {# ------------------- NEW ARTISTS ------------------- #}
         {% if d.wrapped_new_artists|length > 0 %}
-            <section class="bg-white shadow rounded overflow-hidden">
+            <section class="bg-white shadow-sm rounded-sm overflow-hidden">
                 <div class="px-4 py-3 border-b bg-slate-50">
                     <h2 class="font-semibold text-sm">Nouvelles découvertes en {{ year }}</h2>
                 </div>


### PR DESCRIPTION
## Summary

- `cdn.tailwindcss.com` (Play CDN v3, déprécié par Tailwind Labs) ne sert plus rien en prod → la page de login s'affichait sans utility class, seuls les overrides du `<style>` inline du `base.html.twig` (dark theme) s'appliquaient.
- Bascule vers le remplaçant officiel `https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4`.
- Propagation des renames v4 dans tous les templates : `rounded` → `rounded-sm`, `rounded-sm` → `rounded-xs`, `shadow` → `shadow-sm`, `flex-shrink-0` → `shrink-0`. L'override inline `.shadow { box-shadow: … }` du dark theme suit (`.shadow-sm`).
- Pas de toolchain front introduite — on reste sur le pattern CDN, juste un CDN qui marche.

## Test plan

- [ ] Visuel : `/login` retrouve son `max-w-md mx-auto`, son padding, ses coins arrondis et son ombre.
- [ ] Visuel : dashboard, `/stats`, `/lastfm/import`, `/history` rendent comme avant le déploiement (cards `bg-white shadow-sm rounded-sm`, boutons, badges, flash messages).
- [ ] Dark theme : les overrides `.bg-white` → slate-800 et `.shadow-sm` (renommé) tiennent toujours.
- [ ] Mobile : burger menu (`shrink-0` sur le pictogramme santé) intact.
- [ ] Console navigateur : plus de 404 / blocage sur `cdn.tailwindcss.com`, le CDN jsdelivr répond.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqZaJzcxEXoyjejh5kjz3w)_