### PR TITLE
feat(lot-1): socle technique — entités, RunHistoryRecorder, Notifier, BackupService

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,21 +13,21 @@
         "doctrine/doctrine-bundle": "^2.12",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^3.2",
-        "symfony/console": "^7.1",
-        "symfony/dotenv": "^7.1",
+        "symfony/console": "^7.2",
+        "symfony/dotenv": "^7.2",
         "symfony/flex": "^2.4",
-        "symfony/form": "^7.1",
-        "symfony/framework-bundle": "^7.1",
-        "symfony/http-client": "^7.1",
-        "symfony/messenger": "^7.1",
-        "symfony/process": "7.1.*",
-        "symfony/property-access": "^7.1",
-        "symfony/runtime": "^7.1",
-        "symfony/security-bundle": "^7.1",
-        "symfony/twig-bundle": "^7.1",
-        "symfony/validator": "^7.1",
-        "symfony/var-exporter": "^7.1",
-        "symfony/yaml": "^7.1",
+        "symfony/form": "^7.2",
+        "symfony/framework-bundle": "^7.2",
+        "symfony/http-client": "^7.2",
+        "symfony/messenger": "^7.2",
+        "symfony/process": "7.2.*",
+        "symfony/property-access": "^7.2",
+        "symfony/runtime": "^7.2",
+        "symfony/security-bundle": "^7.2",
+        "symfony/twig-bundle": "^7.2",
+        "symfony/validator": "^7.2",
+        "symfony/var-exporter": "^7.2",
+        "symfony/yaml": "^7.2",
         "twig/twig": "^3.10"
     },
     "require-dev": {
@@ -38,8 +38,8 @@
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^11.2",
         "squizlabs/php_codesniffer": "^3.10",
-        "symfony/browser-kit": "^7.1",
-        "symfony/phpunit-bridge": "^7.1"
+        "symfony/browser-kit": "^7.2",
+        "symfony/phpunit-bridge": "^7.2"
     },
     "config": {
         "allow-plugins": {
@@ -71,12 +71,16 @@
             "@phpcs",
             "@phpstan",
             "@test"
-        ]
+        ],
+        "auto-scripts": {
+            "cache:clear": "symfony-cmd",
+            "assets:install %PUBLIC_DIR%": "symfony-cmd"
+        }
     },
     "extra": {
         "symfony": {
             "allow-contrib": false,
-            "require": "7.1.*"
+            "require": "7.2.*"
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,8315 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d3e9f2d95a1f0dce9d4821dff3b50d8b",
+    "packages": [
+        {
+            "name": "doctrine/collections",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/collections.git",
+                "reference": "7713da39d8e237f28411d6a616a3dce5e20d5de2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/collections/zipball/7713da39d8e237f28411d6a616a3dce5e20d5de2",
+                "reference": "7713da39d8e237f28411d6a616a3dce5e20d5de2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1",
+                "php": "^8.1",
+                "symfony/polyfill-php84": "^1.30"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-json": "*",
+                "phpstan/phpstan": "^2.1.30",
+                "phpstan/phpstan-phpunit": "^2.0.7",
+                "phpunit/phpunit": "^10.5.58 || ^11.5.42 || ^12.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Collections\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Collections library that adds additional functionality on top of PHP arrays.",
+            "homepage": "https://www.doctrine-project.org/projects/collections.html",
+            "keywords": [
+                "array",
+                "collections",
+                "iterators",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/collections/issues",
+                "source": "https://github.com/doctrine/collections/tree/2.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fcollections",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-15T10:01:58+00:00"
+        },
+        {
+            "name": "doctrine/dbal",
+            "version": "4.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1.5",
+                "php": "^8.2",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^6.3.8|^7.0|^8.0",
+                "symfony/console": "^5.4|^6.3|^7.0|^8.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-20T08:52:12+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-bundle",
+            "version": "2.18.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineBundle.git",
+                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineBundle/zipball/0ff098b29b8b3c68307c8987dcaed7fd829c6546",
+                "reference": "0ff098b29b8b3c68307c8987dcaed7fd829c6546",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^3.7.0 || ^4.0",
+                "doctrine/deprecations": "^1.0",
+                "doctrine/persistence": "^3.1 || ^4",
+                "doctrine/sql-formatter": "^1.0.1",
+                "php": "^8.1",
+                "symfony/cache": "^6.4 || ^7.0",
+                "symfony/config": "^6.4 || ^7.0",
+                "symfony/console": "^6.4 || ^7.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0",
+                "symfony/doctrine-bridge": "^6.4.3 || ^7.0.3",
+                "symfony/framework-bundle": "^6.4 || ^7.0",
+                "symfony/service-contracts": "^2.5 || ^3"
+            },
+            "conflict": {
+                "doctrine/annotations": ">=3.0",
+                "doctrine/cache": "< 1.11",
+                "doctrine/orm": "<2.17 || >=4.0",
+                "symfony/var-exporter": "< 6.4.1 || 7.0.0",
+                "twig/twig": "<2.13 || >=3.0 <3.0.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1 || ^2",
+                "doctrine/cache": "^1.11 || ^2.0",
+                "doctrine/coding-standard": "^14",
+                "doctrine/orm": "^2.17 || ^3.1",
+                "friendsofphp/proxy-manager-lts": "^1.0",
+                "phpstan/phpstan": "2.1.1",
+                "phpstan/phpstan-phpunit": "2.0.3",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.53 || ^12.3.10",
+                "psr/log": "^1.1.4 || ^2.0 || ^3.0",
+                "symfony/doctrine-messenger": "^6.4 || ^7.0",
+                "symfony/expression-language": "^6.4 || ^7.0",
+                "symfony/messenger": "^6.4 || ^7.0",
+                "symfony/property-info": "^6.4 || ^7.0",
+                "symfony/security-bundle": "^6.4 || ^7.0",
+                "symfony/stopwatch": "^6.4 || ^7.0",
+                "symfony/string": "^6.4 || ^7.0",
+                "symfony/twig-bridge": "^6.4 || ^7.0",
+                "symfony/validator": "^6.4 || ^7.0",
+                "symfony/var-exporter": "^6.4.1 || ^7.0.1",
+                "symfony/web-profiler-bundle": "^6.4 || ^7.0",
+                "symfony/yaml": "^6.4 || ^7.0",
+                "twig/twig": "^2.14.7 || ^3.0.4"
+            },
+            "suggest": {
+                "doctrine/orm": "The Doctrine ORM integration is optional in the bundle.",
+                "ext-pdo": "*",
+                "symfony/web-profiler-bundle": "To use the data collector."
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\DoctrineBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org/"
+                }
+            ],
+            "description": "Symfony DoctrineBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "database",
+                "dbal",
+                "orm",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineBundle/tree/2.18.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-20T21:35:32+00:00"
+        },
+        {
+            "name": "doctrine/doctrine-migrations-bundle",
+            "version": "3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/DoctrineMigrationsBundle.git",
+                "reference": "1e380c6dd8ac8488217f39cff6b77e367f1a644b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/DoctrineMigrationsBundle/zipball/1e380c6dd8ac8488217f39cff6b77e367f1a644b",
+                "reference": "1e380c6dd8ac8488217f39cff6b77e367f1a644b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/doctrine-bundle": "^2.4 || ^3.0",
+                "doctrine/migrations": "^3.2",
+                "php": "^7.2 || ^8.0",
+                "symfony/deprecation-contracts": "^2.1 || ^3",
+                "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/semver": "^3.0",
+                "doctrine/coding-standard": "^12 || ^14",
+                "doctrine/orm": "^2.6 || ^3",
+                "phpstan/phpstan": "^1.4 || ^2",
+                "phpstan/phpstan-deprecation-rules": "^1 || ^2",
+                "phpstan/phpstan-phpunit": "^1 || ^2",
+                "phpstan/phpstan-strict-rules": "^1.1 || ^2",
+                "phpstan/phpstan-symfony": "^1.3 || ^2",
+                "phpunit/phpunit": "^8.5 || ^9.5",
+                "symfony/phpunit-bridge": "^6.3 || ^7 || ^8",
+                "symfony/var-exporter": "^5.4 || ^6 || ^7 || ^8"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Bundle\\MigrationsBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Doctrine Project",
+                    "homepage": "https://www.doctrine-project.org"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony DoctrineMigrationsBundle",
+            "homepage": "https://www.doctrine-project.org",
+            "keywords": [
+                "dbal",
+                "migrations",
+                "schema"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/DoctrineMigrationsBundle/issues",
+                "source": "https://github.com/doctrine/DoctrineMigrationsBundle/tree/3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdoctrine-migrations-bundle",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-15T19:02:59+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-29T07:11:08+00:00"
+        },
+        {
+            "name": "doctrine/inflector",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "reference": "6d6c96277ea252fc1304627204c3d5e6e15faa3b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12.0 || ^13.0",
+                "phpstan/phpstan": "^1.12 || ^2.0",
+                "phpstan/phpstan-phpunit": "^1.4 || ^2.0",
+                "phpstan/phpstan-strict-rules": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^8.5 || ^12.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Inflector\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Inflector is a small library that can perform string manipulations with regard to upper/lowercase and singular/plural forms of words.",
+            "homepage": "https://www.doctrine-project.org/projects/inflector.html",
+            "keywords": [
+                "inflection",
+                "inflector",
+                "lowercase",
+                "manipulation",
+                "php",
+                "plural",
+                "singular",
+                "strings",
+                "uppercase",
+                "words"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/inflector/issues",
+                "source": "https://github.com/doctrine/inflector/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finflector",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T19:31:58+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "reference": "23da848e1a2308728fe5fdddabf4be17ff9720c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T06:47:08+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "3.9.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/dbal": "^3.6 || ^4",
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "doctrine/event-manager": "^1.2 || ^2.0",
+                "php": "^8.1",
+                "psr/log": "^1.1.3 || ^2 || ^3",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^6.2 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/orm": "<2.12 || >=4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/orm": "^2.13 || ^3",
+                "doctrine/persistence": "^2 || ^3 || ^4",
+                "doctrine/sql-formatter": "^1.0",
+                "ext-pdo_sqlite": "*",
+                "fig/log-test": "^1",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpstan/phpstan-symfony": "^2",
+                "phpunit/phpunit": "^10.3 || ^11.0 || ^12.0",
+                "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+                "symfony/yaml": "Allows the use of yaml for migration configuration files."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Migrations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
+            "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+            "keywords": [
+                "database",
+                "dbal",
+                "migrations"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/migrations/issues",
+                "source": "https://github.com/doctrine/migrations/tree/3.9.7"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fmigrations",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-23T19:33:20+00:00"
+        },
+        {
+            "name": "doctrine/orm",
+            "version": "3.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/orm.git",
+                "reference": "7e88b416153dceeb563352ca2b12465f09eea173"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/7e88b416153dceeb563352ca2b12465f09eea173",
+                "reference": "7e88b416153dceeb563352ca2b12465f09eea173",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/collections": "^2.2",
+                "doctrine/dbal": "^3.8.2 || ^4",
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "doctrine/event-manager": "^1.2 || ^2",
+                "doctrine/inflector": "^1.4 || ^2.0",
+                "doctrine/instantiator": "^1.3 || ^2",
+                "doctrine/lexer": "^3",
+                "doctrine/persistence": "^3.3.1 || ^4",
+                "ext-ctype": "*",
+                "php": "^8.1",
+                "psr/cache": "^1 || ^2 || ^3",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^6.3.9 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0",
+                "phpbench/phpbench": "^1.0",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "2.1.23",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpunit/phpunit": "^10.5.0 || ^11.5",
+                "psr/log": "^1 || ^2 || ^3",
+                "symfony/cache": "^5.4 || ^6.2 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-dom": "Provides support for XSD validation for XML mapping files",
+                "symfony/cache": "Provides cache support for Setup Tool with doctrine/cache 2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\ORM\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "Object-Relational-Mapper for PHP",
+            "homepage": "https://www.doctrine-project.org/projects/orm.html",
+            "keywords": [
+                "database",
+                "orm"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/orm/issues",
+                "source": "https://github.com/doctrine/orm/tree/3.6.5"
+            },
+            "time": "2026-05-11T06:47:19+00:00"
+        },
+        {
+            "name": "doctrine/persistence",
+            "version": "4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/persistence.git",
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/persistence/zipball/49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
+                "reference": "49ab73e0d3e2ac8d1f5ecda3dd8acd5503781e8b",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1",
+                "doctrine/event-manager": "^1 || ^2",
+                "php": "^8.1",
+                "psr/cache": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.58 || ^12",
+                "symfony/cache": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/finder": "^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Persistence\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Persistence project is a set of shared interfaces and functionality that the different Doctrine object mappers share.",
+            "homepage": "https://www.doctrine-project.org/projects/persistence.html",
+            "keywords": [
+                "mapper",
+                "object",
+                "odm",
+                "orm",
+                "persistence"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/persistence/issues",
+                "source": "https://github.com/doctrine/persistence/tree/4.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fpersistence",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T12:12:52+00:00"
+        },
+        {
+            "name": "doctrine/sql-formatter",
+            "version": "1.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/sql-formatter.git",
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/sql-formatter/zipball/9563949f5cd3bd12a17d12fb980528bc141c5806",
+                "reference": "9563949f5cd3bd12a17d12fb980528bc141c5806",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "ergebnis/phpunit-slow-test-detector": "^2.20",
+                "phpstan/phpstan": "^2.1.31",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "bin": [
+                "bin/sql-formatter"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\SqlFormatter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Dorn",
+                    "email": "jeremy@jeremydorn.com",
+                    "homepage": "https://jeremydorn.com/"
+                }
+            ],
+            "description": "a PHP SQL highlighting library",
+            "homepage": "https://github.com/doctrine/sql-formatter/",
+            "keywords": [
+                "highlight",
+                "sql"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/sql-formatter/issues",
+                "source": "https://github.com/doctrine/sql-formatter/tree/1.5.4"
+            },
+            "time": "2026-02-08T16:21:46+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/event-dispatcher",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/event-dispatcher.git",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/event-dispatcher/zipball/dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "reference": "dbefd12671e8a14ec7f180cab83036ed26714bb0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\EventDispatcher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Standard interfaces for event handling.",
+            "keywords": [
+                "events",
+                "psr",
+                "psr-14"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/event-dispatcher/issues",
+                "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
+            },
+            "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "symfony/cache",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "e874746cea6893d4b91943eab8376a0fe7528de6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/e874746cea6893d4b91943eab8376a0fe7528de6",
+                "reference": "e874746cea6893d4b91943eab8376a0fe7528de6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/cache": "^2.0|^3.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^2.5|^3",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/var-dumper": "<6.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "2.0|3.0",
+                "psr/simple-cache-implementation": "1.0|2.0|3.0",
+                "symfony/cache-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0|^3.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "classmap": [
+                    "Traits/ValueWrapper.php"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-30T17:03:27+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "225e8a254166bd3442e370c6f50145465db63831"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/225e8a254166bd3442e370c6f50145465db63831",
+                "reference": "225e8a254166bd3442e370c6f50145465db63831",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/cache": "^3.0"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-05T15:33:14+00:00"
+        },
+        {
+            "name": "symfony/clock",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/clock.git",
+                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
+                "reference": "b81435fbd6648ea425d1ee96a2d8e68f4ceacd24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
+            },
+            "provide": {
+                "psr/clock-implementation": "1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/now.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\Clock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Decouples applications from the system clock",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clock",
+                "psr20",
+                "time"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/clock/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "4cfed7041ac389c242122e60884d4a9fc5376cb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4cfed7041ac389c242122e60884d4a9fc5376cb3",
+                "reference": "4cfed7041ac389c242122e60884d4a9fc5376cb3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-26T13:54:51+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "93518c2ff7ce9c1818224c6effed3cf2429c63d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/93518c2ff7ce9c1818224c6effed3cf2429c63d7",
+                "reference": "93518c2ff7ce9c1818224c6effed3cf2429c63d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-30T17:03:27+00:00"
+        },
+        {
+            "name": "symfony/dependency-injection",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "fae0971f518e81fd1ccbfb6218aef410392ac701"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/fae0971f518e81fd1ccbfb6218aef410392ac701",
+                "reference": "fae0971f518e81fd1ccbfb6218aef410392ac701",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^3.5",
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.4",
+                "symfony/finder": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-30T17:31:35+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/doctrine-bridge",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/doctrine-bridge.git",
+                "reference": "ef8b21518615585e91ae7ab552265f04fcfa9dcf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/doctrine-bridge/zipball/ef8b21518615585e91ae7ab552265f04fcfa9dcf",
+                "reference": "ef8b21518615585e91ae7ab552265f04fcfa9dcf",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/event-manager": "^2",
+                "doctrine/persistence": "^3.1|^4",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.8",
+                "doctrine/dbal": "<3.6",
+                "doctrine/lexer": "<1.1",
+                "doctrine/orm": "<2.15",
+                "symfony/cache": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/form": "<6.4.6|>=7,<7.0.6",
+                "symfony/http-foundation": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/security-bundle": "<6.4",
+                "symfony/security-core": "<6.4",
+                "symfony/validator": "<6.4"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.8|^2.0",
+                "doctrine/data-fixtures": "^1.1|^2",
+                "doctrine/dbal": "^3.6|^4",
+                "doctrine/orm": "^2.15|^3",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/doctrine-messenger": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/form": "^6.4.6|^7.0.6",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/type-info": "^7.1.8",
+                "symfony/uid": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Doctrine\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Doctrine with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/doctrine-bridge/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T09:47:02+00:00"
+        },
+        {
+            "name": "symfony/dotenv",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dotenv.git",
+                "reference": "2192790a11f9e22cbcf9dc705a3ff22a5503923a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dotenv/zipball/2192790a11f9e22cbcf9dc705a3ff22a5503923a",
+                "reference": "2192790a11f9e22cbcf9dc705a3ff22a5503923a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/process": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Dotenv\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Registers environment variables from a .env file",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "dotenv",
+                "env",
+                "environment"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/dotenv/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/error-handler",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/error-handler.git",
+                "reference": "df98c90e43fa8267da4a64a88dd9427e0277773a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/df98c90e43fa8267da4a64a88dd9427e0277773a",
+                "reference": "df98c90e43fa8267da4a64a88dd9427e0277773a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/deprecation-contracts": "<2.5",
+                "symfony/http-kernel": "<6.4"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/patch-type-declarations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ErrorHandler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to manage errors and ease debugging PHP code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/error-handler/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-07T08:17:47+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/event-dispatcher-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "provide": {
+                "psr/event-dispatcher-implementation": "1.0",
+                "symfony/event-dispatcher-implementation": "2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\EventDispatcher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/event-dispatcher-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/event-dispatcher-contracts.git",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "reference": "ccba7060602b7fed0b03c85bf025257f76d9ef32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\EventDispatcher\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to dispatching event",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edcbb768a186b5c3f25d0643159a787d3e63b7fd",
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-07T08:17:47+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T13:41:35+00:00"
+        },
+        {
+            "name": "symfony/flex",
+            "version": "v2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/flex.git",
+                "reference": "9cd384775973eabbf6e8b05784dda279fc67c28d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/9cd384775973eabbf6e8b05784dda279fc67c28d",
+                "reference": "9cd384775973eabbf6e8b05784dda279fc67c28d",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.1",
+                "php": ">=8.1"
+            },
+            "conflict": {
+                "composer/semver": "<1.7.2",
+                "symfony/dotenv": "<5.4"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1",
+                "symfony/dotenv": "^6.4|^7.4|^8.0",
+                "symfony/filesystem": "^6.4|^7.4|^8.0",
+                "symfony/phpunit-bridge": "^6.4|^7.4|^8.0",
+                "symfony/process": "^6.4|^7.4|^8.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Flex\\Flex"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Flex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "Composer plugin for Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/flex/issues",
+                "source": "https://github.com/symfony/flex/tree/v2.10.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-16T09:38:19+00:00"
+        },
+        {
+            "name": "symfony/form",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/form.git",
+                "reference": "72dfbaf14138f0c857659536dd65af85f36b546c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/form/zipball/72dfbaf14138f0c857659536dd65af85f36b546c",
+                "reference": "72dfbaf14138f0c857659536dd65af85f36b546c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/options-resolver": "^6.4|^7.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-icu": "^1.21",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<6.4",
+                "symfony/error-handler": "<6.4",
+                "symfony/framework-bundle": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.4"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0|^2.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/html-sanitizer": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/security-csrf": "^6.4|^7.0",
+                "symfony/translation": "^6.4.3|^7.0.3",
+                "symfony/uid": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Form\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows to easily create, process and reuse HTML forms",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/form/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-24T11:52:02+00:00"
+        },
+        {
+            "name": "symfony/framework-bundle",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/framework-bundle.git",
+                "reference": "42ac8bbbf10d3113c335ba8af39fad63db96e4e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/framework-bundle/zipball/42ac8bbbf10d3113c335ba8af39fad63db96e4e2",
+                "reference": "42ac8bbbf10d3113c335ba8af39fad63db96e4e2",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.2",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^7.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/filesystem": "^7.1",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^7.2",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/routing": "^6.4|^7.0"
+            },
+            "conflict": {
+                "doctrine/persistence": "<1.3",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/asset": "<6.4",
+                "symfony/asset-mapper": "<6.4",
+                "symfony/clock": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dom-crawler": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/form": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/property-access": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/runtime": "<6.4.13|>=7.0,<7.1.6",
+                "symfony/scheduler": "<6.4.4|>=7.0.0,<7.0.4",
+                "symfony/security-core": "<6.4",
+                "symfony/security-csrf": "<7.2",
+                "symfony/serializer": "<7.2.5",
+                "symfony/stopwatch": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/twig-bridge": "<6.4",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/web-profiler-bundle": "<6.4",
+                "symfony/webhook": "<7.2",
+                "symfony/workflow": "<6.4"
+            },
+            "require-dev": {
+                "doctrine/persistence": "^1.3|^2|^3",
+                "dragonmantank/cron-expression": "^3.1",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "seld/jsonlint": "^1.10",
+                "symfony/asset": "^6.4|^7.0",
+                "symfony/asset-mapper": "^6.4|^7.0",
+                "symfony/browser-kit": "^6.4|^7.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/css-selector": "^6.4|^7.0",
+                "symfony/dom-crawler": "^6.4|^7.0",
+                "symfony/dotenv": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/html-sanitizer": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/mailer": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/notifier": "^6.4|^7.0",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/scheduler": "^6.4.4|^7.0.4",
+                "symfony/security-bundle": "^6.4|^7.0",
+                "symfony/semaphore": "^6.4|^7.0",
+                "symfony/serializer": "^7.2.5",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/string": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/twig-bundle": "^6.4|^7.0",
+                "symfony/type-info": "^7.1.8",
+                "symfony/uid": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/web-link": "^6.4|^7.0",
+                "symfony/webhook": "^7.2",
+                "symfony/workflow": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\FrameworkBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration between Symfony components and the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/framework-bundle/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-30T17:03:27+00:00"
+        },
+        {
+            "name": "symfony/http-client",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client.git",
+                "reference": "e26182d286135dad99f58ad57c56eef41362d452"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/e26182d286135dad99f58ad57c56eef41362d452",
+                "reference": "e26182d286135dad99f58ad57c56eef41362d452",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-client-contracts": "~3.4.4|^3.5.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "amphp/amp": "<2.5",
+                "php-http/discovery": "<1.15",
+                "symfony/http-foundation": "<6.4"
+            },
+            "provide": {
+                "php-http/async-client-implementation": "*",
+                "php-http/client-implementation": "*",
+                "psr/http-client-implementation": "1.0",
+                "symfony/http-client-implementation": "3.0"
+            },
+            "require-dev": {
+                "amphp/http-client": "^4.2.1|^5.0",
+                "amphp/http-tunnel": "^1.0|^2.0",
+                "amphp/socket": "^1.1",
+                "guzzlehttp/promises": "^1.4|^2.0",
+                "nyholm/psr7": "^1.0",
+                "php-http/httplug": "^1.0|^2.0",
+                "psr/http-client": "^1.0",
+                "symfony/amphp-http-client-meta": "^1.0|^2.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides powerful methods to fetch HTTP resources synchronously or asynchronously",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "http"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/http-client-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-client-contracts.git",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "reference": "4a2d00c37651c0bdc2b9e1c773487a8bf4edb12d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\HttpClient\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to HTTP clients",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-06T13:17:50+00:00"
+        },
+        {
+            "name": "symfony/http-foundation",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-foundation.git",
+                "reference": "7d81b8184601176dff995cf959d3def142309049"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/7d81b8184601176dff995cf959d3def142309049",
+                "reference": "7d81b8184601176dff995cf959d3def142309049",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-mbstring": "~1.1",
+                "symfony/polyfill-php83": "^1.27"
+            },
+            "conflict": {
+                "doctrine/dbal": "<3.6",
+                "symfony/cache": "<6.4.12|>=7.0,<7.1.5"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^3.6|^4",
+                "predis/predis": "^1.1|^2.0",
+                "symfony/cache": "^6.4.12|^7.1.5",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpFoundation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Defines an object-oriented layer for the HTTP specification",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-foundation/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/http-kernel",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/http-kernel.git",
+                "reference": "d0cc0295c9c2fd5e053fee2b2a143001f2d0c33c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/d0cc0295c9c2fd5e053fee2b2a143001f2d0c33c",
+                "reference": "d0cc0295c9c2fd5e053fee2b2a143001f2d0c33c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<6.4",
+                "symfony/cache": "<6.4",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<6.4",
+                "symfony/form": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/mailer": "<6.4",
+                "symfony/messenger": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/translation-contracts": "<2.5",
+                "symfony/twig-bridge": "<6.4",
+                "symfony/validator": "<6.4",
+                "symfony/var-dumper": "<6.4",
+                "twig/twig": "<3.12"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/browser-kit": "^6.4|^7.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/css-selector": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/dom-crawler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/http-client-contracts": "^2.5|^3",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/property-access": "^7.1",
+                "symfony/routing": "^6.4|^7.0",
+                "symfony/serializer": "^7.1",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3",
+                "symfony/uid": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0",
+                "symfony/var-exporter": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\HttpKernel\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a structured process for converting a Request into a Response",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/http-kernel/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-31T09:36:38+00:00"
+        },
+        {
+            "name": "symfony/messenger",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/messenger.git",
+                "reference": "3fd1638aa11ef6f342ed6b10b930a1757c25417c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/messenger/zipball/3fd1638aa11ef6f342ed6b10b930a1757c25417c",
+                "reference": "3fd1638aa11ef6f342ed6b10b930a1757c25417c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/log": "^1|^2|^3",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/console": "<7.2",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/event-dispatcher-contracts": "<2.5",
+                "symfony/framework-bundle": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/serializer": "<6.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "symfony/console": "^7.2",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/routing": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Messenger\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Samuel Roze",
+                    "email": "samuel.roze@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps applications send and receive messages to/from other applications or via message queues",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/messenger/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "b48517d1cef0d533e241cb03801014f1bb832775"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b48517d1cef0d533e241cb03801014f1bb832775",
+                "reference": "b48517d1cef0d533e241cb03801014f1bb832775",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/password-hasher",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/password-hasher.git",
+                "reference": "d8bd3d66d074c0acba1214a0d42f5941a8e1e94d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/password-hasher/zipball/d8bd3d66d074c0acba1214a0d42f5941a8e1e94d",
+                "reference": "d8bd3d66d074c0acba1214a0d42f5941a8e1e94d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/security-core": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0",
+                "symfony/security-core": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PasswordHasher\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Robin Chalas",
+                    "email": "robin.chalas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides password hashing utilities",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "hashing",
+                "password"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/password-hasher/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T13:13:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-icu",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-icu.git",
+                "reference": "3510b63d07376b04e57e27e82607d468bb134f78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-icu/zipball/3510b63d07376b04e57e27e82607d468bb134f78",
+                "reference": "3510b63d07376b04e57e27e82607d468bb134f78",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance and support of other locales than \"en\""
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Icu\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ],
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's ICU-related data and classes",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "icu",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-icu/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:50:15+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "reference": "6a21eb99c6973357967f6ce3708cd55a6bec6315",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php83",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php83.git",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "reference": "3600c2cb22399e25bb226e4a135ce91eeb2a6149",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php83\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T17:25:58+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php84",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "reference": "88486db2c389b290bf87ff1de7ebc1e13e42bb06",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T18:47:49+00:00"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "e0a87c9a60045a354b041db2ea3cf047bf0b15f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e0a87c9a60045a354b041db2ea3cf047bf0b15f5",
+                "reference": "e0a87c9a60045a354b041db2ea3cf047bf0b15f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/property-access",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "9858acdf18abac17b9ab254706454d0cc0de7641"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/9858acdf18abac17b9ab254706454d0cc0de7641",
+                "reference": "9858acdf18abac17b9ab254706454d0cc0de7641",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/property-info": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property-path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T13:41:35+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "16bb9e15292f9f07c28a6f955d4f14c680d1e0b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/16bb9e15292f9f07c28a6f955d4f14c680d1e0b5",
+                "reference": "16bb9e15292f9f07c28a6f955d4f14c680d1e0b5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/string": "^6.4|^7.0",
+                "symfony/type-info": "~7.2.8|^7.3.1"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/cache": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/serializer": "<6.4"
+            },
+            "require-dev": {
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/routing",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/routing.git",
+                "reference": "d5a038e972be748e3f057c884897a41b1111e4a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/d5a038e972be748e3f057c884897a41b1111e4a0",
+                "reference": "d5a038e972be748e3f057c884897a41b1111e4a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/config": "<6.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Routing\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Maps an HTTP request to a set of configuration variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "router",
+                "routing",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/routing/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/runtime",
+            "version": "v7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/runtime.git",
+                "reference": "40d1c481c2370362010a4da64af14dec62a9ec68"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/runtime/zipball/40d1c481c2370362010a4da64af14dec62a9ec68",
+                "reference": "40d1c481c2370362010a4da64af14dec62a9ec68",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=8.2"
+            },
+            "conflict": {
+                "symfony/dotenv": "<6.4"
+            },
+            "require-dev": {
+                "composer/composer": "^2.6",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dotenv": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Component\\Runtime\\Internal\\ComposerPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Runtime\\": "",
+                    "Symfony\\Runtime\\Symfony\\Component\\": "Internal/"
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Enables decoupling PHP applications from global state",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "runtime"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/runtime/tree/v7.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-13T07:47:28+00:00"
+        },
+        {
+            "name": "symfony/security-bundle",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-bundle.git",
+                "reference": "4661890f7d2571e9ef58431401a390c2dde68c78"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/4661890f7d2571e9ef58431401a390c2dde68c78",
+                "reference": "4661890f7d2571e9ef58431401a390c2dde68c78",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "ext-xml": "*",
+                "php": ">=8.2",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4.11|^7.1.4",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/password-hasher": "^6.4|^7.0",
+                "symfony/security-core": "^7.2",
+                "symfony/security-csrf": "^6.4|^7.0",
+                "symfony/security-http": "^7.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/browser-kit": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/framework-bundle": "<6.4",
+                "symfony/http-client": "<6.4",
+                "symfony/ldap": "<6.4",
+                "symfony/serializer": "<6.4",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/validator": "<6.4"
+            },
+            "require-dev": {
+                "symfony/asset": "^6.4|^7.0",
+                "symfony/browser-kit": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/css-selector": "^6.4|^7.0",
+                "symfony/dom-crawler": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/framework-bundle": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/ldap": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/twig-bridge": "^6.4|^7.0",
+                "symfony/twig-bundle": "^6.4|^7.0",
+                "symfony/validator": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0",
+                "twig/twig": "^3.12",
+                "web-token/jwt-library": "^3.3.2|^4.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\SecurityBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of the Security component into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-bundle/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-22T07:39:44+00:00"
+        },
+        {
+            "name": "symfony/security-core",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-core.git",
+                "reference": "28ec042a6aff580693cce7aa820778e6dfa5e5ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-core/zipball/28ec042a6aff580693cce7aa820778e6dfa5e5ef",
+                "reference": "28ec042a6aff580693cce7aa820778e6dfa5e5ef",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/event-dispatcher-contracts": "^2.5|^3",
+                "symfony/password-hasher": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/ldap": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/validator": "<6.4"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0|^2.0|^3.0",
+                "psr/container": "^1.1|^2.0",
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/ldap": "^6.4|^7.0",
+                "symfony/string": "^6.4|^7.0",
+                "symfony/translation": "^6.4.3|^7.0.3",
+                "symfony/validator": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Core\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - Core Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-core/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-22T08:39:58+00:00"
+        },
+        {
+            "name": "symfony/security-csrf",
+            "version": "v7.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-csrf.git",
+                "reference": "2b4b0c46c901729e4e90719eacd980381f53e0a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-csrf/zipball/2b4b0c46c901729e4e90719eacd980381f53e0a3",
+                "reference": "2b4b0c46c901729e4e90719eacd980381f53e0a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/security-core": "^6.4|^7.0"
+            },
+            "conflict": {
+                "symfony/http-foundation": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Csrf\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - CSRF Library",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-csrf/tree/v7.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-01-02T18:42:10+00:00"
+        },
+        {
+            "name": "symfony/security-http",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/security-http.git",
+                "reference": "972dd874c2ce65e4c58dbf59054d2bf7ad70ec54"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/security-http/zipball/972dd874c2ce65e4c58dbf59054d2bf7ad70ec54",
+                "reference": "972dd874c2ce65e4c58dbf59054d2bf7ad70ec54",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/security-core": "^7.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/clock": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/http-client-contracts": "<3.0",
+                "symfony/security-bundle": "<6.4",
+                "symfony/security-csrf": "<6.4"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/clock": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/http-client-contracts": "^3.0",
+                "symfony/rate-limiter": "^6.4|^7.0",
+                "symfony/routing": "^6.4|^7.0",
+                "symfony/security-csrf": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "web-token/jwt-library": "^3.3.2|^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Security\\Http\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Security Component - HTTP Integration",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/security-http/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "reference": "d25d82433a80eba6aa0e6c24b61d7370d99e444a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-28T09:44:51+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v7.2.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
+                "reference": "5a49289e2b308214c8b9c2fda4ea454d8b8ad7cd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v7.2.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-02-24T10:49:57+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "de5189e4def141dbdca2f2ce7a653cc6364f58e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/de5189e4def141dbdca2f2ce7a653cc6364f58e6",
+                "reference": "de5189e4def141dbdca2f2ce7a653cc6364f58e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.0",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/translation-contracts",
+            "version": "v3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation-contracts.git",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to translation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/twig-bridge",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bridge.git",
+                "reference": "e62144411b277877d0e8583b48202673c36941d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bridge/zipball/e62144411b277877d0e8583b48202673c36941d7",
+                "reference": "e62144411b277877d0e8583b48202673c36941d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/translation-contracts": "^2.5|^3",
+                "twig/twig": "^3.12"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/console": "<6.4",
+                "symfony/form": "<6.4",
+                "symfony/http-foundation": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/mime": "<6.4",
+                "symfony/serializer": "<6.4",
+                "symfony/translation": "<6.4",
+                "symfony/workflow": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/asset": "^6.4|^7.0",
+                "symfony/asset-mapper": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/emoji": "^7.1",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/form": "^6.4.20|^7.2.5",
+                "symfony/html-sanitizer": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/polyfill-intl-icu": "~1.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/routing": "^6.4|^7.0",
+                "symfony/security-acl": "^2.8|^3.0",
+                "symfony/security-core": "^6.4|^7.0",
+                "symfony/security-csrf": "^6.4|^7.0",
+                "symfony/security-http": "^6.4|^7.0",
+                "symfony/serializer": "^6.4.3|^7.0.3",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/web-link": "^6.4|^7.0",
+                "symfony/workflow": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0",
+                "twig/cssinliner-extra": "^2.12|^3",
+                "twig/inky-extra": "^2.12|^3",
+                "twig/markdown-extra": "^2.12|^3"
+            },
+            "type": "symfony-bridge",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Twig\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides integration for Twig with various Symfony components",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bridge/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-26T14:12:01+00:00"
+        },
+        {
+            "name": "symfony/twig-bundle",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/twig-bundle.git",
+                "reference": "157de579a9ec25d5dfeb7ee3b3e9b57d2e635c39"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/twig-bundle/zipball/157de579a9ec25d5dfeb7ee3b3e9b57d2e635c39",
+                "reference": "157de579a9ec25d5dfeb7ee3b3e9b57d2e635c39",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": ">=2.1",
+                "php": ">=8.2",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/twig-bridge": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<6.4",
+                "symfony/translation": "<6.4"
+            },
+            "require-dev": {
+                "symfony/asset": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/framework-bundle": "^6.4|^7.0",
+                "symfony/routing": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/translation": "^6.4|^7.0",
+                "symfony/web-link": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\TwigBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a tight integration of Twig into the Symfony full-stack framework",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/twig-bundle/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/type-info",
+            "version": "v7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "ec311f6f16ce2dffdffb6db6f89cdd1533723e42"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/ec311f6f16ce2dffdffb6db6f89cdd1533723e42",
+                "reference": "ec311f6f16ce2dffdffb6db6f89cdd1533723e42",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "psr/container": "^1.1|^2.0"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.0|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v7.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-27T15:23:16+00:00"
+        },
+        {
+            "name": "symfony/validator",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/validator.git",
+                "reference": "b5410782f69892acf828e0eec7943a2caca46ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/b5410782f69892acf828e0eec7943a2caca46ed6",
+                "reference": "b5410782f69892acf828e0eec7943a2caca46ed6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/polyfill-php83": "^1.27",
+                "symfony/translation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "doctrine/lexer": "<1.1",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/doctrine-bridge": "<7.0",
+                "symfony/expression-language": "<6.4",
+                "symfony/http-kernel": "<6.4",
+                "symfony/intl": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/translation": "<6.4.3|>=7.0,<7.0.3",
+                "symfony/yaml": "<6.4"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
+                "symfony/translation": "^6.4.3|^7.0.3",
+                "symfony/type-info": "^7.1.8",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Validator\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/Resources/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides tools to validate values",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/validator/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-29T19:57:35+00:00"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "67ad2a16e50f052c80fe03ccb6a8721bbeffe032"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/67ad2a16e50f052c80fe03ccb6a8721bbeffe032",
+                "reference": "67ad2a16e50f052c80fe03ccb6a8721bbeffe032",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/uid": "^6.4|^7.0",
+                "twig/twig": "^3.12"
+            },
+            "bin": [
+                "Resources/bin/var-dump-server"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides mechanisms for walking through any arbitrary PHP variable",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-dumper/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-29T19:57:35+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "1aab3e8e2e63f7586dd9951746eababe339d3978"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1aab3e8e2e63f7586dd9951746eababe339d3978",
+                "reference": "1aab3e8e2e63f7586dd9951746eababe339d3978",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "0df1031b6a03b9bef3cd052a59e270e006731e90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0df1031b6a03b9bef3cd052a59e270e006731e90",
+                "reference": "0df1031b6a03b9bef3cd052a59e270e006731e90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/a6769aefb305efef849dc25c9fd1653358c148f0",
+                "reference": "a6769aefb305efef849dc25c9fd1653358c148f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "php-cs-fixer/shim": "^3.0@stable",
+                "phpstan/phpstan": "^2.0@stable",
+                "psr/container": "^1.0|^2.0",
+                "symfony/phpunit-bridge": "^5.4.9|^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resources/core.php",
+                    "src/Resources/debug.php",
+                    "src/Resources/escaper.php",
+                    "src/Resources/string_loader.php"
+                ],
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "support": {
+                "issues": "https://github.com/twigphp/Twig/issues",
+                "source": "https://github.com/twigphp/Twig/tree/v3.24.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-17T21:31:11+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.54",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-29T13:31:09+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "2.0.22",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "e87516b034749432d51653c0147e053e476e8c53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/e87516b034749432d51653c0147e053e476e8c53",
+                "reference": "e87516b034749432d51653c0147e053e476e8c53",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.34"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "cache/array-adapter": "^1.1",
+                "composer/semver": "^3.3.2",
+                "cweagans/composer-patches": "^1.7.3",
+                "doctrine/annotations": "^2.0",
+                "doctrine/collections": "^1.6 || ^2.1",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^3.3.8",
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "doctrine/mongodb-odm": "^2.4.3",
+                "doctrine/orm": "^2.16.0",
+                "doctrine/persistence": "^2.2.1 || ^3.4.3",
+                "gedmo/doctrine-extensions": "^3.8",
+                "nesbot/carbon": "^2.49",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6.20",
+                "ramsey/uuid": "^4.2",
+                "shipmonk/name-collision-detector": "^2.1",
+                "symfony/cache": "^5.4",
+                "symfony/uid": "^5.4 || ^6.4 || ^7.3"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/2.0.22"
+            },
+            "time": "2026-05-09T08:10:48+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "reference": "6ab598e1bc106e6827fd346ae4a12b4a5d634c32",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.32"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.16"
+            },
+            "time": "2026-02-14T09:05:21+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "2.0.17",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "fdd0cb5f08d1980c612d6f259d825ea644ed03f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/fdd0cb5f08d1980c612d6f259d825ea644ed03f4",
+                "reference": "fdd0cb5f08d1980c612d6f259d825ea644ed03f4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.13"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^2.0.8",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "psr/container": "1.1.2",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^5.4",
+                "symfony/service-contracts": "^2.2.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/2.0.17"
+            },
+            "time": "2026-05-10T08:14:07+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/browser-kit",
+            "version": "v7.2.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/browser-kit.git",
+                "reference": "776d81d0c4859453aa35c316a542d74d0616330f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/browser-kit/zipball/776d81d0c4859453aa35c316a542d74d0616330f",
+                "reference": "776d81d0c4859453aa35c316a542d74d0616330f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/dom-crawler": "^6.4|^7.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\BrowserKit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Simulates the behavior of a web browser, allowing you to make requests, click on links and submit forms programmatically",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/browser-kit/tree/v7.2.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-07-10T08:29:33+00:00"
+        },
+        {
+            "name": "symfony/dom-crawler",
+            "version": "v7.2.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dom-crawler.git",
+                "reference": "a7473767124513e4099186dba43403dbc45f26dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/a7473767124513e4099186dba43403dbc45f26dc",
+                "reference": "a7473767124513e4099186dba43403dbc45f26dc",
+                "shasum": ""
+            },
+            "require": {
+                "masterminds/html5": "^2.6",
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "symfony/css-selector": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DomCrawler\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases DOM navigation for HTML and XML documents",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dom-crawler/tree/v7.2.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-15T10:06:57+00:00"
+        },
+        {
+            "name": "symfony/phpunit-bridge",
+            "version": "v7.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/phpunit-bridge.git",
+                "reference": "140bbbe1cd1c21a084494ccddeee33f3c3381d7d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/phpunit-bridge/zipball/140bbbe1cd1c21a084494ccddeee33f3c3381d7d",
+                "reference": "140bbbe1cd1c21a084494ccddeee33f3c3381d7d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1.0"
+            },
+            "require-dev": {
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/error-handler": "^6.4.3|^7.0.3|^8.0"
+            },
+            "bin": [
+                "bin/simple-phpunit"
+            ],
+            "type": "symfony-bridge",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/sebastianbergmann/phpunit",
+                    "name": "phpunit/phpunit"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Bridge\\PhpUnit\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/",
+                    "/bin/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides utilities for PHPUnit, especially user deprecation notices management",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "testing"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/phpunit-bridge/tree/v7.4.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-24T13:12:05+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=8.4",
+        "ext-ctype": "*",
+        "ext-iconv": "*",
+        "ext-intl": "*",
+        "ext-pdo_sqlite": "*"
+    },
+    "platform-dev": [],
+    "platform-overrides": {
+        "php": "8.4.0"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -3,6 +3,7 @@ parameters:
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
     app.version: '%env(default::APP_VERSION)%'
     app.run_history_retention_days: '%env(int:RUN_HISTORY_RETENTION_DAYS)%'
+    app.backup_dir: '%kernel.project_dir%/var/backups'
     app.backup_retention_days: '%env(int:BACKUP_RETENTION_DAYS)%'
     navidrome.db_path: '%env(NAVIDROME_DB_PATH)%'
     navidrome.url: '%env(NAVIDROME_URL)%'
@@ -35,6 +36,10 @@ services:
         bind:
             $projectDir: '%kernel.project_dir%'
 
+    _instanceof:
+        App\Notifier\NotifierDriverInterface:
+            tags: ['app.notifier_driver']
+
     App\:
         resource: '../src/'
         exclude:
@@ -46,3 +51,45 @@ services:
         arguments:
             $username: '%app.auth_user%'
             $plainPassword: '%app.auth_password%'
+
+    App\Service\BackupService:
+        arguments:
+            $backupDir: '%app.backup_dir%'
+
+    App\Command\PurgeBackupsCommand:
+        arguments:
+            $retentionDays: '%app.backup_retention_days%'
+
+    App\Command\PurgeHistoryCommand:
+        arguments:
+            $retentionDays: '%app.run_history_retention_days%'
+
+    App\Notifier\Notifier:
+        arguments:
+            $drivers: !tagged_iterator app.notifier_driver
+            $enabledDriversCsv: '%notify.drivers%'
+            $notifyOn: '%notify.on%'
+
+    App\Notifier\Driver\GotifyDriver:
+        arguments:
+            $url: '%notify.gotify.url%'
+            $token: '%notify.gotify.token%'
+            $priority: '%notify.gotify.priority%'
+
+    App\Notifier\Driver\SlackDriver:
+        arguments:
+            $webhookUrl: '%notify.slack.webhook_url%'
+
+    App\Notifier\Driver\DiscordDriver:
+        arguments:
+            $webhookUrl: '%notify.discord.webhook_url%'
+
+    App\Notifier\Driver\PushoverDriver:
+        arguments:
+            $token: '%notify.pushover.token%'
+            $user: '%notify.pushover.user%'
+
+    App\Navidrome\NavidromeRepository:
+        arguments:
+            $dbPath: '%navidrome.db_path%'
+            $userName: '%navidrome.user%'

--- a/migrations/Version20260514200000.php
+++ b/migrations/Version20260514200000.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514200000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Initial schema: run_history, setting, lastfm_alias, lastfm_artist_alias, lastfm_match_cache.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE run_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                type VARCHAR(32) NOT NULL,
+                reference VARCHAR(255) NOT NULL,
+                label VARCHAR(255) NOT NULL,
+                status VARCHAR(16) NOT NULL DEFAULT 'success',
+                started_at DATETIME NOT NULL,
+                finished_at DATETIME DEFAULT NULL,
+                duration_ms INTEGER DEFAULT NULL,
+                message CLOB DEFAULT NULL,
+                metrics CLOB DEFAULT NULL
+            )
+        SQL);
+        $this->addSql('CREATE INDEX idx_run_history_type ON run_history (type)');
+        $this->addSql('CREATE INDEX idx_run_history_status ON run_history (status)');
+        $this->addSql('CREATE INDEX idx_run_history_started_at ON run_history (started_at)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE setting (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "key" VARCHAR(64) NOT NULL,
+                value CLOB NOT NULL DEFAULT '',
+                UNIQUE ("key")
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE lastfm_alias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                source_artist VARCHAR(255) NOT NULL,
+                source_title VARCHAR(255) NOT NULL,
+                source_artist_norm VARCHAR(255) NOT NULL,
+                source_title_norm VARCHAR(255) NOT NULL,
+                target_media_file_id VARCHAR(255) DEFAULT NULL,
+                created_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_lastfm_alias_source_norm ON lastfm_alias (source_artist_norm, source_title_norm)');
+        $this->addSql('CREATE INDEX idx_lastfm_alias_source_norm ON lastfm_alias (source_artist_norm, source_title_norm)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE lastfm_artist_alias (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                source_artist VARCHAR(255) NOT NULL,
+                source_artist_norm VARCHAR(255) NOT NULL,
+                target_artist VARCHAR(255) NOT NULL,
+                created_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_lastfm_artist_alias_source_norm ON lastfm_artist_alias (source_artist_norm)');
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE lastfm_match_cache (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                source_artist VARCHAR(255) NOT NULL,
+                source_title VARCHAR(255) NOT NULL,
+                source_artist_norm VARCHAR(255) NOT NULL,
+                source_title_norm VARCHAR(255) NOT NULL,
+                target_media_file_id VARCHAR(255) DEFAULT NULL,
+                strategy VARCHAR(32) NOT NULL,
+                confidence_score INTEGER DEFAULT NULL,
+                resolved_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_lastfm_match_cache_source_norm ON lastfm_match_cache (source_artist_norm, source_title_norm)');
+        $this->addSql('CREATE INDEX idx_lastfm_match_cache_artist_norm ON lastfm_match_cache (source_artist_norm)');
+        $this->addSql('CREATE INDEX idx_lastfm_match_cache_resolved_at ON lastfm_match_cache (resolved_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE lastfm_match_cache');
+        $this->addSql('DROP TABLE lastfm_artist_alias');
+        $this->addSql('DROP TABLE lastfm_alias');
+        $this->addSql('DROP TABLE setting');
+        $this->addSql('DROP TABLE run_history');
+    }
+}

--- a/src/Command/PurgeBackupsCommand.php
+++ b/src/Command/PurgeBackupsCommand.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Service\BackupService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:backup:purge',
+    description: 'Delete backup files older than BACKUP_RETENTION_DAYS days.',
+)]
+class PurgeBackupsCommand extends Command
+{
+    public function __construct(
+        private readonly BackupService $backupService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly int $retentionDays,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('days', null, InputOption::VALUE_REQUIRED, 'Override retention days.', null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $days = (int) ($input->getOption('days') ?? $this->retentionDays);
+
+        try {
+            $removed = $this->recorder->record(
+                type: RunHistory::TYPE_BACKUP_PURGE,
+                reference: 'backups',
+                label: sprintf('Purge backups > %d days', $days),
+                action: fn () => $this->backupService->pruneOlderThan($days),
+                extractMetrics: static fn (int $n) => ['removed' => $n, 'retention_days' => $days],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Removed %d backup file(s) older than %d days.', $removed, $days));
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/PurgeHistoryCommand.php
+++ b/src/Command/PurgeHistoryCommand.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Repository\RunHistoryRepository;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:history:purge',
+    description: 'Delete run_history entries older than RUN_HISTORY_RETENTION_DAYS days.',
+)]
+class PurgeHistoryCommand extends Command
+{
+    public function __construct(
+        private readonly RunHistoryRepository $runHistoryRepo,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly int $retentionDays,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $cutoff = new \DateTimeImmutable(sprintf('-%d days', $this->retentionDays));
+
+        try {
+            $deleted = $this->recorder->record(
+                type: RunHistory::TYPE_HISTORY_PURGE,
+                reference: 'run_history',
+                label: sprintf('Purge history > %d days', $this->retentionDays),
+                action: fn () => $this->runHistoryRepo->purgeOlderThan($cutoff),
+                extractMetrics: fn (int $n) => ['deleted' => $n, 'retention_days' => $this->retentionDays],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Deleted %d run_history entries older than %d days.', $deleted, $this->retentionDays));
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Repository\RunHistoryRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -9,8 +10,12 @@ use Symfony\Component\Routing\Attribute\Route;
 class DashboardController extends AbstractController
 {
     #[Route('/', name: 'app_dashboard')]
-    public function index(): Response
+    public function index(RunHistoryRepository $runHistory): Response
     {
-        return $this->render('dashboard/index.html.twig');
+        $recentRuns = $runHistory->findFilteredPaginated([], 1, 10)['items'];
+
+        return $this->render('dashboard/index.html.twig', [
+            'recent_runs' => $recentRuns,
+        ]);
     }
 }

--- a/src/Controller/HistoryController.php
+++ b/src/Controller/HistoryController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\RunHistory;
+use App\Repository\RunHistoryRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class HistoryController extends AbstractController
+{
+    #[Route('/history', name: 'app_history')]
+    public function index(Request $request, RunHistoryRepository $repo): Response
+    {
+        $page = max(1, (int) $request->query->get('page', '1'));
+        $filters = [
+            'type' => $request->query->get('type', ''),
+            'status' => $request->query->get('status', ''),
+            'q' => $request->query->get('q', ''),
+        ];
+
+        $result = $repo->findFilteredPaginated($filters, $page, 25);
+
+        return $this->render('history/index.html.twig', [
+            'items' => $result['items'],
+            'total' => $result['total'],
+            'page' => $page,
+            'pages' => max(1, (int) ceil($result['total'] / 25)),
+            'filters' => $filters,
+        ]);
+    }
+
+    #[Route('/history/{id}', name: 'app_history_show', requirements: ['id' => '\d+'])]
+    public function show(RunHistory $runHistory): Response
+    {
+        return $this->render('history/show.html.twig', ['run' => $runHistory]);
+    }
+
+    #[Route('/history/{id}/status.json', name: 'app_history_status', requirements: ['id' => '\d+'])]
+    public function status(RunHistory $runHistory): JsonResponse
+    {
+        return new JsonResponse([
+            'id' => $runHistory->getId(),
+            'status' => $runHistory->getStatus(),
+            'label' => $runHistory->getLabel(),
+            'metrics' => $runHistory->getMetrics(),
+            'message' => $runHistory->getMessage(),
+            'duration_ms' => $runHistory->getDurationMs(),
+        ]);
+    }
+}

--- a/src/Entity/LastFmAlias.php
+++ b/src/Entity/LastFmAlias.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Entity;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmAliasRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Manual mapping (artist, title) → Navidrome media_file id.
+ * Null targetMediaFileId = ignore/skip scrobbles matching this couple.
+ */
+#[ORM\Entity(repositoryClass: LastFmAliasRepository::class)]
+#[ORM\Table(name: 'lastfm_alias')]
+#[ORM\UniqueConstraint(name: 'uniq_lastfm_alias_source_norm', columns: ['source_artist_norm', 'source_title_norm'])]
+#[ORM\Index(columns: ['source_artist_norm', 'source_title_norm'], name: 'idx_lastfm_alias_source_norm')]
+class LastFmAlias
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtist;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitle;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtistNorm;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitleNorm;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $targetMediaFileId = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(string $sourceArtist, string $sourceTitle, ?string $targetMediaFileId)
+    {
+        $this->setSource($sourceArtist, $sourceTitle);
+        $this->targetMediaFileId = ($targetMediaFileId !== null && $targetMediaFileId !== '') ? $targetMediaFileId : null;
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function setSource(string $sourceArtist, string $sourceTitle): void
+    {
+        $this->sourceArtist = trim($sourceArtist);
+        $this->sourceTitle = trim($sourceTitle);
+        $this->sourceArtistNorm = NavidromeRepository::normalize($sourceArtist);
+        $this->sourceTitleNorm = NavidromeRepository::normalize($sourceTitle);
+    }
+
+    public function setTargetMediaFileId(?string $id): void
+    {
+        $this->targetMediaFileId = ($id !== null && $id !== '') ? $id : null;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+    public function getSourceArtist(): string
+    {
+        return $this->sourceArtist;
+    }
+    public function getSourceTitle(): string
+    {
+        return $this->sourceTitle;
+    }
+    public function getSourceArtistNorm(): string
+    {
+        return $this->sourceArtistNorm;
+    }
+    public function getSourceTitleNorm(): string
+    {
+        return $this->sourceTitleNorm;
+    }
+    public function getTargetMediaFileId(): ?string
+    {
+        return $this->targetMediaFileId;
+    }
+    public function isSkip(): bool
+    {
+        return $this->targetMediaFileId === null;
+    }
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Entity/LastFmArtistAlias.php
+++ b/src/Entity/LastFmArtistAlias.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Entity;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmArtistAliasRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Artist-level alias: rewrite the Last.fm artist name before the matching
+ * cascade runs. Covers all tracks by that artist.
+ */
+#[ORM\Entity(repositoryClass: LastFmArtistAliasRepository::class)]
+#[ORM\Table(name: 'lastfm_artist_alias')]
+#[ORM\UniqueConstraint(name: 'uniq_lastfm_artist_alias_source_norm', columns: ['source_artist_norm'])]
+class LastFmArtistAlias
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtist;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtistNorm;
+
+    #[ORM\Column(length: 255)]
+    private string $targetArtist;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $createdAt;
+
+    public function __construct(string $sourceArtist, string $targetArtist)
+    {
+        $this->setSource($sourceArtist);
+        $this->setTargetArtist($targetArtist);
+        $this->createdAt = new \DateTimeImmutable();
+    }
+
+    public function setSource(string $sourceArtist): void
+    {
+        $this->sourceArtist = trim($sourceArtist);
+        $this->sourceArtistNorm = NavidromeRepository::normalize($sourceArtist);
+    }
+
+    public function setTargetArtist(string $targetArtist): void
+    {
+        $this->targetArtist = trim($targetArtist);
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+    public function getSourceArtist(): string
+    {
+        return $this->sourceArtist;
+    }
+    public function getSourceArtistNorm(): string
+    {
+        return $this->sourceArtistNorm;
+    }
+    public function getTargetArtist(): string
+    {
+        return $this->targetArtist;
+    }
+    public function getCreatedAt(): \DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/src/Entity/LastFmMatchCacheEntry.php
+++ b/src/Entity/LastFmMatchCacheEntry.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace App\Entity;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmMatchCacheRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Memoized resolution of a Last.fm `(artist, title)` couple to a Navidrome
+ * `media_file` id. Consulted by {@see \App\LastFm\ScrobbleMatcher} *after*
+ * the alias steps and *before* the heuristic cascade so repeated imports
+ * (and especially `app:lastfm:rematch` runs) skip the SQL + Last.fm
+ * `track.getInfo` round-trips when we already know the answer.
+ *
+ * `target_media_file_id` semantics:
+ *   - non-null → positive cache hit, return matched.
+ *   - null     → negative cache hit ; the cascade ran, found nothing,
+ *                and we remember it for `LASTFM_MATCH_CACHE_TTL_DAYS`
+ *                so we don't waste time / API calls re-trying.
+ */
+#[ORM\Entity(repositoryClass: LastFmMatchCacheRepository::class)]
+#[ORM\Table(name: 'lastfm_match_cache')]
+#[ORM\UniqueConstraint(name: 'uniq_lastfm_match_cache_source_norm', columns: ['source_artist_norm', 'source_title_norm'])]
+#[ORM\Index(columns: ['source_artist_norm'], name: 'idx_lastfm_match_cache_artist_norm')]
+#[ORM\Index(columns: ['resolved_at'], name: 'idx_lastfm_match_cache_resolved_at')]
+class LastFmMatchCacheEntry
+{
+    public const STRATEGY_MBID = 'mbid';
+    public const STRATEGY_TRIPLET = 'triplet';
+    public const STRATEGY_COUPLE = 'couple';
+    public const STRATEGY_FUZZY = 'fuzzy';
+    public const STRATEGY_LASTFM_CORRECTION = 'lastfm-correction';
+    public const STRATEGY_NEGATIVE = 'negative';
+
+    private const VALID_STRATEGIES = [
+        self::STRATEGY_MBID,
+        self::STRATEGY_TRIPLET,
+        self::STRATEGY_COUPLE,
+        self::STRATEGY_FUZZY,
+        self::STRATEGY_LASTFM_CORRECTION,
+        self::STRATEGY_NEGATIVE,
+    ];
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtist;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitle;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceArtistNorm;
+
+    #[ORM\Column(length: 255)]
+    private string $sourceTitleNorm;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $targetMediaFileId = null;
+
+    #[ORM\Column(length: 32)]
+    private string $strategy;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $confidenceScore = null;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $resolvedAt;
+
+    public function __construct(
+        string $sourceArtist,
+        string $sourceTitle,
+        ?string $targetMediaFileId,
+        string $strategy,
+        ?int $confidenceScore = null,
+    ) {
+        $this->setSource($sourceArtist, $sourceTitle);
+        $this->setResolution($targetMediaFileId, $strategy, $confidenceScore);
+        $this->resolvedAt = new \DateTimeImmutable();
+    }
+
+    /**
+     * Build a transient (unmanaged) entry from a raw DB row. Used by
+     * {@see \App\Repository\LastFmMatchCacheRepository::findByCouple} to
+     * hand the matcher an object it can read getters off of without
+     * roundtripping through the ORM identity map.
+     *
+     * @param array<string, mixed> $row
+     */
+    public static function fromRow(array $row): self
+    {
+        $entry = new self(
+            (string) $row['source_artist'],
+            (string) $row['source_title'],
+            isset($row['target_media_file_id']) && $row['target_media_file_id'] !== '' ? (string) $row['target_media_file_id'] : null,
+            (string) $row['strategy'],
+            isset($row['confidence_score']) ? (int) $row['confidence_score'] : null,
+        );
+        // The constructor stamps resolvedAt = now ; restore the DB value so
+        // isStale() compares against the actual age of the cached resolution.
+        (new \ReflectionProperty(self::class, 'resolvedAt'))
+            ->setValue($entry, new \DateTimeImmutable((string) $row['resolved_at']));
+
+        return $entry;
+    }
+
+    public function setSource(string $sourceArtist, string $sourceTitle): void
+    {
+        $this->sourceArtist = trim($sourceArtist);
+        $this->sourceTitle = trim($sourceTitle);
+        $this->sourceArtistNorm = NavidromeRepository::normalize($sourceArtist);
+        $this->sourceTitleNorm = NavidromeRepository::normalize($sourceTitle);
+    }
+
+    public function setResolution(?string $targetMediaFileId, string $strategy, ?int $confidenceScore = null): void
+    {
+        if (!in_array($strategy, self::VALID_STRATEGIES, true)) {
+            throw new \InvalidArgumentException(sprintf('Invalid match cache strategy "%s".', $strategy));
+        }
+        $this->targetMediaFileId = $targetMediaFileId !== null && $targetMediaFileId !== '' ? $targetMediaFileId : null;
+        $this->strategy = $strategy;
+        $this->confidenceScore = $confidenceScore;
+        $this->resolvedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getSourceArtist(): string
+    {
+        return $this->sourceArtist;
+    }
+
+    public function getSourceTitle(): string
+    {
+        return $this->sourceTitle;
+    }
+
+    public function getSourceArtistNorm(): string
+    {
+        return $this->sourceArtistNorm;
+    }
+
+    public function getSourceTitleNorm(): string
+    {
+        return $this->sourceTitleNorm;
+    }
+
+    public function getTargetMediaFileId(): ?string
+    {
+        return $this->targetMediaFileId;
+    }
+
+    public function isPositive(): bool
+    {
+        return $this->targetMediaFileId !== null;
+    }
+
+    public function getStrategy(): string
+    {
+        return $this->strategy;
+    }
+
+    public function getConfidenceScore(): ?int
+    {
+        return $this->confidenceScore;
+    }
+
+    public function getResolvedAt(): \DateTimeImmutable
+    {
+        return $this->resolvedAt;
+    }
+
+    /**
+     * A row is stale once `resolvedAt` is older than `$ttlDays` days.
+     * `$ttlDays <= 0` means « never expire » — useful for setups that
+     * trust positive matches forever and prefer manual purges.
+     */
+    public function isStale(int $ttlDays, ?\DateTimeImmutable $now = null): bool
+    {
+        if ($ttlDays <= 0) {
+            return false;
+        }
+        $now ??= new \DateTimeImmutable();
+
+        return $this->resolvedAt < $now->modify(sprintf('-%d days', $ttlDays));
+    }
+}

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\RunHistoryRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: RunHistoryRepository::class)]
+#[ORM\Table(name: 'run_history')]
+#[ORM\Index(columns: ['type'], name: 'idx_run_history_type')]
+#[ORM\Index(columns: ['status'], name: 'idx_run_history_status')]
+#[ORM\Index(columns: ['started_at'], name: 'idx_run_history_started_at')]
+class RunHistory
+{
+    public const TYPE_LASTFM_FETCH = 'lastfm-fetch';
+    public const TYPE_NAVIDROME_SYNC = 'navidrome-sync';
+    public const TYPE_NAVIDROME_REMATCH = 'navidrome-rematch';
+    public const TYPE_STRAWBERRY_SYNC = 'strawberry-sync';
+    public const TYPE_STRAWBERRY_REMATCH = 'strawberry-rematch';
+    public const TYPE_STATS = 'stats';
+    public const TYPE_BACKUP_PURGE = 'backup-purge';
+    public const TYPE_HISTORY_PURGE = 'history-purge';
+
+    public const STATUS_SUCCESS = 'success';
+    public const STATUS_ERROR = 'error';
+    public const STATUS_SKIPPED = 'skipped';
+    public const STATUS_RUNNING = 'running';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 32)]
+    private string $type;
+
+    #[ORM\Column(length: 255)]
+    private string $reference;
+
+    #[ORM\Column(length: 255)]
+    private string $label;
+
+    #[ORM\Column(length: 16)]
+    private string $status = self::STATUS_SUCCESS;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $startedAt;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE, nullable: true)]
+    private ?\DateTimeImmutable $finishedAt = null;
+
+    #[ORM\Column(type: Types::INTEGER, nullable: true)]
+    private ?int $durationMs = null;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $message = null;
+
+    /** @var array<string, mixed>|null */
+    #[ORM\Column(type: Types::JSON, nullable: true)]
+    private ?array $metrics = null;
+
+    public function __construct(string $type, string $reference, string $label)
+    {
+        $this->type = $type;
+        $this->reference = $reference;
+        $this->label = $label;
+        $this->startedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+    public function getType(): string
+    {
+        return $this->type;
+    }
+    public function getReference(): string
+    {
+        return $this->reference;
+    }
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+    public function getStartedAt(): \DateTimeImmutable
+    {
+        return $this->startedAt;
+    }
+    public function getFinishedAt(): ?\DateTimeImmutable
+    {
+        return $this->finishedAt;
+    }
+    public function getDurationMs(): ?int
+    {
+        return $this->durationMs;
+    }
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    /** @return array<string, mixed>|null */
+    public function getMetrics(): ?array
+    {
+        return $this->metrics;
+    }
+
+    public function setStatus(string $status): self
+    {
+        $this->status = $status;
+        return $this;
+    }
+    public function setFinishedAt(?\DateTimeImmutable $at): self
+    {
+        $this->finishedAt = $at;
+        return $this;
+    }
+    public function setDurationMs(?int $ms): self
+    {
+        $this->durationMs = $ms;
+        return $this;
+    }
+
+    public function setMessage(?string $message): self
+    {
+        if ($message !== null && strlen($message) > 5000) {
+            $message = substr($message, 0, 5000) . '… (truncated)';
+        }
+        $this->message = $message;
+        return $this;
+    }
+
+    /** @param array<string, mixed>|null $metrics */
+    public function setMetrics(?array $metrics): self
+    {
+        $this->metrics = $metrics;
+        return $this;
+    }
+}

--- a/src/Entity/Setting.php
+++ b/src/Entity/Setting.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\SettingRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: SettingRepository::class)]
+#[ORM\Table(name: 'setting')]
+class Setting
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(name: '`key`', length: 64, unique: true)]
+    private string $key;
+
+    #[ORM\Column(type: Types::TEXT)]
+    private string $value = '';
+
+    public function __construct(string $key = '', string $value = '')
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function setKey(string $key): self
+    {
+        $this->key = $key;
+        return $this;
+    }
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+        return $this;
+    }
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -1,0 +1,2179 @@
+<?php
+
+namespace App\Navidrome;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\Exception as DbalException;
+
+class NavidromeRepository
+{
+    private ?Connection $connection = null;
+    private ?bool $hasScrobblesCache = null;
+    private ?string $userIdCache = null;
+    /** @var array<string>|null */
+    private ?array $scrobbleColumnsCache = null;
+
+    public function __construct(
+        private readonly string $dbPath,
+        private readonly string $userName,
+    ) {
+    }
+
+    public function isAvailable(): bool
+    {
+        try {
+            $this->connection()->executeQuery('SELECT 1');
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Most recent scrobbles for the configured user, joined with media_file
+     * to expose artist/title/album. Returns an empty array when the
+     * scrobbles table does not exist (Navidrome < 0.55).
+     *
+     * @return list<array{media_file_id: string, played_at: \DateTimeImmutable, artist: string, title: string, album: string}>
+     */
+    public function getRecentScrobbles(int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT s.media_file_id AS id, s.submission_time AS ts,
+                    mf.artist AS artist, mf.title AS title, mf.album AS album
+             FROM scrobbles s
+             LEFT JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid
+             ORDER BY s.submission_time DESC
+             LIMIT :lim',
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): array => [
+            'media_file_id' => (string) $r['id'],
+            'played_at' => (new \DateTimeImmutable('@' . (int) $r['ts']))->setTimezone(new \DateTimeZone(date_default_timezone_get())),
+            'artist' => (string) ($r['artist'] ?? ''),
+            'title' => (string) ($r['title'] ?? ''),
+            'album' => (string) ($r['album'] ?? ''),
+        ], $rows);
+    }
+
+    /**
+     * Total number of rows in the Navidrome `scrobbles` table for any user.
+     * Returns 0 when the table does not exist (Navidrome < 0.55).
+     */
+    public function getScrobblesCount(): int
+    {
+        if (!$this->hasScrobblesTable()) {
+            return 0;
+        }
+
+        return (int) $this->connection()->fetchOne('SELECT COUNT(*) FROM scrobbles');
+    }
+
+    public function hasScrobblesTable(): bool
+    {
+        if ($this->hasScrobblesCache !== null) {
+            return $this->hasScrobblesCache;
+        }
+
+        $row = $this->connection()->fetchOne(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='scrobbles'"
+        );
+
+        return $this->hasScrobblesCache = ($row !== false);
+    }
+
+    /**
+     * Columns of the scrobbles table (lower-cased), or [] when the table
+     * is missing. Used to feature-detect optional columns like `client`
+     * (Subsonic client name) which exist on Navidrome 0.55+ but not on
+     * older or stripped-down installs.
+     *
+     * @return array<string>
+     */
+    public function scrobbleColumns(): array
+    {
+        if ($this->scrobbleColumnsCache !== null) {
+            return $this->scrobbleColumnsCache;
+        }
+        if (!$this->hasScrobblesTable()) {
+            return $this->scrobbleColumnsCache = [];
+        }
+        $rows = $this->connection()->fetchAllAssociative('PRAGMA table_info(scrobbles)');
+
+        return $this->scrobbleColumnsCache = array_map(
+            static fn (array $r): string => strtolower((string) $r['name']),
+            $rows,
+        );
+    }
+
+    public function hasScrobbleClient(): bool
+    {
+        return in_array('client', $this->scrobbleColumns(), true);
+    }
+
+    /**
+     * Distinct non-empty Subsonic clients found in the scrobbles table.
+     * Returns [] when the column doesn't exist.
+     *
+     * @return list<string>
+     */
+    public function listScrobbleClients(): array
+    {
+        if (!$this->hasScrobbleClient()) {
+            return [];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT DISTINCT client FROM scrobbles
+             WHERE client IS NOT NULL AND client != \'\'
+             ORDER BY client ASC',
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['client'], $rows);
+    }
+
+    public function resolveUserId(): string
+    {
+        if ($this->userIdCache !== null) {
+            return $this->userIdCache;
+        }
+
+        $id = $this->connection()->fetchOne(
+            'SELECT id FROM user WHERE user_name = :name LIMIT 1',
+            ['name' => $this->userName],
+        );
+        if (!is_string($id) || $id === '') {
+            throw new \RuntimeException(sprintf(
+                'Navidrome user "%s" not found in database. Check NAVIDROME_USER.',
+                $this->userName,
+            ));
+        }
+
+        return $this->userIdCache = $id;
+    }
+
+    /**
+     * Top tracks within [from, to). Uses scrobbles when available, otherwise
+     * falls back to annotation.play_date.
+     *
+     * @return string[] media_file ids ordered by play count DESC
+     */
+    public function topTracksInWindow(\DateTimeInterface $from, \DateTimeInterface $to, int $limit): array
+    {
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = <<<'SQL'
+                SELECT s.media_file_id AS id
+                FROM scrobbles s
+                WHERE s.user_id = :uid
+                  AND s.submission_time >= :from
+                  AND s.submission_time <  :to
+                GROUP BY s.media_file_id
+                ORDER BY COUNT(*) DESC, MAX(s.submission_time) DESC
+                LIMIT :lim
+            SQL;
+            $params = ['uid' => $userId, 'from' => $from->getTimestamp(), 'to' => $to->getTimestamp(), 'lim' => $limit];
+            $types = [
+                'from' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'to' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ];
+        } else {
+            $sql = <<<'SQL'
+                SELECT a.item_id AS id
+                FROM annotation a
+                WHERE a.item_type = 'media_file'
+                  AND a.user_id = :uid
+                  AND a.play_date >= :from
+                  AND a.play_date <  :to
+                ORDER BY a.play_count DESC, a.play_date DESC
+                LIMIT :lim
+            SQL;
+            $params = [
+                'uid' => $userId,
+                'from' => $from->format('Y-m-d H:i:s'),
+                'to' => $to->format('Y-m-d H:i:s'),
+                'lim' => $limit,
+            ];
+            $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r) => (string) $r['id'], $rows);
+    }
+
+    /**
+     * Top tracks aggregated across several disjoint windows. Identical
+     * semantics to {@see topTracksInWindow()} but the WHERE clause unions
+     * each `[from, to)` pair so a track played in multiple windows ranks
+     * higher (used by the anniversary generator that aggregates « same
+     * day of year, 1 / 2 / 5 / 10 years ago »).
+     *
+     * @param list<array{from: \DateTimeInterface, to: \DateTimeInterface}> $windows
+     *
+     * @return string[] media_file ids ordered by total play count DESC
+     */
+    public function topTracksInWindows(array $windows, int $limit): array
+    {
+        if ($windows === []) {
+            return [];
+        }
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $clauses = [];
+            $params = ['uid' => $userId, 'lim' => $limit];
+            $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+            foreach ($windows as $i => $w) {
+                $fromKey = "f{$i}";
+                $toKey = "t{$i}";
+                $clauses[] = "(s.submission_time >= :{$fromKey} AND s.submission_time < :{$toKey})";
+                $params[$fromKey] = $w['from']->getTimestamp();
+                $params[$toKey] = $w['to']->getTimestamp();
+                $types[$fromKey] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types[$toKey] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            $sql = sprintf(
+                "SELECT s.media_file_id AS id
+                 FROM scrobbles s
+                 WHERE s.user_id = :uid AND (%s)
+                 GROUP BY s.media_file_id
+                 ORDER BY COUNT(*) DESC, MAX(s.submission_time) DESC
+                 LIMIT :lim",
+                implode(' OR ', $clauses),
+            );
+
+            $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+            return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+        }
+
+        // Annotation fallback: only the LAST play matters, so we just match
+        // any window the row's play_date falls in. Less reliable but keeps
+        // the generator usable on Navidrome < 0.55.
+        $clauses = [];
+        $params = ['uid' => $userId, 'lim' => $limit];
+        $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+        foreach ($windows as $i => $w) {
+            $fromKey = "f{$i}";
+            $toKey = "t{$i}";
+            $clauses[] = "(a.play_date >= :{$fromKey} AND a.play_date < :{$toKey})";
+            $params[$fromKey] = $w['from']->format('Y-m-d H:i:s');
+            $params[$toKey] = $w['to']->format('Y-m-d H:i:s');
+        }
+        $sql = sprintf(
+            "SELECT a.item_id AS id
+             FROM annotation a
+             WHERE a.item_type = 'media_file' AND a.user_id = :uid AND (%s)
+             ORDER BY a.play_count DESC, a.play_date DESC
+             LIMIT :lim",
+            implode(' OR ', $clauses),
+        );
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
+     * All-time top: based on annotation.play_count (always available).
+     *
+     * @return string[]
+     */
+    public function topAllTime(int $limit): array
+    {
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT a.item_id AS id
+            FROM annotation a
+            WHERE a.item_type = 'media_file'
+              AND a.user_id = :uid
+              AND a.play_count > 0
+            ORDER BY a.play_count DESC, a.play_date DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative($sql, [
+            'uid' => $userId,
+            'lim' => $limit,
+        ], [
+            'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return array_map(static fn (array $r) => (string) $r['id'], $rows);
+    }
+
+    /**
+     * Random media files never played by the configured user.
+     *
+     * @return string[]
+     */
+    public function neverPlayedRandom(int $limit): array
+    {
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT mf.id
+            FROM media_file mf
+            LEFT JOIN annotation a
+              ON a.item_id = mf.id
+             AND a.item_type = 'media_file'
+             AND a.user_id = :uid
+            WHERE COALESCE(a.play_count, 0) = 0
+            ORDER BY RANDOM()
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative($sql, [
+            'uid' => $userId,
+            'lim' => $limit,
+        ], [
+            'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return array_map(static fn (array $r) => (string) $r['id'], $rows);
+    }
+
+    /**
+     * Total number of plays in [from, to). Pass null/null for all-time.
+     *
+     * Always prefers the `scrobbles` table when present (so a Last.fm
+     * import is reflected in the count). Falls back to summing
+     * `annotation.play_count` when scrobbles is missing — note that the
+     * fallback's "windowed" mode is only an approximation: it counts
+     * tracks whose *last* play falls inside the window.
+     */
+    public function getTotalPlays(?\DateTimeInterface $from, ?\DateTimeInterface $to, ?string $client = null): int
+    {
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = 'SELECT COUNT(*) FROM scrobbles WHERE user_id = :uid';
+            $params = ['uid' => $userId];
+            $types = [];
+            if ($from !== null && $to !== null) {
+                $sql .= ' AND submission_time >= :f AND submission_time < :t';
+                $params['f'] = $from->getTimestamp();
+                $params['t'] = $to->getTimestamp();
+                $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND client = :client';
+                $params['client'] = $client;
+            }
+
+            return (int) $this->connection()->fetchOne($sql, $params, $types);
+        }
+
+        if ($from !== null && $to !== null) {
+            // Fallback: only counts plays whose LAST play falls in the window.
+            $sql = "SELECT COALESCE(SUM(play_count), 0) FROM annotation
+                    WHERE item_type = 'media_file' AND user_id = :uid
+                      AND play_date >= :f AND play_date < :t";
+
+            return (int) $this->connection()->fetchOne($sql, [
+                'uid' => $userId,
+                'f' => $from->format('Y-m-d H:i:s'),
+                't' => $to->format('Y-m-d H:i:s'),
+            ]);
+        }
+
+        $sql = "SELECT COALESCE(SUM(play_count), 0) FROM annotation
+                WHERE item_type = 'media_file' AND user_id = :uid";
+
+        return (int) $this->connection()->fetchOne($sql, ['uid' => $userId]);
+    }
+
+    /**
+     * Number of distinct media files played at least once in [from, to).
+     * Uses scrobbles when available (always accurate), annotation otherwise.
+     */
+    public function getDistinctTracksPlayed(?\DateTimeInterface $from, ?\DateTimeInterface $to, ?string $client = null): int
+    {
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = 'SELECT COUNT(DISTINCT media_file_id) FROM scrobbles WHERE user_id = :uid';
+            $params = ['uid' => $userId];
+            $types = [];
+            if ($from !== null && $to !== null) {
+                $sql .= ' AND submission_time >= :f AND submission_time < :t';
+                $params['f'] = $from->getTimestamp();
+                $params['t'] = $to->getTimestamp();
+                $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND client = :client';
+                $params['client'] = $client;
+            }
+
+            return (int) $this->connection()->fetchOne($sql, $params, $types);
+        }
+
+        if ($from !== null && $to !== null) {
+            $sql = "SELECT COUNT(*) FROM annotation
+                    WHERE item_type = 'media_file' AND user_id = :uid
+                      AND play_count > 0
+                      AND play_date >= :f AND play_date < :t";
+
+            return (int) $this->connection()->fetchOne($sql, [
+                'uid' => $userId,
+                'f' => $from->format('Y-m-d H:i:s'),
+                't' => $to->format('Y-m-d H:i:s'),
+            ]);
+        }
+
+        $sql = "SELECT COUNT(*) FROM annotation
+                WHERE item_type = 'media_file' AND user_id = :uid AND play_count > 0";
+
+        return (int) $this->connection()->fetchOne($sql, ['uid' => $userId]);
+    }
+
+    /**
+     * Top artists by aggregated plays in [from, to). Pass null/null for all-time.
+     *
+     * @return list<array{artist: string, plays: int}>
+     */
+    public function getTopArtists(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
+    {
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = 'SELECT mf.artist AS artist, COUNT(*) AS plays
+                    FROM scrobbles s
+                    JOIN media_file mf ON mf.id = s.media_file_id
+                    WHERE s.user_id = :uid
+                      AND mf.artist != ""';
+            $params = ['uid' => $userId, 'lim' => $limit];
+            $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+            if ($from !== null && $to !== null) {
+                $sql .= ' AND s.submission_time >= :f AND s.submission_time < :t';
+                $params['f'] = $from->getTimestamp();
+                $params['t'] = $to->getTimestamp();
+                $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND s.client = :client';
+                $params['client'] = $client;
+            }
+            $sql .= ' GROUP BY mf.artist ORDER BY plays DESC, artist ASC LIMIT :lim';
+
+            $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+            return array_map(
+                static fn (array $r) => ['artist' => (string) $r['artist'], 'plays' => (int) $r['plays']],
+                $rows,
+            );
+        } elseif ($from !== null && $to !== null) {
+            $sql = 'SELECT mf.artist AS artist, COALESCE(SUM(a.play_count), 0) AS plays
+                    FROM annotation a
+                    JOIN media_file mf ON mf.id = a.item_id
+                    WHERE a.item_type = "media_file" AND a.user_id = :uid
+                      AND a.play_date >= :f AND a.play_date < :t
+                      AND mf.artist != ""
+                    GROUP BY mf.artist
+                    ORDER BY plays DESC, artist ASC
+                    LIMIT :lim';
+            $params = [
+                'uid' => $userId,
+                'f' => $from->format('Y-m-d H:i:s'),
+                't' => $to->format('Y-m-d H:i:s'),
+                'lim' => $limit,
+            ];
+        } else {
+            $sql = 'SELECT mf.artist AS artist, COALESCE(SUM(a.play_count), 0) AS plays
+                    FROM annotation a
+                    JOIN media_file mf ON mf.id = a.item_id
+                    WHERE a.item_type = "media_file" AND a.user_id = :uid
+                      AND a.play_count > 0
+                      AND mf.artist != ""
+                    GROUP BY mf.artist
+                    ORDER BY plays DESC, artist ASC
+                    LIMIT :lim';
+            $params = ['uid' => $userId, 'lim' => $limit];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, [
+            'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return array_map(
+            static fn (array $r) => ['artist' => (string) $r['artist'], 'plays' => (int) $r['plays']],
+            $rows,
+        );
+    }
+
+    /**
+     * Top tracks (with full metadata) by aggregated plays in [from, to).
+     * Pass null/null for all-time.
+     *
+     * @return list<array{id: string, title: string, artist: string, album: string, plays: int}>
+     */
+    public function getTopTracksWithDetails(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
+    {
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = 'SELECT mf.id AS id, mf.title AS title, mf.artist AS artist, mf.album AS album,
+                           COUNT(*) AS plays
+                    FROM scrobbles s
+                    JOIN media_file mf ON mf.id = s.media_file_id
+                    WHERE s.user_id = :uid';
+            $params = ['uid' => $userId, 'lim' => $limit];
+            $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+            if ($from !== null && $to !== null) {
+                $sql .= ' AND s.submission_time >= :f AND s.submission_time < :t';
+                $params['f'] = $from->getTimestamp();
+                $params['t'] = $to->getTimestamp();
+                $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+                $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            }
+            if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+                $sql .= ' AND s.client = :client';
+                $params['client'] = $client;
+            }
+            $sql .= ' GROUP BY mf.id, mf.title, mf.artist, mf.album
+                      ORDER BY plays DESC, title ASC LIMIT :lim';
+
+            $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+            return array_map(static fn (array $r) => [
+                'id' => (string) $r['id'],
+                'title' => (string) $r['title'],
+                'artist' => (string) $r['artist'],
+                'album' => (string) $r['album'],
+                'plays' => (int) $r['plays'],
+            ], $rows);
+        } elseif ($from !== null && $to !== null) {
+            $sql = 'SELECT mf.id AS id, mf.title AS title, mf.artist AS artist, mf.album AS album,
+                           COALESCE(a.play_count, 0) AS plays
+                    FROM annotation a
+                    JOIN media_file mf ON mf.id = a.item_id
+                    WHERE a.item_type = "media_file" AND a.user_id = :uid
+                      AND a.play_date >= :f AND a.play_date < :t
+                    ORDER BY plays DESC, title ASC
+                    LIMIT :lim';
+            $params = [
+                'uid' => $userId,
+                'f' => $from->format('Y-m-d H:i:s'),
+                't' => $to->format('Y-m-d H:i:s'),
+                'lim' => $limit,
+            ];
+        } else {
+            $sql = 'SELECT mf.id AS id, mf.title AS title, mf.artist AS artist, mf.album AS album,
+                           a.play_count AS plays
+                    FROM annotation a
+                    JOIN media_file mf ON mf.id = a.item_id
+                    WHERE a.item_type = "media_file" AND a.user_id = :uid
+                      AND a.play_count > 0
+                    ORDER BY plays DESC, title ASC
+                    LIMIT :lim';
+            $params = ['uid' => $userId, 'lim' => $limit];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, [
+            'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return array_map(static fn (array $r) => [
+            'id' => (string) $r['id'],
+            'title' => (string) $r['title'],
+            'artist' => (string) $r['artist'],
+            'album' => (string) $r['album'],
+            'plays' => (int) $r['plays'],
+        ], $rows);
+    }
+
+    /**
+     * Top albums by aggregated plays in [from, to). Pass null/null for all-time.
+     * `sample_track_id` is the most-played media_file in the album, used for
+     * cover art on the UI.
+     *
+     * @return list<array{album: string, album_artist: string, plays: int, track_count: int, sample_track_id: string}>
+     */
+    public function getTopAlbums(?\DateTimeInterface $from, ?\DateTimeInterface $to, int $limit, ?string $client = null): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+
+        $sql = 'SELECT mf.album AS album,
+                       COALESCE(NULLIF(mf.album_artist, ""), mf.artist) AS album_artist,
+                       COUNT(*) AS plays,
+                       COUNT(DISTINCT mf.id) AS track_count,
+                       (SELECT s2.media_file_id
+                        FROM scrobbles s2
+                        JOIN media_file mf2 ON mf2.id = s2.media_file_id
+                        WHERE s2.user_id = :uid
+                          AND mf2.album = mf.album
+                          AND COALESCE(NULLIF(mf2.album_artist, ""), mf2.artist) = COALESCE(NULLIF(mf.album_artist, ""), mf.artist)
+                        GROUP BY s2.media_file_id
+                        ORDER BY COUNT(*) DESC, s2.media_file_id ASC
+                        LIMIT 1) AS sample_track_id
+                FROM scrobbles s
+                JOIN media_file mf ON mf.id = s.media_file_id
+                WHERE s.user_id = :uid
+                  AND mf.album != ""';
+        $params = ['uid' => $userId, 'lim' => $limit];
+        $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+        if ($from !== null && $to !== null) {
+            $sql .= ' AND s.submission_time >= :f AND s.submission_time < :t';
+            $params['f'] = $from->getTimestamp();
+            $params['t'] = $to->getTimestamp();
+            $types['f'] = \Doctrine\DBAL\ParameterType::INTEGER;
+            $types['t'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        }
+        if ($client !== null && $client !== '' && $this->hasScrobbleClient()) {
+            $sql .= ' AND s.client = :client';
+            $params['client'] = $client;
+        }
+        $sql .= ' GROUP BY mf.album, COALESCE(NULLIF(mf.album_artist, ""), mf.artist)
+                  ORDER BY plays DESC, album ASC LIMIT :lim';
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r) => [
+            'album' => (string) $r['album'],
+            'album_artist' => (string) $r['album_artist'],
+            'plays' => (int) $r['plays'],
+            'track_count' => (int) $r['track_count'],
+            'sample_track_id' => (string) ($r['sample_track_id'] ?? ''),
+        ], $rows);
+    }
+
+    /**
+     * Plays per month over the last $monthsBack months. Optionally filtered
+     * to a single artist. Months without scrobbles are returned with plays=0.
+     *
+     * @return list<array{month: string, plays: int}>
+     */
+    public function getPlaysByMonth(int $monthsBack, ?string $artist = null): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $from = $now->modify('first day of this month')->setTime(0, 0)
+            ->modify(sprintf('-%d months', max(0, $monthsBack - 1)));
+
+        $sql = "SELECT strftime('%Y-%m', s.submission_time, 'unixepoch') AS month, COUNT(*) AS plays
+                FROM scrobbles s
+                JOIN media_file mf ON mf.id = s.media_file_id
+                WHERE s.user_id = :uid
+                  AND s.submission_time >= :from";
+        $params = ['uid' => $userId, 'from' => $from->getTimestamp()];
+        $types = ['from' => \Doctrine\DBAL\ParameterType::INTEGER];
+        if ($artist !== null && $artist !== '') {
+            $sql .= ' AND mf.artist = :artist';
+            $params['artist'] = $artist;
+        }
+        $sql .= ' GROUP BY month ORDER BY month ASC';
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+        $byMonth = [];
+        foreach ($rows as $r) {
+            $byMonth[(string) $r['month']] = (int) $r['plays'];
+        }
+
+        // Fill missing months with zero plays so the chart has a continuous axis.
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $monthsBack; $i++) {
+            $key = $cursor->format('Y-m');
+            $out[] = ['month' => $key, 'plays' => $byMonth[$key] ?? 0];
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Set of normalized artist names already present in `media_file`.
+     * Returned as `[normalized => true]` for O(1) « do we already own X? »
+     * lookups (used by the discover suggestions). Uses the same
+     * `np_normalize` UDF as `findArtistIdByName` so the keys match what
+     * external matchers produce client-side.
+     *
+     * @return array<string, true>
+     */
+    public function getKnownArtistsNormalized(): array
+    {
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT np_normalize(artist) AS norm FROM media_file WHERE artist != ''",
+        );
+
+        $out = [];
+        foreach ($rows as $r) {
+            $key = (string) $r['norm'];
+            if ($key !== '') {
+                $out[$key] = true;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Albums with no MusicBrainz album id, ranked by lifetime plays.
+     * Plays count is taken from `scrobbles` when available (lifetime),
+     * falls back to `annotation.play_count` otherwise. Returns [] when
+     * the `mbz_album_id` column doesn't exist (very old Navidrome).
+     *
+     * @return list<array{album: string, album_artist: string, tracks: int, plays: int}>
+     */
+    public function getIncompleteAlbums(int $limit = 200): array
+    {
+        $columns = $this->mediaFileColumns();
+        if (!in_array('mbz_album_id', $columns, true)) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+
+        if ($this->hasScrobblesTable()) {
+            $sql = "SELECT mf.album AS album,
+                           mf.album_artist AS album_artist,
+                           COUNT(DISTINCT mf.id) AS tracks,
+                           COUNT(s.id) AS plays
+                    FROM media_file mf
+                    LEFT JOIN scrobbles s ON s.media_file_id = mf.id AND s.user_id = :uid
+                    WHERE (mf.mbz_album_id IS NULL OR mf.mbz_album_id = '')
+                      AND mf.album != ''
+                    GROUP BY mf.album, mf.album_artist
+                    ORDER BY plays DESC, tracks DESC, album_artist ASC, album ASC
+                    LIMIT :lim";
+        } else {
+            $sql = "SELECT mf.album AS album,
+                           mf.album_artist AS album_artist,
+                           COUNT(DISTINCT mf.id) AS tracks,
+                           COALESCE(SUM(a.play_count), 0) AS plays
+                    FROM media_file mf
+                    LEFT JOIN annotation a ON a.item_id = mf.id
+                                          AND a.item_type = 'media_file'
+                                          AND a.user_id = :uid
+                    WHERE (mf.mbz_album_id IS NULL OR mf.mbz_album_id = '')
+                      AND mf.album != ''
+                    GROUP BY mf.album, mf.album_artist
+                    ORDER BY plays DESC, tracks DESC, album_artist ASC, album ASC
+                    LIMIT :lim";
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): array => [
+            'album' => (string) $r['album'],
+            'album_artist' => (string) $r['album_artist'],
+            'tracks' => (int) $r['tracks'],
+            'plays' => (int) $r['plays'],
+        ], $rows);
+    }
+
+    /**
+     * Artists with high lifetime plays that haven't been played in the
+     * last $idleMonths months. Sorted by `plays * idle_seconds` desc
+     * (so heavy listening + long silence ranks first). Returns at most
+     * $limit rows. Empty array when scrobbles is missing — annotation
+     * fallback would be unreliable here (no MAX(play_date) per artist).
+     *
+     * @return list<array{artist: string, plays: int, last_played_at: \DateTimeImmutable, idle_days: int}>
+     */
+    public function getForgottenArtists(int $minPlays = 50, int $idleMonths = 12, int $limit = 200): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $idleThreshold = $now->modify(sprintf('-%d months', $idleMonths))->getTimestamp();
+        $nowTs = $now->getTimestamp();
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT mf.artist AS artist,
+                    COUNT(*) AS plays,
+                    MAX(s.submission_time) AS last_play
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND mf.artist != ''
+             GROUP BY mf.artist
+             HAVING plays >= :min_plays AND last_play < :idle_threshold
+             ORDER BY plays * (:now_ts - last_play) DESC
+             LIMIT :lim",
+            [
+                'uid' => $userId,
+                'min_plays' => $minPlays,
+                'idle_threshold' => $idleThreshold,
+                'now_ts' => $nowTs,
+                'lim' => $limit,
+            ],
+            [
+                'min_plays' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'idle_threshold' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'now_ts' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+
+        $tz = new \DateTimeZone(date_default_timezone_get());
+
+        return array_map(static function (array $r) use ($tz, $nowTs): array {
+            $lastPlay = (int) $r['last_play'];
+
+            return [
+                'artist' => (string) $r['artist'],
+                'plays' => (int) $r['plays'],
+                'last_played_at' => (new \DateTimeImmutable('@' . $lastPlay))->setTimezone($tz),
+                'idle_days' => (int) floor(($nowTs - $lastPlay) / 86400),
+            ];
+        }, $rows);
+    }
+
+    /**
+     * Plays + distinct artists per month over the last $monthsBack months.
+     * Months without scrobbles return plays=0, uniques=0.
+     *
+     * @return list<array{month: string, plays: int, uniques: int}>
+     */
+    public function getDiversityByMonth(int $monthsBack): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $from = $now->modify('first day of this month')->setTime(0, 0)
+            ->modify(sprintf('-%d months', max(0, $monthsBack - 1)));
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT strftime('%Y-%m', s.submission_time, 'unixepoch') AS month,
+                    COUNT(*) AS plays,
+                    COUNT(DISTINCT mf.artist) AS uniques
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND s.submission_time >= :from AND mf.artist != ''
+             GROUP BY month
+             ORDER BY month ASC",
+            ['uid' => $userId, 'from' => $from->getTimestamp()],
+            ['from' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+        $byMonth = [];
+        foreach ($rows as $r) {
+            $byMonth[(string) $r['month']] = [
+                'plays' => (int) $r['plays'],
+                'uniques' => (int) $r['uniques'],
+            ];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $monthsBack; $i++) {
+            $key = $cursor->format('Y-m');
+            $out[] = [
+                'month' => $key,
+                'plays' => $byMonth[$key]['plays'] ?? 0,
+                'uniques' => $byMonth[$key]['uniques'] ?? 0,
+            ];
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Top $topN artists by total plays over the last $monthsBack months,
+     * with a per-month timeseries for each.
+     *
+     * @return list<array{artist: string, artist_id: ?string, total: int, series: list<array{month: string, plays: int}>}>
+     */
+    public function getTopArtistsTimeline(int $monthsBack, int $topN): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $now = new \DateTimeImmutable();
+        $from = $now->modify('first day of this month')->setTime(0, 0)
+            ->modify(sprintf('-%d months', max(0, $monthsBack - 1)));
+
+        // Top artists in window. MAX(artist_id) picks one stable id when
+        // the same artist name maps to multiple media_file.artist_id rows
+        // (rare). Used by the cover proxy to fetch the artist photo.
+        $topRows = $this->connection()->fetchAllAssociative(
+            "SELECT mf.artist AS artist, MAX(mf.artist_id) AS artist_id, COUNT(*) AS plays
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND s.submission_time >= :from AND mf.artist != ''
+             GROUP BY mf.artist
+             ORDER BY plays DESC
+             LIMIT :lim",
+            ['uid' => $userId, 'from' => $from->getTimestamp(), 'lim' => $topN],
+            [
+                'from' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+        if ($topRows === []) {
+            return [];
+        }
+        $topArtists = array_map(static fn (array $r) => (string) $r['artist'], $topRows);
+
+        // Per-(artist, month) plays in a single query
+        $placeholders = implode(',', array_fill(0, count($topArtists), '?'));
+        $sql = sprintf(
+            "SELECT mf.artist AS artist, strftime('%%Y-%%m', s.submission_time, 'unixepoch') AS month, COUNT(*) AS plays
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = ? AND s.submission_time >= ? AND mf.artist IN (%s)
+             GROUP BY mf.artist, month",
+            $placeholders,
+        );
+        $byArtistMonth = [];
+        foreach (
+            $this->connection()->fetchAllAssociative(
+                $sql,
+                array_merge([$userId, $from->getTimestamp()], $topArtists),
+            ) as $r
+        ) {
+            $byArtistMonth[(string) $r['artist']][(string) $r['month']] = (int) $r['plays'];
+        }
+
+        $months = [];
+        $cursor = $from;
+        for ($i = 0; $i < $monthsBack; $i++) {
+            $months[] = $cursor->format('Y-m');
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        $out = [];
+        foreach ($topRows as $top) {
+            $artist = (string) $top['artist'];
+            $artistId = isset($top['artist_id']) && $top['artist_id'] !== '' ? (string) $top['artist_id'] : null;
+            $series = [];
+            foreach ($months as $m) {
+                $series[] = ['month' => $m, 'plays' => $byArtistMonth[$artist][$m] ?? 0];
+            }
+            $out[] = ['artist' => $artist, 'artist_id' => $artistId, 'total' => (int) $top['plays'], 'series' => $series];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Heatmap matrix [day-of-week 0..6][hour 0..23] = plays count.
+     * Returns a fully-filled 7x24 matrix (zeros included).
+     *
+     * @return array<int, array<int, int>>
+     */
+    public function getHeatmapDayHour(?\DateTimeInterface $from, ?\DateTimeInterface $to): array
+    {
+        $matrix = [];
+        for ($d = 0; $d < 7; $d++) {
+            $matrix[$d] = array_fill(0, 24, 0);
+        }
+        if (!$this->hasScrobblesTable()) {
+            return $matrix;
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = "SELECT CAST(strftime('%w', submission_time, 'unixepoch') AS INTEGER) AS dow,
+                       CAST(strftime('%H', submission_time, 'unixepoch') AS INTEGER) AS hour,
+                       COUNT(*) AS plays
+                FROM scrobbles
+                WHERE user_id = :uid";
+        $params = ['uid' => $userId];
+        $types = [];
+        if ($from !== null) {
+            $sql .= ' AND submission_time >= :from';
+            $params['from'] = $from->getTimestamp();
+            $types['from'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        }
+        if ($to !== null) {
+            $sql .= ' AND submission_time < :to';
+            $params['to'] = $to->getTimestamp();
+            $types['to'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        }
+        $sql .= ' GROUP BY dow, hour';
+
+        foreach ($this->connection()->fetchAllAssociative($sql, $params, $types) as $r) {
+            $matrix[(int) $r['dow']][(int) $r['hour']] = (int) $r['plays'];
+        }
+
+        return $matrix;
+    }
+
+    /**
+     * Plays per day for the given calendar year. Days without scrobbles
+     * return 0. Keys are 'Y-m-d' strings.
+     *
+     * @return array<string, int>
+     */
+    public function getDailyPlays(int $year): array
+    {
+        $start = new \DateTimeImmutable(sprintf('%04d-01-01 00:00:00', $year));
+        $end = new \DateTimeImmutable(sprintf('%04d-01-01 00:00:00', $year + 1));
+
+        $out = [];
+        $cursor = $start;
+        while ($cursor < $end) {
+            $out[$cursor->format('Y-m-d')] = 0;
+            $cursor = $cursor->modify('+1 day');
+        }
+
+        if (!$this->hasScrobblesTable()) {
+            return $out;
+        }
+
+        $userId = $this->resolveUserId();
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT date(submission_time, 'unixepoch') AS d, COUNT(*) AS plays
+             FROM scrobbles
+             WHERE user_id = :uid AND submission_time >= :from AND submission_time < :to
+             GROUP BY d",
+            [
+                'uid' => $userId,
+                'from' => $start->getTimestamp(),
+                'to' => $end->getTimestamp(),
+            ],
+            [
+                'from' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'to' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+        foreach ($rows as $r) {
+            $key = (string) $r['d'];
+            if (isset($out[$key])) {
+                $out[$key] = (int) $r['plays'];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Artists whose first-ever scrobble for this user falls in $year.
+     *
+     * @return list<array{artist: string, first_play: string}>
+     */
+    public function getNewArtists(int $year, int $limit = 100): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT mf.artist AS artist, datetime(MIN(s.submission_time), 'unixepoch') AS first_play
+             FROM scrobbles s
+             JOIN media_file mf ON mf.id = s.media_file_id
+             WHERE s.user_id = :uid AND mf.artist != ''
+             GROUP BY mf.artist
+             HAVING strftime('%Y', MIN(s.submission_time), 'unixepoch') = :year
+             ORDER BY MIN(s.submission_time) ASC
+             LIMIT :lim",
+            ['uid' => $userId, 'year' => (string) $year, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(
+            static fn (array $r) => ['artist' => (string) $r['artist'], 'first_play' => (string) $r['first_play']],
+            $rows,
+        );
+    }
+
+    /**
+     * Longest run of consecutive days with at least one scrobble in $year.
+     */
+    public function getLongestListeningStreak(int $year): int
+    {
+        $daily = $this->getDailyPlays($year);
+        $best = 0;
+        $current = 0;
+        foreach ($daily as $plays) {
+            if ($plays > 0) {
+                $current++;
+                $best = max($best, $current);
+            } else {
+                $current = 0;
+            }
+        }
+
+        return $best;
+    }
+
+    /**
+     * Most active month (by plays) of $year.
+     *
+     * @return array{month: string, plays: int}|null
+     */
+    public function getMostActiveMonth(int $year): ?array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return null;
+        }
+
+        $userId = $this->resolveUserId();
+        $row = $this->connection()->fetchAssociative(
+            "SELECT strftime('%Y-%m', submission_time, 'unixepoch') AS month, COUNT(*) AS plays
+             FROM scrobbles
+             WHERE user_id = :uid
+               AND strftime('%Y', submission_time, 'unixepoch') = :year
+             GROUP BY month
+             ORDER BY plays DESC, month DESC
+             LIMIT 1",
+            ['uid' => $userId, 'year' => (string) $year],
+        );
+        if ($row === false) {
+            return null;
+        }
+
+        return ['month' => (string) $row['month'], 'plays' => (int) $row['plays']];
+    }
+
+    /**
+     * Tracks the user once loved (play_count >= $minPlays) but hasn't
+     * listened to in a while (last play strictly before $cutoff). Sorted
+     * by play_count DESC, then by play_date ASC (oldest forgotten first).
+     *
+     * @return string[] media_file ids
+     */
+    public function getSongsLovedAndForgotten(int $minPlays, \DateTimeInterface $cutoff, int $limit): array
+    {
+        $userId = $this->resolveUserId();
+        $sql = "SELECT a.item_id AS id
+                FROM annotation a
+                JOIN media_file mf ON mf.id = a.item_id
+                WHERE a.item_type = 'media_file'
+                  AND a.user_id = :uid
+                  AND a.play_count >= :min
+                  AND a.play_date IS NOT NULL
+                  AND a.play_date < :cutoff
+                ORDER BY a.play_count DESC, a.play_date ASC
+                LIMIT :lim";
+
+        $rows = $this->connection()->fetchAllAssociative($sql, [
+            'uid' => $userId,
+            'min' => $minPlays,
+            'cutoff' => $cutoff->format('Y-m-d H:i:s'),
+            'lim' => $limit,
+        ], [
+            'min' => \Doctrine\DBAL\ParameterType::INTEGER,
+            'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return array_map(static fn (array $r) => (string) $r['id'], $rows);
+    }
+
+    /**
+     * Resolve a list of media_file ids to TrackSummary[], preserving order.
+     *
+     * When $from/$to are provided AND the scrobbles table exists, the
+     * `plays` field counts the scrobbles for each track inside [from, to)
+     * (the same window the playlist generator operates on). Otherwise it
+     * falls back to the lifetime annotation.play_count.
+     *
+     * @param string[] $ids
+     *
+     * @return TrackSummary[]
+     */
+    public function summarize(array $ids, ?\DateTimeInterface $from = null, ?\DateTimeInterface $to = null): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $useWindow = $from !== null && $to !== null && $this->hasScrobblesTable();
+
+        if ($useWindow) {
+            $sql = sprintf(
+                'SELECT mf.id, mf.title, mf.artist, mf.album, mf.duration,
+                        COALESCE((SELECT COUNT(*) FROM scrobbles s
+                                  WHERE s.media_file_id = mf.id
+                                    AND s.user_id = ?
+                                    AND s.submission_time >= ?
+                                    AND s.submission_time <  ?), 0) AS plays
+                 FROM media_file mf
+                 WHERE mf.id IN (%s)',
+                $placeholders,
+            );
+            $rows = $this->connection()->fetchAllAssociative(
+                $sql,
+                array_merge([$userId, $from->getTimestamp(), $to->getTimestamp()], $ids),
+                [
+                    1 => \Doctrine\DBAL\ParameterType::INTEGER,
+                    2 => \Doctrine\DBAL\ParameterType::INTEGER,
+                ],
+            );
+        } else {
+            $sql = sprintf(
+                'SELECT mf.id, mf.title, mf.artist, mf.album, mf.duration,
+                        COALESCE(a.play_count, 0) AS plays
+                 FROM media_file mf
+                 LEFT JOIN annotation a
+                   ON a.item_id = mf.id AND a.item_type=\'media_file\' AND a.user_id = ?
+                 WHERE mf.id IN (%s)',
+                $placeholders,
+            );
+            $rows = $this->connection()->fetchAllAssociative($sql, array_merge([$userId], $ids));
+        }
+        $byId = [];
+        foreach ($rows as $r) {
+            $byId[(string) $r['id']] = new TrackSummary(
+                id: (string) $r['id'],
+                title: (string) ($r['title'] ?? ''),
+                artist: (string) ($r['artist'] ?? ''),
+                album: (string) ($r['album'] ?? ''),
+                duration: (int) ($r['duration'] ?? 0),
+                plays: (int) ($r['plays'] ?? 0),
+            );
+        }
+
+        $out = [];
+        foreach ($ids as $id) {
+            if (isset($byId[$id])) {
+                $out[] = $byId[$id];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Given a list of media_file ids, return those that no longer exist
+     * in the Navidrome library (file was removed/moved/renamed). Useful
+     * for detecting « dead » entries inside a Subsonic playlist.
+     *
+     * @param string[] $ids
+     *
+     * @return string[] subset of $ids, preserving original order
+     */
+    public function filterMissingMediaFileIds(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $rows = $this->connection()->fetchAllAssociative(
+            sprintf('SELECT id FROM media_file WHERE id IN (%s)', $placeholders),
+            $ids,
+        );
+
+        $existing = [];
+        foreach ($rows as $r) {
+            $existing[(string) $r['id']] = true;
+        }
+
+        $missing = [];
+        foreach ($ids as $id) {
+            if (!isset($existing[$id])) {
+                $missing[] = $id;
+            }
+        }
+
+        return $missing;
+    }
+
+    /**
+     * Per-id metadata needed for playlist stats (year + album + artist).
+     * Returned in the same order as input ids; missing rows are silently
+     * dropped (use {@see filterMissingMediaFileIds()} to surface them).
+     *
+     * @param string[] $ids
+     *
+     * @return array<int, array{id: string, artist: string, album: string, year: ?int, duration: int}>
+     */
+    public function getMediaFileMetadata(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+        $rows = $this->connection()->fetchAllAssociative(
+            sprintf(
+                'SELECT id, artist, album, year, duration FROM media_file WHERE id IN (%s)',
+                $placeholders,
+            ),
+            $ids,
+        );
+
+        $byId = [];
+        foreach ($rows as $r) {
+            $byId[(string) $r['id']] = [
+                'id' => (string) $r['id'],
+                'artist' => (string) ($r['artist'] ?? ''),
+                'album' => (string) ($r['album'] ?? ''),
+                'year' => isset($r['year']) ? (int) $r['year'] : null,
+                'duration' => (int) ($r['duration'] ?? 0),
+            ];
+        }
+
+        $out = [];
+        foreach ($ids as $id) {
+            if (isset($byId[$id])) {
+                $out[] = $byId[$id];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Find an artist id by name. Prefers the dedicated `artist` table when
+     * present (Navidrome >= 0.50), falls back on a DISTINCT lookup over
+     * media_file. Case- and whitespace-insensitive. Returns null when no
+     * match or when more than one artist matches.
+     */
+    public function findArtistIdByName(string $name): ?string
+    {
+        $name = self::normalize($name);
+        if ($name === '') {
+            return null;
+        }
+
+        $tables = $this->connection()->fetchAllAssociative(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='artist'",
+        );
+        if ($tables !== []) {
+            $rows = $this->connection()->fetchAllAssociative(
+                'SELECT id FROM artist WHERE np_normalize(name) = :n LIMIT 2',
+                ['n' => $name],
+            );
+            if (count($rows) === 1) {
+                return (string) $rows[0]['id'];
+            }
+            if (count($rows) > 1) {
+                return null;
+            }
+            // 0 row in artist table → fall through to media_file lookup.
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT artist_id FROM media_file
+             WHERE np_normalize(artist) = :n AND artist_id != '' LIMIT 2",
+            ['n' => $name],
+        );
+        if (count($rows) === 1) {
+            return (string) $rows[0]['artist_id'];
+        }
+
+        return null;
+    }
+
+    /**
+     * Find a media_file by MusicBrainz id (mbz_track_id, recording id, or fallback).
+     * Returns null if no match.
+     */
+    public function findMediaFileByMbid(string $mbid): ?string
+    {
+        if ($mbid === '') {
+            return null;
+        }
+
+        // Navidrome's media_file may have either 'mbz_track_id' or
+        // 'mbz_recording_id' depending on version. We probe both.
+        $columns = $this->mediaFileColumns();
+        $candidates = array_values(array_filter(
+            ['mbz_track_id', 'mbz_recording_id'],
+            static fn (string $c) => in_array($c, $columns, true),
+        ));
+        if ($candidates === []) {
+            return null;
+        }
+
+        $where = implode(' OR ', array_map(static fn (string $c) => "$c = :mbid", $candidates));
+        $sql = sprintf('SELECT id FROM media_file WHERE %s LIMIT 1', $where);
+
+        $id = $this->connection()->fetchOne($sql, ['mbid' => $mbid]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * List media_files where every MBID column known to this Navidrome version
+     * is either NULL or empty — i.e. tracks that the Last.fm matcher cannot
+     * resolve via the most reliable path. Used by the /tagging/missing-mbid
+     * audit page and by `app:beets:tag-missing` to feed beets a worklist.
+     *
+     * Filters and pagination:
+     *   - $artistFilter / $albumFilter: case-insensitive substring (LIKE
+     *     %term%) on artist / album. Empty / null = no filter.
+     *   - $limit: max rows returned. Bound to [1, 1000].
+     *   - $offset: SQL offset for pagination.
+     *
+     * Returned shape exposes the optional `path` column when Navidrome stores
+     * it (every modern version does), so callers can hand the absolute file
+     * paths to an external tagger like beets.
+     *
+     * @return list<array{
+     *     id: string,
+     *     path: string,
+     *     artist: string,
+     *     album_artist: string,
+     *     album: string,
+     *     title: string,
+     *     year: int
+     * }>
+     */
+    public function findMediaFilesWithoutMbid(
+        ?string $artistFilter = null,
+        ?string $albumFilter = null,
+        int $limit = 100,
+        int $offset = 0,
+    ): array {
+        $where = $this->missingMbidWhereClause();
+        if ($where === null) {
+            return [];
+        }
+
+        $columns = $this->mediaFileColumns();
+        $hasPath = in_array('path', $columns, true);
+        $select = sprintf(
+            'id, %s AS path, artist, album_artist, album, title, year',
+            $hasPath ? 'path' : "''",
+        );
+
+        $params = [];
+        $types = [];
+        $clauses = [$where];
+        if ($artistFilter !== null && trim($artistFilter) !== '') {
+            $clauses[] = 'LOWER(artist) LIKE :artist';
+            $params['artist'] = '%' . strtolower(trim($artistFilter)) . '%';
+        }
+        if ($albumFilter !== null && trim($albumFilter) !== '') {
+            $clauses[] = 'LOWER(album) LIKE :album';
+            $params['album'] = '%' . strtolower(trim($albumFilter)) . '%';
+        }
+
+        $limit = max(1, min(1000, $limit));
+        $offset = max(0, $offset);
+        $params['lim'] = $limit;
+        $params['off'] = $offset;
+        $types['lim'] = \Doctrine\DBAL\ParameterType::INTEGER;
+        $types['off'] = \Doctrine\DBAL\ParameterType::INTEGER;
+
+        $sql = sprintf(
+            'SELECT %s FROM media_file WHERE %s ORDER BY artist, album, title LIMIT :lim OFFSET :off',
+            $select,
+            implode(' AND ', $clauses),
+        );
+
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(static fn (array $r): array => [
+            'id' => (string) $r['id'],
+            'path' => (string) ($r['path'] ?? ''),
+            'artist' => (string) ($r['artist'] ?? ''),
+            'album_artist' => (string) ($r['album_artist'] ?? ''),
+            'album' => (string) ($r['album'] ?? ''),
+            'title' => (string) ($r['title'] ?? ''),
+            'year' => (int) ($r['year'] ?? 0),
+        ], $rows);
+    }
+
+    /**
+     * Counts every media_file row whose MBID columns are all NULL or empty.
+     * Same filter semantics as {@see findMediaFilesWithoutMbid()}; used by
+     * the dashboard card and by paginated UIs.
+     */
+    public function countMediaFilesWithoutMbid(
+        ?string $artistFilter = null,
+        ?string $albumFilter = null,
+    ): int {
+        $where = $this->missingMbidWhereClause();
+        if ($where === null) {
+            return 0;
+        }
+
+        $params = [];
+        $clauses = [$where];
+        if ($artistFilter !== null && trim($artistFilter) !== '') {
+            $clauses[] = 'LOWER(artist) LIKE :artist';
+            $params['artist'] = '%' . strtolower(trim($artistFilter)) . '%';
+        }
+        if ($albumFilter !== null && trim($albumFilter) !== '') {
+            $clauses[] = 'LOWER(album) LIKE :album';
+            $params['album'] = '%' . strtolower(trim($albumFilter)) . '%';
+        }
+
+        $sql = sprintf('SELECT COUNT(*) FROM media_file WHERE %s', implode(' AND ', $clauses));
+
+        return (int) $this->connection()->fetchOne($sql, $params);
+    }
+
+    /**
+     * Build a WHERE fragment matching rows where every MBID column known to
+     * this Navidrome version is NULL or ''. Returns null when none of the
+     * MBID columns exist (e.g. a stub fixture without MBID columns) — caller
+     * should treat that as « nothing to do ».
+     */
+    private function missingMbidWhereClause(): ?string
+    {
+        $columns = $this->mediaFileColumns();
+        $candidates = array_values(array_filter(
+            ['mbz_track_id', 'mbz_recording_id'],
+            static fn (string $c) => in_array($c, $columns, true),
+        ));
+        if ($candidates === []) {
+            return null;
+        }
+
+        return implode(' AND ', array_map(
+            static fn (string $c) => sprintf("(%s IS NULL OR %s = '')", $c, $c),
+            $candidates,
+        ));
+    }
+
+    /**
+     * Find a media_file by normalised (artist, title) pair. Case- and whitespace-
+     * insensitive. Returns null when there is no match. When several rows share
+     * the same (artist, title) — e.g. the same song shipped on a studio album
+     * and a compilation — picks one deterministically: prefer the row where
+     * `album_artist = artist` (canonical studio release over a tribute /
+     * various-artists compilation), tie-broken by `id` ASC for stability across
+     * import runs.
+     *
+     * Lookup strategy when the strict match fails:
+     *   1. retry with the lead artist (drop "feat. …" suffix on the artist) ;
+     *   2. retry with the bare title (drop "(Radio Edit)" / "- Remastered 2011"
+     *      and similar version markers from the title) ;
+     *   3. retry with both strips combined.
+     * Last.fm tends to credit "Orelsan feat. Thomas Bangalter" or label tracks
+     * "Bicycle Race - Remastered 2011" while Navidrome stores the bare form.
+     */
+    /**
+     * Last-resort fuzzy match by Levenshtein distance on (artist, title).
+     * Pulls candidate rows whose normalized artist or title shares the same
+     * 3-char prefix to avoid scanning the whole library, then picks the row
+     * with the smallest combined edit distance under $maxDistance.
+     *
+     * Off when $maxDistance <= 0 (returns null without querying). Returns
+     * null when no candidate is within range.
+     */
+    public function findMediaFileFuzzy(string $artist, string $title, int $maxDistance): ?string
+    {
+        if ($maxDistance <= 0) {
+            return null;
+        }
+
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        // PHP's levenshtein() is capped at 255 chars; bail out on longer
+        // strings rather than crash. (Real-world artist/title rarely exceed
+        // 100 chars; this is a safety net.)
+        if ($artistN === '' || $titleN === '' || strlen($artistN) > 255 || strlen($titleN) > 255) {
+            return null;
+        }
+
+        $artistPrefix = mb_substr($artistN, 0, 3);
+        $titlePrefix = mb_substr($titleN, 0, 3);
+        if ($artistPrefix === '' && $titlePrefix === '') {
+            return null;
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT id, artist, title FROM media_file
+             WHERE substr(np_normalize(artist), 1, 3) = :ap
+                OR substr(np_normalize(title), 1, 3) = :tp',
+            ['ap' => $artistPrefix, 'tp' => $titlePrefix],
+        );
+
+        $bestId = null;
+        $bestScore = PHP_INT_MAX;
+        foreach ($rows as $row) {
+            $candArtist = self::normalize((string) ($row['artist'] ?? ''));
+            $candTitle = self::normalize((string) ($row['title'] ?? ''));
+            if (
+                $candArtist === '' || $candTitle === ''
+                || strlen($candArtist) > 255 || strlen($candTitle) > 255
+            ) {
+                continue;
+            }
+            $score = levenshtein($candArtist, $artistN) + levenshtein($candTitle, $titleN);
+            if ($score <= $maxDistance && $score < $bestScore) {
+                $bestId = (string) $row['id'];
+                $bestScore = $score;
+            }
+        }
+
+        return $bestId;
+    }
+
+    /**
+     * Disambiguate a (artist, title) lookup with the album. Used as a
+     * tighter pre-step to {@see findMediaFileByArtistTitle()} when the
+     * scrobble carries a non-empty album: the same song can be present on
+     * the studio album, a single, a compilation and a live release —
+     * matching the album resolves which row the user actually played
+     * instead of falling back to the deterministic but arbitrary tie-break.
+     *
+     * Strict semantics: returns the id only when *exactly one* row matches
+     * the normalized triplet. Returns null on zero match (caller falls back
+     * to the couple lookup) or on >1 match (still ambiguous).
+     */
+    public function findMediaFileByArtistTitleAlbum(string $artist, string $title, string $album): ?string
+    {
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        $albumN = self::normalize($album);
+        if ($artistN === '' || $titleN === '' || $albumN === '') {
+            return null;
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT id FROM media_file
+             WHERE np_normalize(artist) = :a
+               AND np_normalize(title) = :t
+               AND np_normalize(album) = :al
+             LIMIT 2',
+            ['a' => $artistN, 't' => $titleN, 'al' => $albumN],
+        );
+
+        if (count($rows) !== 1) {
+            return null;
+        }
+
+        return (string) $rows[0]['id'];
+    }
+
+    public function findMediaFileByArtistTitle(string $artist, string $title): ?string
+    {
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        if ($artistN === '' || $titleN === '') {
+            return null;
+        }
+
+        $id = $this->lookupExactArtistTitle($artistN, $titleN);
+        if ($id !== null) {
+            return $id;
+        }
+
+        // Strip decorations on the ORIGINAL inputs — the regexes rely on
+        // delimiters (parens, dashes, dots in "feat.") that self::normalize()
+        // now strips out. Re-normalize the stripped form before lookup.
+        $leadArtistN = self::normalize(self::stripFeaturedArtists($artist));
+        $bareTitle = self::stripVersionMarkers(self::stripFeaturingFromTitle(
+            self::stripTruncatedParen(self::stripTrackNumberPrefix($title)),
+        ));
+        $bareTitleN = self::normalize($bareTitle);
+        $artistChanged = $leadArtistN !== '' && $leadArtistN !== $artistN;
+        $titleChanged = $bareTitleN !== '' && $bareTitleN !== $titleN;
+        $titleHadFeaturing = self::titleHasFeaturingMarker($title);
+
+        if ($artistChanged) {
+            $id = $this->lookupExactArtistTitle($leadArtistN, $titleN);
+            if ($id !== null) {
+                return $id;
+            }
+        }
+        if ($titleChanged) {
+            $id = $this->lookupExactArtistTitle($artistN, $bareTitleN);
+            if ($id !== null) {
+                return $id;
+            }
+
+            // Asymmetric featuring : Last.fm packs "(feat. X)" in the title,
+            // Navidrome packs it in the artist column ("Jurassic 5 feat.
+            // Roots Manuva / Join the Dots"). Strict match on bareTitle
+            // failed because the artist column has a longer string. Try a
+            // prefix-based artist lookup, gated on the explicit featuring
+            // marker in the original title to keep the false-positive rate
+            // tight.
+            if ($titleHadFeaturing) {
+                $id = $this->lookupArtistPrefixFeaturingTitle($artistN, $bareTitleN);
+                if ($id !== null) {
+                    return $id;
+                }
+            }
+        }
+        if ($artistChanged && $titleChanged) {
+            $id = $this->lookupExactArtistTitle($leadArtistN, $bareTitleN);
+            if ($id !== null) {
+                return $id;
+            }
+        }
+
+        // Last-resort: split lead artist on multi-artist separators
+        // ("&", " - ", " and ", " et ", ","). Conservative: only on the
+        // strict (artist, title) couple AND require album_artist to match
+        // the stripped artist for confidence.
+        $leadOnlyN = self::normalize(self::stripLeadArtist($artist));
+        if ($leadOnlyN !== '' && $leadOnlyN !== $artistN && $leadOnlyN !== $leadArtistN) {
+            return $this->lookupExactArtistTitleRequiringAlbumArtist($leadOnlyN, $titleN);
+        }
+
+        return null;
+    }
+
+    private function lookupExactArtistTitle(string $artistNormalized, string $titleNormalized): ?string
+    {
+        $sql = 'SELECT id FROM media_file
+                WHERE np_normalize(artist) = :a
+                  AND np_normalize(title) = :t
+                ORDER BY (np_normalize(album_artist) = :a) DESC, id ASC
+                LIMIT 1';
+        $id = $this->connection()->fetchOne($sql, ['a' => $artistNormalized, 't' => $titleNormalized]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * Refined lookup for the asymmetric-featuring case: title strict on
+     * the bare (already feat-stripped) form, artist matched as a prefix
+     * followed by a recognised featuring marker. Catches the convention
+     * where Last.fm puts "(feat. X)" in the title while Navidrome puts
+     * it in the artist column. Gated by {@see titleHasFeaturingMarker()}
+     * in the cascade caller to avoid false-positives on plain titles.
+     *
+     * Marker list mirrors {@see stripFeaturingFromTitle()}: feat / ft /
+     * featuring / with — already lower-cased and dot-stripped by
+     * np_normalize() on the candidate side, hence the simple `LIKE
+     * ':a feat %'` form below.
+     */
+    private function lookupArtistPrefixFeaturingTitle(string $artistNormalized, string $titleNormalized): ?string
+    {
+        if ($artistNormalized === '' || $titleNormalized === '') {
+            return null;
+        }
+
+        $sql = 'SELECT id FROM media_file
+                WHERE np_normalize(title) = :t
+                  AND (
+                      np_normalize(artist) LIKE :feat
+                      OR np_normalize(artist) LIKE :ft
+                      OR np_normalize(artist) LIKE :featuring
+                      OR np_normalize(artist) LIKE :with
+                  )
+                ORDER BY id ASC
+                LIMIT 1';
+        $id = $this->connection()->fetchOne($sql, [
+            't' => $titleNormalized,
+            'feat' => $artistNormalized . ' feat %',
+            'ft' => $artistNormalized . ' ft %',
+            'featuring' => $artistNormalized . ' featuring %',
+            'with' => $artistNormalized . ' with %',
+        ]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * True when the (raw) title carries an explicit featuring marker —
+     * "(feat. X)" / "[ft. X]" / "(featuring X)" / "(with X)" — including
+     * truncated open-paren forms ("(Ft Roots Manuva" without trailing
+     * `)`) when the truncation comes from Last.fm's title length cap.
+     * Used as the signal to enable {@see lookupArtistPrefixFeaturingTitle()}.
+     */
+    private static function titleHasFeaturingMarker(string $title): bool
+    {
+        // Closed paren / bracket form.
+        if (preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+[^)]+\)/iu', $title)) {
+            return true;
+        }
+        if (preg_match('/\[(?:feat\.?|ft\.?|featuring|with)\s+[^\]]+\]/iu', $title)) {
+            return true;
+        }
+
+        // Truncated open paren (no closing paren in the whole title).
+        if (
+            !preg_match('/\([^)]*\)/u', $title)
+            && preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+/iu', $title)
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Strict couple lookup that ALSO requires album_artist to match.
+     * Used as a confidence threshold for risky strips (e.g. lead-artist
+     * fallback on multi-artist separators) where the relaxed tie-break
+     * of {@see lookupExactArtistTitle()} would let through false-positives.
+     */
+    private function lookupExactArtistTitleRequiringAlbumArtist(string $artistNormalized, string $titleNormalized): ?string
+    {
+        $sql = 'SELECT id FROM media_file
+                WHERE np_normalize(artist) = :a
+                  AND np_normalize(title) = :t
+                  AND np_normalize(album_artist) = :a
+                ORDER BY id ASC
+                LIMIT 1';
+        $id = $this->connection()->fetchOne($sql, ['a' => $artistNormalized, 't' => $titleNormalized]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * Drop a trailing or parenthesized featuring suffix from a (raw, not yet
+     * normalized) artist string. Recognises `feat`, `feat.`, `ft`, `ft.`,
+     * `featuring` case-insensitively. Returns the input unchanged when no
+     * marker is present. Operates on the raw input because self::normalize()
+     * strips parens/dots, which would defeat the patterns below.
+     */
+    private static function stripFeaturedArtists(string $artist): string
+    {
+        // 1. Strip parenthesized suffix: "(feat. …)" / "(ft. …)" / "(featuring …)".
+        $stripped = preg_replace('/\s*\((?:feat\.?|ft\.?|featuring)\s+[^)]*\)\s*/iu', '', $artist) ?? $artist;
+        // 2. Strip trailing form: " feat. …" / " ft. …" / " featuring …" until end.
+        $stripped = preg_replace('/\s+(?:feat\.?|ft\.?|featuring)\s+.*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a trailing version-marker / decoration suffix from a (raw, not yet
+     * normalized) title. Handles three forms — parenthesized "(Radio Edit)",
+     * bracketed "[Radio Edit]", dash-separated " - Radio Edit" (ASCII -, en
+     * dash, em dash). Strips master/packaging markers (radio/album/single/
+     * extended/mono/stereo edit/version/mix, remaster with optional year) and
+     * recording-context markers (live, acoustic, instrumental, demo, deluxe).
+     * Live/acoustic/etc. is only stripped when *delimited* — `Live and Let
+     * Die` in the title body remains intact. Remix is intentionally NOT
+     * stripped (DJ remixes are usually distinct recordings). Operates on
+     * the raw input because self::normalize() strips parens/dashes/dots
+     * which would defeat the patterns below.
+     */
+    private static function stripVersionMarkers(string $title): string
+    {
+        // Order matters: longer alternatives must come first so "remastered 2011"
+        // is captured by the year-aware pattern instead of just "remastered".
+        // Contextual markers (live/acoustic/…) accept an optional trailing
+        // qualifier so "Live at Reading 1992" / "Acoustic Version" / "Deluxe
+        // Edition" all match.
+        $markers = '(?:'
+            . 'remastered \d{4}|remaster \d{4}|\d{4} remastered|\d{4} remaster'
+            . '|radio edit|radio mix|radio version'
+            . '|album version|album mix|album edit'
+            . '|single version|single edit|single mix'
+            . '|extended version|extended mix|extended edit'
+            . '|mono version|stereo version'
+            . '|remastered|remaster'
+            . '|live(?:\s[^)\]]+)?'
+            . '|acoustic(?:\s+(?:version|mix))?'
+            . '|instrumental(?:\s+version)?'
+            . '|demo(?:\s+version)?'
+            . '|deluxe(?:\s+(?:edition|version))?'
+            . ')';
+
+        // Parenthesized form: " (Radio Edit)".
+        $stripped = preg_replace('/\s*\(' . $markers . '\)\s*$/iu', '', $title) ?? $title;
+        // Bracketed form: " [Radio Edit]".
+        $stripped = preg_replace('/\s*\[' . $markers . '\]\s*$/iu', '', $stripped) ?? $stripped;
+        // Dash-separated form: " - Radio Edit" (ASCII -, en dash, em dash).
+        $stripped = preg_replace('/\s+[\-\x{2013}\x{2014}]\s+' . $markers . '\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a parenthesized or bracketed featuring/with suffix from a title.
+     * Catches "Crazy in Love (feat. Jay-Z)", "Bad Guy (with Justin Bieber)",
+     * "Some Track [featuring X]". Only the delimited form is stripped — never
+     * a trailing " feat. X" without parens, which is too risky on titles
+     * (real titles can legitimately contain "feat" as a word). Operates on
+     * the raw input.
+     */
+    private static function stripFeaturingFromTitle(string $title): string
+    {
+        $pattern = '(?:feat\.?|ft\.?|featuring|with)\s+[^)\]]+';
+        $stripped = preg_replace('/\s*\(' . $pattern . '\)\s*$/iu', '', $title) ?? $title;
+        $stripped = preg_replace('/\s*\[' . $pattern . '\]\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a leading track-number prefix like "01 - ", "02_", "12-",
+     * "100. " from a title — vestige of old MP3 tags where the title
+     * embeds the track number. Requires a delimiter (`_`, `-`, `.`,
+     * whitespace) AND a non-blank character behind, so titles like
+     * "1979" or "5/4" (followed by end-of-string) are not eaten.
+     */
+    private static function stripTrackNumberPrefix(string $title): string
+    {
+        return trim(preg_replace('/^\d{1,3}[_\-.\s]+(?=\S)/u', '', $title) ?? $title);
+    }
+
+    /**
+     * Drop a trailing OPEN parenthesis block when its content starts
+     * with a known marker keyword — Last.fm truncates titles around 64
+     * chars and leaves unbalanced parens. Abstains if the title already
+     * contains a closed `(...)` group (could be legit). Conservative:
+     * only strips when the open-paren content begins with a recognized
+     * marker so we don't eat legit titles ending in "Foo (something".
+     */
+    private static function stripTruncatedParen(string $title): string
+    {
+        if (preg_match('/\([^)]*\)/u', $title)) {
+            return $title;
+        }
+        $markers = '(?:feat\.?|ft\.?|featuring|with|live|acoustic|remastered|remaster|deluxe|extended|radio|album|single|mono|stereo|instrumental|demo)';
+
+        return trim(preg_replace('/\s*\(' . $markers . '[^)]*$/iu', '', $title) ?? $title);
+    }
+
+    /**
+     * Drop trailing co-artists separated by `,`, ` - `, `&`, ` and `,
+     * ` et ` to keep only the lead artist (e.g. "Médine & Rounhaa" →
+     * "Médine"). Returns the input unchanged if no recognized
+     * separator is present. Used as a last-resort fallback when the
+     * regular cascade fails.
+     */
+    private static function stripLeadArtist(string $artist): string
+    {
+        if (preg_match('/^(.*?)(?:\s*,\s*|\s+-\s+|\s*&\s*|\s+(?:and|et)\s+)/iu', $artist, $m)) {
+            $lead = trim($m[1]);
+            if ($lead !== '' && $lead !== $artist) {
+                return $lead;
+            }
+        }
+
+        return $artist;
+    }
+
+    /**
+     * True if a scrobble already exists for (user, media_file) within
+     * ±$toleranceSeconds of $time.
+     */
+    public function scrobbleExistsNear(
+        string $userId,
+        string $mediaFileId,
+        \DateTimeInterface $time,
+        int $toleranceSeconds = 60,
+    ): bool {
+        if (!$this->hasScrobblesTable()) {
+            return false;
+        }
+
+        $immutable = $time instanceof \DateTimeImmutable
+            ? $time
+            : \DateTimeImmutable::createFromInterface($time);
+        $tolerance = new \DateInterval('PT' . max(0, $toleranceSeconds) . 'S');
+        $from = $immutable->sub($tolerance);
+        $to = $immutable->add($tolerance);
+
+        $sql = 'SELECT 1 FROM scrobbles
+                WHERE user_id = :uid AND media_file_id = :mfid
+                  AND submission_time >= :f AND submission_time <= :t
+                LIMIT 1';
+
+        $found = $this->connection()->fetchOne($sql, [
+            'uid' => $userId,
+            'mfid' => $mediaFileId,
+            'f' => $from->getTimestamp(),
+            't' => $to->getTimestamp(),
+        ], [
+            'f' => \Doctrine\DBAL\ParameterType::INTEGER,
+            't' => \Doctrine\DBAL\ParameterType::INTEGER,
+        ]);
+
+        return $found !== false;
+    }
+
+    /**
+     * Insert a scrobble row. Caller is responsible for dedup. Throws if the
+     * scrobbles table does not exist (Navidrome < 0.55) or if the DB is
+     * mounted read-only.
+     *
+     * Callers that insert in batch should wrap their loop in
+     * {@see beginWriteTransaction()} / {@see commitWrite()} (or
+     * {@see rollbackWrite()} on error) — autocommit per row leaves a crash
+     * mid-batch with partial writes and a half-flushed WAL.
+     */
+    public function insertScrobble(string $userId, string $mediaFileId, \DateTimeInterface $time): void
+    {
+        if (!$this->hasScrobblesTable()) {
+            throw new \RuntimeException(
+                'The Navidrome scrobbles table does not exist. Upgrade Navidrome to >= 0.55 (late 2025).',
+            );
+        }
+
+        $this->connection()->executeStatement(
+            'INSERT INTO scrobbles (user_id, media_file_id, submission_time) VALUES (?, ?, ?)',
+            [$userId, $mediaFileId, $time->getTimestamp()],
+            [2 => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+    }
+
+    /**
+     * Open a write transaction with `BEGIN IMMEDIATE` — takes the RESERVED
+     * lock right away and fails fast if another writer (Navidrome
+     * accidentally restarted by Docker auto-restart, a parallel
+     * `app:lastfm:process` somehow scheduled twice, etc.) is holding it.
+     * `Connection::beginTransaction()` would do `BEGIN DEFERRED` which only
+     * locks on the first INSERT, leaving a window for a concurrent writer.
+     */
+    public function beginWriteTransaction(): void
+    {
+        $this->connection()->executeStatement('BEGIN IMMEDIATE');
+    }
+
+    public function commitWrite(): void
+    {
+        $this->connection()->executeStatement('COMMIT');
+    }
+
+    public function rollbackWrite(): void
+    {
+        $this->connection()->executeStatement('ROLLBACK');
+    }
+
+    /**
+     * Force-merge any pending WAL frames into the main DB and truncate the
+     * WAL file. Should be called in a `finally` at the end of any batch
+     * write run, before {@see closeWriteConnection()} — otherwise SQLite may
+     * leave the WAL un-checkpointed across a restart, and Navidrome opening
+     * the DB next would have to recover an inconsistent WAL (risk of
+     * corruption).
+     *
+     * No-op when the journal mode is `DELETE` (Navidrome forces WAL by
+     * default, but be defensive). Errors are swallowed because this lives in
+     * a `finally` and the caller's post-action quick_check upstream is the
+     * authoritative integrity check.
+     */
+    public function walCheckpointTruncate(): void
+    {
+        if ($this->connection === null) {
+            return;
+        }
+        try {
+            $this->connection->executeQuery('PRAGMA wal_checkpoint(TRUNCATE)')->fetchAssociative();
+        } catch (\Throwable) {
+            // best-effort
+        }
+    }
+
+    /**
+     * Close the underlying PDO connection so the OS file lock is released
+     * and SQLite can do its own final checkpoint book-keeping. The
+     * connection lazily reconnects on the next access.
+     */
+    public function closeWriteConnection(): void
+    {
+        if ($this->connection === null) {
+            return;
+        }
+        try {
+            $this->connection->close();
+        } catch (\Throwable) {
+            // best-effort
+        }
+        $this->connection = null;
+    }
+
+    /**
+     * Lowercase, trim, strip Unicode diacritics, then strip every character
+     * that is not a letter, digit or whitespace (collapsing repeated
+     * whitespace afterwards). So "Beyoncé" matches "Beyonce", "Sigur Rós"
+     * matches "Sigur Ros", "AC/DC" matches "ACDC", "Guns N' Roses" matches
+     * "Guns N Roses", "P!nk" matches "Pink", "t.A.T.u." matches "tATu", etc.
+     *
+     * Decomposition uses NFKD (compatibility decomposition) then drops every
+     * combining mark (\p{Mn}). Also exposed to SQLite as the
+     * `np_normalize(value)` UDF so that the same transformation is applied
+     * server-side on the indexed columns — see {@see connection()}.
+     */
+    public static function normalize(string $s): string
+    {
+        $s = mb_strtolower(trim($s));
+        $decomposed = \Normalizer::normalize($s, \Normalizer::FORM_KD);
+        if ($decomposed === false) {
+            // Input was not valid UTF-8 — fall back to the lowercased form.
+            return $s;
+        }
+        $stripped = (string) preg_replace('/\p{Mn}+/u', '', $decomposed);
+        // Drop punctuation/symbols (keep letters, digits, whitespace).
+        $cleaned = (string) preg_replace('/[^\p{L}\p{N}\s]+/u', '', $stripped);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $cleaned));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function mediaFileColumns(): array
+    {
+        /** @var array<int, array{name: string}> $rows */
+        $rows = $this->connection()->fetchAllAssociative('PRAGMA table_info(media_file)');
+
+        return array_map(static fn (array $r) => (string) $r['name'], $rows);
+    }
+
+    private function connection(): Connection
+    {
+        if ($this->connection !== null) {
+            return $this->connection;
+        }
+
+        try {
+            // We rely on the Docker volume being mounted read-only (`:ro`)
+            // for safety. We do not open the DB in SQLite read-only mode
+            // because that prevents seeing concurrent writes from Navidrome
+            // on some platforms.
+            $this->connection = DriverManager::getConnection([
+                'driver' => 'pdo_sqlite',
+                'path' => $this->dbPath,
+                'driverOptions' => [
+                    \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                ],
+            ]);
+        } catch (DbalException $e) {
+            throw new \RuntimeException('Cannot open Navidrome database at ' . $this->dbPath . ': ' . $e->getMessage(), 0, $e);
+        }
+
+        // Expose self::normalize() as a SQLite scalar UDF so that artist/title
+        // columns can be matched accent- and case-insensitively without
+        // pre-computing a normalized column. Cost is one PHP callback per row
+        // scanned; acceptable for libs under ~100k tracks.
+        $native = $this->connection->getNativeConnection();
+        if ($native instanceof \PDO) {
+            $native->sqliteCreateFunction('np_normalize', [self::class, 'normalize'], 1);
+        }
+
+        // Durability + concurrency knobs:
+        //  - busy_timeout: retry-on-lock window. If Navidrome got restarted
+        //    by Docker auto-restart while we were writing, every INSERT
+        //    waits up to 30s for the lock instead of failing instantly.
+        //    Cost: zero in the happy path.
+        //  - synchronous=FULL: every COMMIT waits for fsync of both the WAL
+        //    page and the WAL header. Slower than NORMAL but absolutely
+        //    necessary on a SQLite file that another process (Navidrome)
+        //    will reopen — a power-cut / OOM-kill must not leave a torn
+        //    write that corrupts the DB. This is what Navidrome itself
+        //    runs by default, we just make sure to match it.
+        //  - We deliberately do NOT touch journal_mode: it is persistent
+        //    (stored in the DB header) and Navidrome owns that decision.
+        $this->connection->executeStatement('PRAGMA busy_timeout = 30000');
+        $this->connection->executeStatement('PRAGMA synchronous = FULL');
+
+        return $this->connection;
+    }
+}

--- a/src/Navidrome/TrackSummary.php
+++ b/src/Navidrome/TrackSummary.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Navidrome;
+
+final class TrackSummary
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $title,
+        public readonly string $artist,
+        public readonly string $album,
+        public readonly int $duration,
+        public readonly int $plays,
+    ) {
+    }
+}

--- a/src/Notifier/Driver/DiscordDriver.php
+++ b/src/Notifier/Driver/DiscordDriver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifier\Driver;
+
+use App\Notifier\Notification;
+use App\Notifier\NotifierDriverInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class DiscordDriver implements NotifierDriverInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $http,
+        private readonly string $webhookUrl,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'discord';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->webhookUrl !== '';
+    }
+
+    public function send(Notification $notification): void
+    {
+        $content = sprintf("**%s**\n```%s```", $notification->title(), $notification->summary());
+
+        // Discord caps `content` at 2000 chars — guard against very long
+        // error messages stamped into the summary.
+        if (strlen($content) > 1900) {
+            $content = substr($content, 0, 1893) . "…```";
+        }
+
+        $this->http->request('POST', $this->webhookUrl, [
+            'headers' => ['content-type' => 'application/json'],
+            'json' => ['content' => $content],
+            'timeout' => 10,
+        ])->getStatusCode();
+    }
+}

--- a/src/Notifier/Driver/GotifyDriver.php
+++ b/src/Notifier/Driver/GotifyDriver.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Notifier\Driver;
+
+use App\Notifier\Notification;
+use App\Notifier\NotifierDriverInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class GotifyDriver implements NotifierDriverInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $http,
+        private readonly string $url,
+        private readonly string $token,
+        private readonly int $priority = 5,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'gotify';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->url !== '' && $this->token !== '';
+    }
+
+    public function send(Notification $notification): void
+    {
+        $endpoint = rtrim($this->url, '/') . '/message?token=' . rawurlencode($this->token);
+
+        $this->http->request('POST', $endpoint, [
+            'headers' => ['content-type' => 'application/json'],
+            'json' => [
+                'title' => $notification->title(),
+                'message' => $notification->summary(),
+                'priority' => $notification->isError() ? max($this->priority, 8) : $this->priority,
+            ],
+            'timeout' => 10,
+        ])->getStatusCode();
+    }
+}

--- a/src/Notifier/Driver/PushoverDriver.php
+++ b/src/Notifier/Driver/PushoverDriver.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Notifier\Driver;
+
+use App\Notifier\Notification;
+use App\Notifier\NotifierDriverInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class PushoverDriver implements NotifierDriverInterface
+{
+    private const ENDPOINT = 'https://api.pushover.net/1/messages.json';
+
+    public function __construct(
+        private readonly HttpClientInterface $http,
+        private readonly string $token,
+        private readonly string $user,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'pushover';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->token !== '' && $this->user !== '';
+    }
+
+    public function send(Notification $notification): void
+    {
+        $this->http->request('POST', self::ENDPOINT, [
+            'body' => [
+                'token' => $this->token,
+                'user' => $this->user,
+                'title' => $notification->title(),
+                'message' => $notification->summary(),
+                // Pushover priority scale -2..2 ; bump to 1 on error so
+                // it bypasses quiet hours but doesn't require ack.
+                'priority' => $notification->isError() ? 1 : 0,
+            ],
+            'timeout' => 10,
+        ])->getStatusCode();
+    }
+}

--- a/src/Notifier/Driver/SlackDriver.php
+++ b/src/Notifier/Driver/SlackDriver.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Notifier\Driver;
+
+use App\Notifier\Notification;
+use App\Notifier\NotifierDriverInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class SlackDriver implements NotifierDriverInterface
+{
+    public function __construct(
+        private readonly HttpClientInterface $http,
+        private readonly string $webhookUrl,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'slack';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->webhookUrl !== '';
+    }
+
+    public function send(Notification $notification): void
+    {
+        $text = sprintf("*%s*\n```%s```", $notification->title(), $notification->summary());
+
+        $this->http->request('POST', $this->webhookUrl, [
+            'headers' => ['content-type' => 'application/json'],
+            'json' => ['text' => $text],
+            'timeout' => 10,
+        ])->getStatusCode();
+    }
+}

--- a/src/Notifier/Notification.php
+++ b/src/Notifier/Notification.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Notifier;
+
+use App\Entity\RunHistory;
+
+/**
+ * Payload pushed to every configured notification driver after a
+ * RunHistoryRecorder-wrapped job finishes. Holds the minimum a human
+ * needs to triage the run from a phone notification (type/label/status/
+ * duration/error) without consulting the UI — plus the run id so a
+ * driver can include a deep link to /history/{id}.
+ */
+final class Notification
+{
+    /** @param array<string, mixed>|null $metrics */
+    public function __construct(
+        public readonly string $type,
+        public readonly string $label,
+        public readonly string $status,
+        public readonly int $durationMs,
+        public readonly ?int $runId = null,
+        public readonly ?string $errorMessage = null,
+        public readonly ?array $metrics = null,
+    ) {
+    }
+
+    public static function fromRunHistory(RunHistory $run): self
+    {
+        return new self(
+            type: $run->getType(),
+            label: $run->getLabel(),
+            status: $run->getStatus(),
+            durationMs: $run->getDurationMs() ?? 0,
+            runId: $run->getId(),
+            errorMessage: $run->getStatus() === RunHistory::STATUS_ERROR ? $run->getMessage() : null,
+            metrics: $run->getMetrics(),
+        );
+    }
+
+    public function isError(): bool
+    {
+        return $this->status === RunHistory::STATUS_ERROR;
+    }
+
+    public function title(): string
+    {
+        $prefix = $this->isError() ? '[ERROR]' : '[OK]';
+
+        return sprintf('%s %s', $prefix, $this->label);
+    }
+
+    public function summary(): string
+    {
+        $lines = [
+            sprintf('Type: %s', $this->type),
+            sprintf('Status: %s', $this->status),
+            sprintf('Duration: %s', self::formatDuration($this->durationMs)),
+        ];
+
+        if ($this->errorMessage !== null && $this->errorMessage !== '') {
+            $lines[] = sprintf('Error: %s', self::truncate($this->errorMessage, 500));
+        }
+
+        if (!empty($this->metrics)) {
+            $pairs = [];
+            foreach ($this->metrics as $key => $value) {
+                if (is_scalar($value) || $value === null) {
+                    $pairs[] = sprintf('%s=%s', $key, self::scalarToString($value));
+                }
+            }
+            if ($pairs !== []) {
+                $lines[] = 'Metrics: ' . implode(' ', $pairs);
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private static function formatDuration(int $ms): string
+    {
+        if ($ms < 1000) {
+            return $ms . 'ms';
+        }
+        $s = $ms / 1000;
+        if ($s < 60) {
+            return sprintf('%.1fs', $s);
+        }
+        $m = (int) floor($s / 60);
+        $rest = $s - ($m * 60);
+
+        return sprintf('%dm%02ds', $m, (int) round($rest));
+    }
+
+    private static function truncate(string $s, int $max): string
+    {
+        if (strlen($s) <= $max) {
+            return $s;
+        }
+
+        return substr($s, 0, $max) . '…';
+    }
+
+    private static function scalarToString(mixed $v): string
+    {
+        if (is_bool($v)) {
+            return $v ? 'true' : 'false';
+        }
+        if ($v === null) {
+            return 'null';
+        }
+
+        return (string) $v;
+    }
+}

--- a/src/Notifier/Notifier.php
+++ b/src/Notifier/Notifier.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Notifier;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Fan-out notifier : iterates over every driver tagged
+ * `app.notifier_driver`, picks those listed in NOTIFY_DRIVERS, applies
+ * the NOTIFY_ON filter, and best-effort dispatches. A failing driver
+ * is logged but never blocks the others or the calling job.
+ */
+class Notifier
+{
+    public const ON_ALL = 'all';
+    public const ON_ERROR = 'error';
+
+    /** @var list<string> */
+    private readonly array $enabledDriverNames;
+
+    /** @var list<NotifierDriverInterface> */
+    private readonly array $drivers;
+
+    /** @param iterable<NotifierDriverInterface> $drivers */
+    public function __construct(
+        iterable $drivers,
+        string $enabledDriversCsv,
+        private readonly string $notifyOn = self::ON_ERROR,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+        $this->drivers = is_array($drivers) ? array_values($drivers) : iterator_to_array($drivers, false);
+        $this->enabledDriverNames = self::parseDriverCsv($enabledDriversCsv);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function parseDriverCsv(string $csv): array
+    {
+        $names = [];
+        foreach (explode(',', $csv) as $raw) {
+            $name = strtolower(trim($raw));
+            if ($name !== '') {
+                $names[] = $name;
+            }
+        }
+
+        return array_values(array_unique($names));
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabledDriverNames !== [];
+    }
+
+    public function getNotifyOn(): string
+    {
+        return $this->notifyOn;
+    }
+
+    /**
+     * Returns a status snapshot for every registered driver — useful to
+     * the settings UI to list which channels exist and whether they'd
+     * actually fire today. Does not dispatch anything.
+     *
+     * @return list<array{name: string, listed: bool, configured: bool}>
+     */
+    public function describeDrivers(): array
+    {
+        $out = [];
+        foreach ($this->drivers as $driver) {
+            $name = $driver->getName();
+            $out[] = [
+                'name' => $name,
+                'listed' => in_array($name, $this->enabledDriverNames, true),
+                'configured' => $driver->isConfigured(),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Dispatch immediately on every listed+configured driver, regardless
+     * of the NOTIFY_ON filter — used by the settings page "send test"
+     * button so the operator can validate both a success and an error
+     * payload without flipping NOTIFY_ON. Returns the per-driver
+     * outcome so the caller can surface it as a flash.
+     *
+     * @return array<string, string> driver name → "sent" / "skipped:<reason>" / "error:<message>"
+     */
+    public function testSend(Notification $notification): array
+    {
+        $result = [];
+        foreach ($this->drivers as $driver) {
+            $name = $driver->getName();
+            if (!in_array($name, $this->enabledDriverNames, true)) {
+                $result[$name] = 'skipped:not-listed';
+                continue;
+            }
+            if (!$driver->isConfigured()) {
+                $result[$name] = 'skipped:not-configured';
+                continue;
+            }
+            try {
+                $driver->send($notification);
+                $result[$name] = 'sent';
+            } catch (\Throwable $e) {
+                $this->logger->error('Notifier driver "{driver}" failed during test: {message}', [
+                    'driver' => $name,
+                    'message' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
+                $result[$name] = 'error:' . $e->getMessage();
+            }
+        }
+
+        return $result;
+    }
+
+    public function notify(Notification $notification): void
+    {
+        if ($this->enabledDriverNames === []) {
+            return;
+        }
+        if (!$notification->isError() && $this->notifyOn !== self::ON_ALL) {
+            return;
+        }
+
+        foreach ($this->drivers as $driver) {
+            if (!in_array($driver->getName(), $this->enabledDriverNames, true)) {
+                continue;
+            }
+            if (!$driver->isConfigured()) {
+                $this->logger->warning('Notifier driver "{driver}" is listed in NOTIFY_DRIVERS but not configured — skipping.', [
+                    'driver' => $driver->getName(),
+                ]);
+                continue;
+            }
+            try {
+                $driver->send($notification);
+            } catch (\Throwable $e) {
+                $this->logger->error('Notifier driver "{driver}" failed: {message}', [
+                    'driver' => $driver->getName(),
+                    'message' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
+            }
+        }
+    }
+}

--- a/src/Notifier/NotifierDriverInterface.php
+++ b/src/Notifier/NotifierDriverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Notifier;
+
+interface NotifierDriverInterface
+{
+    /**
+     * Stable identifier used by NOTIFY_DRIVERS to enable this driver.
+     * Lowercase, no spaces (e.g. "gotify", "slack", "discord", "pushover").
+     */
+    public function getName(): string;
+
+    /**
+     * True only when the driver has the credentials it needs to send.
+     * False = the orchestrator silently skips it (typical when the env
+     * vars are empty).
+     */
+    public function isConfigured(): bool;
+
+    /**
+     * Push the notification synchronously. Drivers MAY throw on transport
+     * failure ; the orchestrator catches and logs so one broken driver
+     * never blocks the others.
+     */
+    public function send(Notification $notification): void;
+}

--- a/src/Repository/LastFmAliasRepository.php
+++ b/src/Repository/LastFmAliasRepository.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LastFmAlias;
+use App\Navidrome\NavidromeRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LastFmAlias>
+ */
+class LastFmAliasRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LastFmAlias::class);
+    }
+
+    /**
+     * Look up an alias for a Last.fm scrobble. Both inputs are normalized
+     * with {@see NavidromeRepository::normalize()} so the lookup is
+     * accent/case/punctuation-insensitive.
+     */
+    public function findByScrobble(string $artist, string $title): ?LastFmAlias
+    {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
+        if ($artistNorm === '' || $titleNorm === '') {
+            return null;
+        }
+
+        return $this->findOneBy([
+            'sourceArtistNorm' => $artistNorm,
+            'sourceTitleNorm' => $titleNorm,
+        ]);
+    }
+
+    /**
+     * Paginated search by raw substring on either source field. Used by
+     * the alias admin page.
+     *
+     * @return list<LastFmAlias>
+     */
+    public function search(string $query, int $page, int $perPage): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->orderBy('a.createdAt', 'DESC')
+            ->setFirstResult(max(0, ($page - 1) * $perPage))
+            ->setMaxResults($perPage);
+
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.sourceTitle) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        /** @var list<LastFmAlias> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    public function countSearch(string $query): int
+    {
+        $qb = $this->createQueryBuilder('a')->select('COUNT(a.id)');
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.sourceTitle) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+}

--- a/src/Repository/LastFmArtistAliasRepository.php
+++ b/src/Repository/LastFmArtistAliasRepository.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LastFmArtistAlias;
+use App\Navidrome\NavidromeRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LastFmArtistAlias>
+ */
+class LastFmArtistAliasRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LastFmArtistAlias::class);
+    }
+
+    /**
+     * Look up an artist alias by its source name. Lookup is normalized
+     * via {@see NavidromeRepository::normalize()} (case / accents /
+     * punctuation insensitive).
+     */
+    public function findBySourceArtist(string $artist): ?LastFmArtistAlias
+    {
+        $norm = NavidromeRepository::normalize($artist);
+        if ($norm === '') {
+            return null;
+        }
+
+        return $this->findOneBy(['sourceArtistNorm' => $norm]);
+    }
+
+    /**
+     * Resolve `$artist` to its canonical form via the alias table, or
+     * return null when no alias is registered. Used by the matching
+     * cascade ({@see \App\LastFm\ScrobbleMatcher}) to rewrite the source
+     * artist before any heuristic.
+     */
+    public function resolve(string $artist): ?string
+    {
+        $alias = $this->findBySourceArtist($artist);
+
+        return $alias?->getTargetArtist();
+    }
+
+    /**
+     * Paginated search by substring on source / target artist.
+     *
+     * @return list<LastFmArtistAlias>
+     */
+    public function search(string $query, int $page, int $perPage): array
+    {
+        $qb = $this->createQueryBuilder('a')
+            ->orderBy('a.createdAt', 'DESC')
+            ->setFirstResult(max(0, ($page - 1) * $perPage))
+            ->setMaxResults($perPage);
+
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.targetArtist) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        /** @var list<LastFmArtistAlias> $rows */
+        $rows = $qb->getQuery()->getResult();
+
+        return $rows;
+    }
+
+    public function countSearch(string $query): int
+    {
+        $qb = $this->createQueryBuilder('a')->select('COUNT(a.id)');
+        if ($query !== '') {
+            $qb->andWhere('LOWER(a.sourceArtist) LIKE :q OR LOWER(a.targetArtist) LIKE :q')
+                ->setParameter('q', '%' . mb_strtolower($query) . '%');
+        }
+
+        return (int) $qb->getQuery()->getSingleScalarResult();
+    }
+}

--- a/src/Repository/LastFmMatchCacheRepository.php
+++ b/src/Repository/LastFmMatchCacheRepository.php
@@ -1,0 +1,214 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\LastFmMatchCacheEntry;
+use App\Navidrome\NavidromeRepository;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<LastFmMatchCacheEntry>
+ *
+ * Reads and writes go through raw SQL on the underlying DBAL connection
+ * rather than the ORM unit-of-work. The cache is just a memoization table
+ * (no relations, no lifecycle), and the previous ORM-based `persist()` +
+ * `findOneBy()` dance kept stumbling on the unique index
+ * `uniq_lastfm_match_cache_source_norm` whenever Doctrine's identity-map /
+ * pending-state diverged from the actual row state — typically when a
+ * persisted-but-unflushed entity was forgotten and a duplicate persist for
+ * the same normalized couple slipped through to flush. SQLite UPSERT
+ * (`INSERT … ON CONFLICT … DO UPDATE`) handles dedup atomically at the DB
+ * level, so the in-memory bookkeeping is no longer necessary.
+ */
+class LastFmMatchCacheRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, LastFmMatchCacheEntry::class);
+    }
+
+    /**
+     * Look up a memoized resolution by normalized `(artist, title)`. Returns a
+     * detached `LastFmMatchCacheEntry` hydrated from the row — sufficient for
+     * the matcher's getters (`getTargetMediaFileId`, `getStrategy`,
+     * `isPositive`, `isStale`). The entity is intentionally unmanaged: any
+     * subsequent `recordPositive/Negative` must go through `upsert()` (raw
+     * SQL UPSERT) rather than mutating this object.
+     */
+    public function findByCouple(string $artist, string $title): ?LastFmMatchCacheEntry
+    {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
+        if ($artistNorm === '' || $titleNorm === '') {
+            return null;
+        }
+
+        $row = $this->connection()->fetchAssociative(
+            'SELECT source_artist, source_title, target_media_file_id, strategy, confidence_score, resolved_at
+             FROM lastfm_match_cache
+             WHERE source_artist_norm = :a AND source_title_norm = :t',
+            ['a' => $artistNorm, 't' => $titleNorm],
+        );
+        if ($row === false) {
+            return null;
+        }
+
+        return LastFmMatchCacheEntry::fromRow($row);
+    }
+
+    /**
+     * Upsert a positive resolution. Atomic via SQLite UPSERT.
+     */
+    public function recordPositive(
+        string $artist,
+        string $title,
+        string $mediaFileId,
+        string $strategy,
+        ?int $confidenceScore = null,
+    ): void {
+        $this->upsert($artist, $title, $mediaFileId, $strategy, $confidenceScore);
+    }
+
+    /**
+     * Upsert a negative resolution. Strategy is fixed to `negative` so we
+     * can later distinguish « we tried and gave up » from a positive match.
+     */
+    public function recordNegative(string $artist, string $title): void
+    {
+        $this->upsert($artist, $title, null, LastFmMatchCacheEntry::STRATEGY_NEGATIVE, null);
+    }
+
+    private function upsert(
+        string $artist,
+        string $title,
+        ?string $mediaFileId,
+        string $strategy,
+        ?int $confidenceScore,
+    ): void {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
+        // Don't cache rows that would normalize to an empty key — they'd
+        // collide on the unique (norm, norm) index after the first insert
+        // and the cascade can't lookup them anyway.
+        if ($artistNorm === '' || $titleNorm === '') {
+            return;
+        }
+
+        $this->connection()->executeStatement(
+            'INSERT INTO lastfm_match_cache
+                (source_artist, source_title, source_artist_norm, source_title_norm,
+                 target_media_file_id, strategy, confidence_score, resolved_at)
+             VALUES (:sa, :st, :san, :stn, :tid, :strat, :conf, :rat)
+             ON CONFLICT (source_artist_norm, source_title_norm) DO UPDATE SET
+                source_artist = excluded.source_artist,
+                source_title = excluded.source_title,
+                target_media_file_id = excluded.target_media_file_id,
+                strategy = excluded.strategy,
+                confidence_score = excluded.confidence_score,
+                resolved_at = excluded.resolved_at',
+            [
+                'sa' => trim($artist),
+                'st' => trim($title),
+                'san' => $artistNorm,
+                'stn' => $titleNorm,
+                'tid' => $mediaFileId,
+                'strat' => $strategy,
+                'conf' => $confidenceScore,
+                'rat' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            ],
+        );
+    }
+
+    /**
+     * No-op kept for backwards compatibility with callers
+     * ({@see \App\LastFm\LastFmBufferProcessor},
+     * {@see \App\Service\LastFmRematchService}). The previous implementation
+     * maintained an in-memory map of un-flushed entities to dedup persists
+     * within a batch; raw SQL UPSERT removes that need.
+     */
+    public function detachPending(): void
+    {
+    }
+
+    /**
+     * Drop the row matching this exact couple. Returns the number of rows
+     * deleted (0 or 1). Called when the user creates / edits / deletes a
+     * track-level alias for that couple.
+     */
+    public function purgeByCouple(string $artist, string $title): int
+    {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        $titleNorm = NavidromeRepository::normalize($title);
+        if ($artistNorm === '' || $titleNorm === '') {
+            return 0;
+        }
+
+        return (int) $this->connection()->executeStatement(
+            'DELETE FROM lastfm_match_cache
+             WHERE source_artist_norm = :a AND source_title_norm = :t',
+            ['a' => $artistNorm, 't' => $titleNorm],
+        );
+    }
+
+    /**
+     * Drop every row whose source artist matches `$artist`. Called when the
+     * user creates / edits an artist-level alias on `$artist` (the source
+     * side of the alias) so the next cascade re-resolves through the new
+     * alias.
+     */
+    public function purgeByArtist(string $artist): int
+    {
+        $artistNorm = NavidromeRepository::normalize($artist);
+        if ($artistNorm === '') {
+            return 0;
+        }
+
+        return (int) $this->connection()->executeStatement(
+            'DELETE FROM lastfm_match_cache WHERE source_artist_norm = :a',
+            ['a' => $artistNorm],
+        );
+    }
+
+    /**
+     * Drop every negative cache row older than `$ttlDays`. Called once at
+     * the start of each import / rematch run. `$ttlDays <= 0` means
+     * « never expire », so it's a no-op.
+     */
+    public function purgeStale(int $ttlDays): int
+    {
+        if ($ttlDays <= 0) {
+            return 0;
+        }
+        $threshold = (new \DateTimeImmutable())
+            ->modify(sprintf('-%d days', $ttlDays))
+            ->format('Y-m-d H:i:s');
+
+        return (int) $this->connection()->executeStatement(
+            'DELETE FROM lastfm_match_cache
+             WHERE target_media_file_id IS NULL AND resolved_at < :threshold',
+            ['threshold' => $threshold],
+        );
+    }
+
+    /**
+     * Wipe the table. `$negativeOnly = true` keeps positive matches —
+     * useful when one wants to retry the Last.fm `track.getInfo` step
+     * for previously-missed scrobbles without losing known good
+     * resolutions.
+     */
+    public function purgeAll(bool $negativeOnly = false): int
+    {
+        $sql = $negativeOnly
+            ? 'DELETE FROM lastfm_match_cache WHERE target_media_file_id IS NULL'
+            : 'DELETE FROM lastfm_match_cache';
+
+        return (int) $this->connection()->executeStatement($sql);
+    }
+
+    private function connection(): Connection
+    {
+        return $this->getEntityManager()->getConnection();
+    }
+}

--- a/src/Repository/RunHistoryRepository.php
+++ b/src/Repository/RunHistoryRepository.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\RunHistory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<RunHistory> */
+class RunHistoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, RunHistory::class);
+    }
+
+    /**
+     * @param array{type?: ?string, status?: ?string, q?: ?string} $filters
+     * @return array{items: RunHistory[], total: int}
+     */
+    public function findFilteredPaginated(array $filters, int $page, int $perPage): array
+    {
+        $qb = $this->createQueryBuilder('h')->orderBy('h.startedAt', 'DESC');
+
+        if (!empty($filters['type'])) {
+            $qb->andWhere('h.type = :type')->setParameter('type', $filters['type']);
+        }
+        if (!empty($filters['status'])) {
+            $qb->andWhere('h.status = :status')->setParameter('status', $filters['status']);
+        }
+        if (!empty($filters['q'])) {
+            $qb->andWhere('LOWER(h.label) LIKE :q')->setParameter('q', '%' . strtolower($filters['q']) . '%');
+        }
+
+        $total = (int) (clone $qb)->select('COUNT(h.id)')->getQuery()->getSingleScalarResult();
+
+        /** @var RunHistory[] $items */
+        $items = $qb->setMaxResults($perPage)->setFirstResult(($page - 1) * $perPage)->getQuery()->getResult();
+
+        return ['items' => $items, 'total' => $total];
+    }
+
+    public function purgeOlderThan(\DateTimeInterface $cutoff): int
+    {
+        return (int) $this->createQueryBuilder('h')
+            ->delete()
+            ->andWhere('h.startedAt < :cutoff')
+            ->setParameter('cutoff', $cutoff)
+            ->getQuery()
+            ->execute();
+    }
+}

--- a/src/Repository/SettingRepository.php
+++ b/src/Repository/SettingRepository.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Setting;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<Setting> */
+class SettingRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry, private readonly EntityManagerInterface $em)
+    {
+        parent::__construct($registry, Setting::class);
+    }
+
+    public function get(string $key, string $default = ''): string
+    {
+        return $this->findOneBy(['key' => $key])?->getValue() ?? $default;
+    }
+
+    public function set(string $key, string $value): void
+    {
+        $setting = $this->findOneBy(['key' => $key]);
+        if ($setting === null) {
+            $setting = new Setting($key, $value);
+            $this->em->persist($setting);
+        } else {
+            $setting->setValue($value);
+        }
+        $this->em->flush();
+    }
+}

--- a/src/Service/BackupService.php
+++ b/src/Service/BackupService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Creates SQLite database snapshots and prunes old ones.
+ *
+ * Backup filenames follow the pattern: YYYY-MM-DD_HH-MM-SS_LABEL.sqlite
+ * Stored in $backupDir (default var/backups, configured as a Docker volume).
+ */
+class BackupService
+{
+    public function __construct(private readonly string $backupDir)
+    {
+    }
+
+    /**
+     * Copy $dbPath to the backup directory. Returns the full path of the
+     * created backup file.
+     *
+     * @throws \RuntimeException if the source file is not readable or the
+     *                           copy fails.
+     */
+    public function backup(string $dbPath, string $label): string
+    {
+        if (!file_exists($dbPath)) {
+            throw new \RuntimeException(sprintf('Database file not found: %s', $dbPath));
+        }
+
+        if (!is_dir($this->backupDir)) {
+            if (!mkdir($this->backupDir, 0755, true)) {
+                throw new \RuntimeException(sprintf('Cannot create backup directory: %s', $this->backupDir));
+            }
+        }
+
+        $safeLabel = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $label) ?? $label;
+        $filename = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d_H-i-s')
+            . '_' . $safeLabel . '.sqlite';
+        $dest = $this->backupDir . '/' . $filename;
+
+        if (!copy($dbPath, $dest)) {
+            throw new \RuntimeException(sprintf('Failed to copy %s to %s', $dbPath, $dest));
+        }
+
+        // Also copy WAL and SHM siblings if present.
+        foreach (['-wal', '-shm'] as $suffix) {
+            $sibling = $dbPath . $suffix;
+            if (file_exists($sibling)) {
+                copy($sibling, $dest . $suffix);
+            }
+        }
+
+        return $dest;
+    }
+
+    /**
+     * Delete backup files older than $days days. Returns the number of
+     * files removed.
+     */
+    public function pruneOlderThan(int $days): int
+    {
+        if (!is_dir($this->backupDir) || $days <= 0) {
+            return 0;
+        }
+
+        $cutoff = (new \DateTimeImmutable())->modify(sprintf('-%d days', $days))->getTimestamp();
+        $removed = 0;
+
+        foreach (glob($this->backupDir . '/*.sqlite') ?: [] as $file) {
+            if (filemtime($file) < $cutoff) {
+                unlink($file);
+                $removed++;
+                // Remove WAL/SHM siblings too.
+                foreach (['-wal', '-shm'] as $suffix) {
+                    if (file_exists($file . $suffix)) {
+                        unlink($file . $suffix);
+                    }
+                }
+            }
+        }
+
+        return $removed;
+    }
+
+    /**
+     * @return list<array{path: string, label: string, size: int, created_at: \DateTimeImmutable}>
+     */
+    public function listBackups(): array
+    {
+        if (!is_dir($this->backupDir)) {
+            return [];
+        }
+
+        $files = glob($this->backupDir . '/*.sqlite') ?: [];
+        rsort($files);
+
+        return array_map(static function (string $path): array {
+            $name = basename($path, '.sqlite');
+            return [
+                'path' => $path,
+                'label' => $name,
+                'size' => (int) filesize($path),
+                'created_at' => new \DateTimeImmutable('@' . filemtime($path)),
+            ];
+        }, $files);
+    }
+}

--- a/src/Service/RunHistoryRecorder.php
+++ b/src/Service/RunHistoryRecorder.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\RunHistory;
+use App\Notifier\Notification;
+use App\Notifier\Notifier;
+use Doctrine\ORM\EntityManagerInterface;
+
+class RunHistoryRecorder
+{
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly ?Notifier $notifier = null,
+    ) {
+    }
+
+    /**
+     * Wraps an action and records its outcome (success/error) into run_history.
+     * Re-throws on error so the caller can surface it to the user.
+     *
+     * The action callable receives the freshly persisted RunHistory entry
+     * (already flushed, so its id is set) — this lets the action attach
+     * child entities to the run via foreign key. Existing arrow-fn callers
+     * that don't declare the parameter ignore it (PHP silently discards
+     * extra positional args).
+     *
+     * @template T
+     *
+     * @param callable(RunHistory): T            $action
+     * @param ?callable(T): array<string, mixed> $extractMetrics
+     *
+     * @return T
+     */
+    public function record(
+        string $type,
+        string $reference,
+        string $label,
+        callable $action,
+        ?callable $extractMetrics = null,
+    ): mixed {
+        $entry = new RunHistory($type, $reference, $label);
+        $entry->setStatus(RunHistory::STATUS_RUNNING);
+        $this->em->persist($entry);
+        $this->em->flush();
+
+        $startedMicrotime = microtime(true);
+
+        try {
+            $result = $action($entry);
+        } catch (\Throwable $e) {
+            $entry->setStatus(RunHistory::STATUS_ERROR);
+            $entry->setMessage($e->getMessage());
+            $entry->setFinishedAt(new \DateTimeImmutable());
+            $entry->setDurationMs((int) round((microtime(true) - $startedMicrotime) * 1000));
+            $this->em->flush();
+            $this->notify($entry);
+            throw $e;
+        }
+
+        $entry->setStatus(RunHistory::STATUS_SUCCESS);
+        $entry->setFinishedAt(new \DateTimeImmutable());
+        $entry->setDurationMs((int) round((microtime(true) - $startedMicrotime) * 1000));
+
+        if ($extractMetrics !== null) {
+            try {
+                $entry->setMetrics($extractMetrics($result));
+            } catch (\Throwable) {
+                // Swallow metric extraction errors — they should never block a successful run.
+            }
+        }
+
+        $this->em->flush();
+        $this->notify($entry);
+
+        return $result;
+    }
+
+    private function notify(RunHistory $entry): void
+    {
+        if ($this->notifier === null) {
+            return;
+        }
+        try {
+            $this->notifier->notify(Notification::fromRunHistory($entry));
+        } catch (\Throwable) {
+            // Notification dispatch must never abort the job. The
+            // orchestrator already catches per-driver, this is a final
+            // safety net.
+        }
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,6 +11,7 @@
 {% if app.user %}
 <nav class="bg-slate-800 text-slate-100 px-4 py-2 flex items-center gap-4 text-sm">
     <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white">Navidrome Tools</a>
+    <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
     <span class="flex-1"></span>
     <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>
 </nav>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -1,8 +1,59 @@
 {% extends 'base.html.twig' %}
 {% block title %}Dashboard{% endblock %}
 {% block body %}
-    <h1 class="text-2xl font-semibold mb-4">Dashboard</h1>
-    <div class="bg-white shadow-sm rounded-sm p-6 text-slate-500 text-sm">
-        Le développement de Navidrome Tools v2 est en cours. 🚧
+    <h1 class="text-2xl font-semibold mb-6">Dashboard</h1>
+
+    <div class="bg-amber-50 border border-amber-300 rounded-sm p-4 mb-6 text-sm text-amber-900">
+        🚧 <strong>Navidrome Tools v2</strong> — développement en cours (Lot 2 : import Last.fm à venir).
+    </div>
+
+    {# Derniers runs #}
+    <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+        <div class="flex items-center justify-between px-3 py-2 bg-slate-100 border-b">
+            <h2 class="text-sm font-semibold text-slate-700">Derniers runs</h2>
+            <a href="{{ path('app_history') }}" class="text-xs text-sky-700 hover:underline">Voir tout →</a>
+        </div>
+        {% if recent_runs is empty %}
+            <div class="px-3 py-4 text-sm text-slate-500 text-center">Aucun run pour l'instant.</div>
+        {% else %}
+            <table class="w-full text-sm">
+                <thead class="bg-slate-50 text-xs text-slate-500 uppercase">
+                    <tr>
+                        <th class="px-3 py-2 text-left">Label</th>
+                        <th class="px-3 py-2 text-left">Type</th>
+                        <th class="px-3 py-2 text-left">Statut</th>
+                        <th class="px-3 py-2 text-right">Durée</th>
+                        <th class="px-3 py-2 text-right">Lancé le</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for run in recent_runs %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5">
+                            <a href="{{ path('app_history_show', {id: run.id}) }}" class="hover:underline">
+                                {{ run.label }}
+                            </a>
+                        </td>
+                        <td class="px-3 py-1.5 font-mono text-xs text-slate-500">{{ run.type }}</td>
+                        <td class="px-3 py-1.5">
+                            <span class="text-xs px-1.5 py-0.5 rounded-sm font-medium
+                                {% if run.status == 'success' %}bg-emerald-100 text-emerald-800
+                                {% elseif run.status == 'error' %}bg-rose-100 text-rose-800
+                                {% elseif run.status == 'running' %}bg-sky-100 text-sky-800
+                                {% else %}bg-slate-100 text-slate-700{% endif %}">
+                                {{ run.status }}
+                            </span>
+                        </td>
+                        <td class="px-3 py-1.5 text-right text-xs text-slate-500 font-mono">
+                            {% if run.durationMs %}{{ (run.durationMs / 1000)|number_format(1) }}s{% else %}—{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-right text-xs text-slate-500">
+                            {{ run.startedAt|date('d/m H:i') }}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
     </div>
 {% endblock %}

--- a/templates/history/index.html.twig
+++ b/templates/history/index.html.twig
@@ -1,0 +1,86 @@
+{% extends 'base.html.twig' %}
+{% block title %}Historique des runs{% endblock %}
+{% block body %}
+    <div class="flex items-center justify-between mb-4">
+        <h1 class="text-2xl font-semibold">Historique des runs</h1>
+        <span class="text-sm text-slate-500">{{ total }} run{{ total != 1 ? 's' : '' }}</span>
+    </div>
+
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Type</label>
+            <input type="text" name="type" value="{{ filters.type }}" placeholder="lastfm-fetch…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Statut</label>
+            <select name="status" class="border rounded-sm px-2 py-1 text-sm">
+                <option value="">Tous</option>
+                <option value="success" {% if filters.status == 'success' %}selected{% endif %}>success</option>
+                <option value="error" {% if filters.status == 'error' %}selected{% endif %}>error</option>
+                <option value="running" {% if filters.status == 'running' %}selected{% endif %}>running</option>
+            </select>
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Recherche</label>
+            <input type="text" name="q" value="{{ filters.q }}" placeholder="label…"
+                   class="border rounded-sm px-2 py-1 text-sm">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_history') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+    </form>
+
+    {% if items is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun run trouvé.</div>
+    {% else %}
+    <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+        <table class="w-full text-sm">
+            <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                <tr>
+                    <th class="px-3 py-2 text-left w-8">#</th>
+                    <th class="px-3 py-2 text-left">Label</th>
+                    <th class="px-3 py-2 text-left">Type</th>
+                    <th class="px-3 py-2 text-left">Statut</th>
+                    <th class="px-3 py-2 text-right">Durée</th>
+                    <th class="px-3 py-2 text-right">Lancé le</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y">
+            {% for run in items %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 text-xs">{{ run.id }}</td>
+                    <td class="px-3 py-1.5">
+                        <a href="{{ path('app_history_show', {id: run.id}) }}" class="hover:underline">{{ run.label }}</a>
+                        {% if run.message %}<div class="text-xs text-rose-600 truncate max-w-xs">{{ run.message }}</div>{% endif %}
+                    </td>
+                    <td class="px-3 py-1.5 font-mono text-xs text-slate-500">{{ run.type }}</td>
+                    <td class="px-3 py-1.5">
+                        <span class="text-xs px-1.5 py-0.5 rounded-sm font-medium
+                            {% if run.status == 'success' %}bg-emerald-100 text-emerald-800
+                            {% elseif run.status == 'error' %}bg-rose-100 text-rose-800
+                            {% elseif run.status == 'running' %}bg-sky-100 text-sky-800
+                            {% else %}bg-slate-100 text-slate-700{% endif %}">
+                            {{ run.status }}
+                        </span>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">
+                        {% if run.durationMs %}{{ (run.durationMs / 1000)|number_format(1) }}s{% else %}—{% endif %}
+                    </td>
+                    <td class="px-3 py-1.5 text-right text-xs text-slate-500">
+                        {{ run.startedAt|date('d/m/Y H:i:s') }}
+                    </td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% if pages > 1 %}
+    <div class="flex gap-2 items-center text-sm">
+        {% if page > 1 %}<a href="{{ path('app_history', filters|merge({page: page - 1})) }}" class="px-3 py-1 rounded-sm bg-white border hover:bg-slate-50">← Préc.</a>{% endif %}
+        <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
+        {% if page < pages %}<a href="{{ path('app_history', filters|merge({page: page + 1})) }}" class="px-3 py-1 rounded-sm bg-white border hover:bg-slate-50">Suiv. →</a>{% endif %}
+    </div>
+    {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/history/show.html.twig
+++ b/templates/history/show.html.twig
@@ -1,0 +1,65 @@
+{% extends 'base.html.twig' %}
+{% block title %}Run #{{ run.id }}{% endblock %}
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_history') }}" class="text-sm text-sky-700 hover:underline">← Historique</a>
+    </div>
+
+    <div class="bg-white shadow-sm rounded-sm p-6 mb-4">
+        <div class="flex items-start justify-between mb-4">
+            <div>
+                <h1 class="text-xl font-semibold">{{ run.label }}</h1>
+                <div class="text-sm text-slate-500 mt-1">
+                    <span class="font-mono">{{ run.type }}</span>
+                    / <span class="font-mono">{{ run.reference }}</span>
+                    / #{{ run.id }}
+                </div>
+            </div>
+            <span class="text-sm px-2 py-1 rounded-sm font-medium
+                {% if run.status == 'success' %}bg-emerald-100 text-emerald-800
+                {% elseif run.status == 'error' %}bg-rose-100 text-rose-800
+                {% elseif run.status == 'running' %}bg-sky-100 text-sky-800
+                {% else %}bg-slate-100 text-slate-700{% endif %}"
+                  {% if run.status == 'running' %}id="run-status"{% endif %}>
+                {{ run.status }}
+            </span>
+        </div>
+
+        <dl class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            <div><dt class="text-xs text-slate-500">Lancé le</dt><dd>{{ run.startedAt|date('d/m/Y H:i:s') }}</dd></div>
+            <div><dt class="text-xs text-slate-500">Terminé le</dt><dd>{{ run.finishedAt ? run.finishedAt|date('d/m/Y H:i:s') : '—' }}</dd></div>
+            <div><dt class="text-xs text-slate-500">Durée</dt><dd>{{ run.durationMs ? (run.durationMs / 1000)|number_format(2) ~ 's' : '—' }}</dd></div>
+        </dl>
+
+        {% if run.message %}
+        <div class="mt-4 p-3 bg-rose-50 border border-rose-200 rounded-sm text-sm text-rose-800 font-mono whitespace-pre-wrap">{{ run.message }}</div>
+        {% endif %}
+    </div>
+
+    {% if run.metrics %}
+    <div class="bg-white shadow-sm rounded-sm p-6">
+        <h2 class="text-sm font-semibold uppercase text-slate-500 mb-3">Métriques</h2>
+        <dl class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm">
+            {% for key, val in run.metrics %}
+                <div><dt class="text-xs text-slate-500">{{ key }}</dt><dd class="font-mono">{{ val }}</dd></div>
+            {% endfor %}
+        </dl>
+    </div>
+    {% endif %}
+
+    {% if run.status == 'running' %}
+    <script>
+        (function poll() {
+            fetch('{{ path('app_history_status', {id: run.id}) }}')
+                .then(r => r.json())
+                .then(data => {
+                    if (data.status !== 'running') {
+                        window.location.reload();
+                    } else {
+                        setTimeout(poll, 2000);
+                    }
+                });
+        })();
+    </script>
+    {% endif %}
+{% endblock %}

--- a/tests/Service/BackupServiceTest.php
+++ b/tests/Service/BackupServiceTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Service\BackupService;
+use PHPUnit\Framework\TestCase;
+
+class BackupServiceTest extends TestCase
+{
+    private string $backupDir;
+    private string $sourceDb;
+
+    protected function setUp(): void
+    {
+        $this->backupDir = sys_get_temp_dir() . '/backup-test-' . uniqid();
+        $this->sourceDb = sys_get_temp_dir() . '/source-' . uniqid() . '.sqlite';
+        file_put_contents($this->sourceDb, 'SQLite format 3' . str_repeat("\0", 81));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->backupDir . '/*') ?: [] as $f) {
+            unlink($f);
+        }
+        if (is_dir($this->backupDir)) {
+            rmdir($this->backupDir);
+        }
+        if (file_exists($this->sourceDb)) {
+            unlink($this->sourceDb);
+        }
+    }
+
+    public function testBackupCreatesFile(): void
+    {
+        $svc = new BackupService($this->backupDir);
+        $dest = $svc->backup($this->sourceDb, 'navidrome');
+
+        $this->assertFileExists($dest);
+        $this->assertStringContainsString('navidrome', basename($dest));
+        $this->assertStringEndsWith('.sqlite', $dest);
+    }
+
+    public function testBackupThrowsWhenSourceMissing(): void
+    {
+        $svc = new BackupService($this->backupDir);
+
+        $this->expectException(\RuntimeException::class);
+        $svc->backup('/nonexistent/db.sqlite', 'test');
+    }
+
+    public function testPruneRemovesOldFiles(): void
+    {
+        mkdir($this->backupDir, 0755, true);
+        $old = $this->backupDir . '/2020-01-01_00-00-00_old.sqlite';
+        $recent = $this->backupDir . '/2099-01-01_00-00-00_recent.sqlite';
+        file_put_contents($old, 'x');
+        file_put_contents($recent, 'x');
+        touch($old, time() - 8 * 86400);
+
+        $svc = new BackupService($this->backupDir);
+        $removed = $svc->pruneOlderThan(7);
+
+        $this->assertSame(1, $removed);
+        $this->assertFileDoesNotExist($old);
+        $this->assertFileExists($recent);
+    }
+
+    public function testListBackupsReturnsSortedList(): void
+    {
+        $svc = new BackupService($this->backupDir);
+        $svc->backup($this->sourceDb, 'first');
+        $svc->backup($this->sourceDb, 'second');
+
+        $list = $svc->listBackups();
+        $this->assertCount(2, $list);
+        $this->assertArrayHasKey('label', $list[0]);
+        $this->assertArrayHasKey('size', $list[0]);
+    }
+}

--- a/tests/Service/RunHistoryRecorderTest.php
+++ b/tests/Service/RunHistoryRecorderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\RunHistory;
+use App\Service\RunHistoryRecorder;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class RunHistoryRecorderTest extends TestCase
+{
+    public function testRecordSuccessCreatesRunHistory(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $persisted = [];
+        $em->method('persist')->willReturnCallback(function (object $e) use (&$persisted): void {
+            $persisted[] = $e;
+        });
+        $em->method('flush');
+
+        $recorder = new RunHistoryRecorder($em);
+        $result = $recorder->record(
+            type: RunHistory::TYPE_LASTFM_FETCH,
+            reference: 'alice',
+            label: 'Test run',
+            action: fn () => 42,
+            extractMetrics: static fn (int $v) => ['value' => $v],
+        );
+
+        $this->assertSame(42, $result);
+        $runHistory = $persisted[0];
+        $this->assertInstanceOf(RunHistory::class, $runHistory);
+        $this->assertSame(RunHistory::TYPE_LASTFM_FETCH, $runHistory->getType());
+        $this->assertSame(RunHistory::STATUS_SUCCESS, $runHistory->getStatus());
+    }
+
+    public function testRecordErrorSetsStatusAndRethrows(): void
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        $recorder = new RunHistoryRecorder($em);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('boom');
+
+        $recorder->record(
+            type: RunHistory::TYPE_LASTFM_FETCH,
+            reference: 'alice',
+            label: 'Failing run',
+            action: fn () => throw new \RuntimeException('boom'),
+        );
+    }
+}


### PR DESCRIPTION
## Lot 1 — Socle technique

Pose les fondations réutilisables pour tous les lots suivants.

## Ce qui est inclus

**Entités + migration unique `Version20260514200000` :**
- `run_history` — audit de chaque run CLI/HTTP (statut, durée, métriques JSON)
- `setting` — KV store (dont `lastfm_last_fetch_{user}` pour le smart date du Lot 2)
- `lastfm_alias` / `lastfm_artist_alias` — mappings manuels et réécriture d'artiste pour le matching
- `lastfm_match_cache` — memoization matching (positif ∞, négatif TTL configurable)

**Portés de poc-v0 (0 modification) :**
- `RunHistoryRecorder` — wrapping action → persist RunHistory
- `Notifier` + 4 drivers (Gotify, Slack, Discord, Pushover)
- `NavidromeRepository` — bridge SQLite Navidrome + `normalize()` statique
- `TrackSummary` — DTO

**Nouveaux :**
- `BackupService` — `backup()` + `pruneOlderThan()` + `listBackups()`
- `app:backup:purge` — supprime backups > `BACKUP_RETENTION_DAYS` (défaut 7j)
- `app:history:purge` — purge run_history > `RUN_HISTORY_RETENTION_DAYS`
- `HistoryController` — `/history` (liste + filtres), `/history/{id}`, `/history/{id}/status.json` (polling)
- Dashboard avec liste des derniers runs

**Infrastructure :**
- Symfony 7.2 (upgrade depuis 7.1 — advisory sécurité CVE sur http-foundation)
- `composer.lock` inclus

## Tests

6 tests / 16 assertions — tous verts. CI phpcs + phpstan OK.

## Prochaine étape

**Lot 2 — Import Last.fm → table `scrobbles`** (entité `Scrobble`, `LastFmFetcher`, smart date tracking, trigger HTTP via Messenger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)