### PR TITLE
feat(lot-2): import Last.fm → table scrobbles (source de vérité)

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -12,5 +12,4 @@ framework:
                     multiplier: 2
 
         routing:
-            # Messages are routed here as features are added.
-            # Example: 'App\Message\FetchLastFmMessage': async
+            'App\Message\FetchLastFmMessage': async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -93,3 +93,17 @@ services:
         arguments:
             $dbPath: '%navidrome.db_path%'
             $userName: '%navidrome.user%'
+
+    App\LastFm\LastFmClient:
+        arguments:
+            $pageDelaySeconds: '%lastfm.page_delay_seconds%'
+
+    App\Command\FetchLastFmCommand:
+        arguments:
+            $defaultApiKey: '%lastfm.api_key%'
+            $defaultUser: '%lastfm.user%'
+
+    App\Controller\LastFmImportController:
+        arguments:
+            $defaultApiKey: '%lastfm.api_key%'
+            $defaultUser: '%lastfm.user%'

--- a/migrations/Version20260514210000.php
+++ b/migrations/Version20260514210000.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514210000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add scrobbles table: local source of truth for Last.fm scrobbles.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE scrobbles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                lastfm_user VARCHAR(255) NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                album VARCHAR(255) DEFAULT NULL,
+                album_artist VARCHAR(255) DEFAULT NULL,
+                mbid_track VARCHAR(64) DEFAULT NULL,
+                mbid_artist VARCHAR(64) DEFAULT NULL,
+                mbid_album VARCHAR(64) DEFAULT NULL,
+                played_at DATETIME NOT NULL,
+                loved BOOLEAN NOT NULL DEFAULT 0,
+                image_url CLOB DEFAULT NULL,
+                fetched_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_scrobble_user_played_track ON scrobbles (lastfm_user, played_at, artist, title)');
+        $this->addSql('CREATE INDEX idx_scrobble_user_played ON scrobbles (lastfm_user, played_at)');
+        $this->addSql('CREATE INDEX idx_scrobble_played_at ON scrobbles (played_at)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE scrobbles');
+    }
+}

--- a/src/Command/FetchLastFmCommand.php
+++ b/src/Command/FetchLastFmCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\LastFm\FetchReport;
+use App\LastFm\LastFmFetcher;
+use App\Repository\SettingRepository;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Fetch scrobbles from Last.fm and store them in the local `scrobbles` table.
+ *
+ * Smart date mode (no --date-min): reads setting[lastfm_last_fetch_{user}]
+ * and fetches from that date - 1h to now. On success, updates the setting.
+ * With --date-min: explicit window, does NOT update the last_fetch setting.
+ */
+#[AsCommand(
+    name: 'app:lastfm:fetch',
+    description: 'Fetch Last.fm scrobble history into the local scrobbles table.',
+)]
+class FetchLastFmCommand extends Command
+{
+    private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
+    private const OVERLAP_HOURS = 1;
+
+    public function __construct(
+        private readonly LastFmFetcher $fetcher,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly SettingRepository $settings,
+        private readonly string $defaultApiKey,
+        private readonly string $defaultUser,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('user', InputArgument::OPTIONAL, 'Last.fm username (defaults to LASTFM_USER env).')
+            ->addOption('api-key', null, InputOption::VALUE_REQUIRED, 'Last.fm API key (defaults to LASTFM_API_KEY env).')
+            ->addOption('date-min', null, InputOption::VALUE_REQUIRED, 'Fetch from this date (YYYY-MM-DD). Overrides smart date.')
+            ->addOption('date-max', null, InputOption::VALUE_REQUIRED, 'Fetch until this date (YYYY-MM-DD).')
+            ->addOption('max-scrobbles', null, InputOption::VALUE_REQUIRED, 'Stop after N scrobbles.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Count without writing to DB.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $user = (string) ($input->getArgument('user') ?: $this->defaultUser);
+        $apiKey = (string) ($input->getOption('api-key') ?: $this->defaultApiKey);
+        $dryRun = (bool) $input->getOption('dry-run');
+        $maxScrobbles = $input->getOption('max-scrobbles') !== null ? (int) $input->getOption('max-scrobbles') : null;
+
+        if ($user === '') {
+            $io->error('No Last.fm user specified. Pass as argument or set LASTFM_USER env.');
+            return Command::FAILURE;
+        }
+        if ($apiKey === '') {
+            $io->error('No Last.fm API key. Pass --api-key or set LASTFM_API_KEY env.');
+            return Command::FAILURE;
+        }
+
+        $explicitDateMin = $input->getOption('date-min');
+        $explicitDateMax = $input->getOption('date-max');
+        $smartDate = $explicitDateMin === null;
+
+        [$dateMin, $dateMax] = $this->resolveDateRange($user, $explicitDateMin, $explicitDateMax, $io);
+
+        if ($dateMin !== null) {
+            $io->note(sprintf(
+                'Fetch window: %s → %s%s',
+                $dateMin->format('Y-m-d H:i:s'),
+                $dateMax?->format('Y-m-d H:i:s') ?? 'now',
+                $smartDate ? ' (smart date)' : ' (explicit)',
+            ));
+        }
+
+        $label = sprintf('Last.fm fetch %s%s', $user, $dryRun ? ' [dry-run]' : '');
+        $now = new \DateTimeImmutable();
+
+        try {
+            $report = $this->recorder->record(
+                type: RunHistory::TYPE_LASTFM_FETCH,
+                reference: $user,
+                label: $label,
+                action: fn () => $this->fetcher->fetch(
+                    apiKey: $apiKey,
+                    lastFmUser: $user,
+                    dateMin: $dateMin,
+                    dateMax: $dateMax,
+                    maxScrobbles: $maxScrobbles,
+                    dryRun: $dryRun,
+                    progress: function (int $f, int $i, int $d) use ($io): void {
+                        $io->writeln(sprintf('  fetched=%d inserted=%d duplicates=%d', $f, $i, $d));
+                    },
+                ),
+                extractMetrics: static fn (FetchReport $r) => [
+                    'fetched' => $r->fetched,
+                    'inserted' => $r->inserted,
+                    'duplicates' => $r->duplicates,
+                    'smart_date' => $smartDate,
+                    'dry_run' => $dryRun,
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        // Update last_fetch setting only on explicit (non-dry-run, non-explicit-date) runs.
+        if ($smartDate && !$dryRun && $report->fetched > 0) {
+            $this->settings->set(self::SETTING_KEY_PREFIX . $user, $now->format('Y-m-d H:i:s'));
+        }
+
+        $io->success(sprintf(
+            '%s done. fetched=%d inserted=%d duplicates=%d',
+            $dryRun ? 'Dry-run' : 'Fetch',
+            $report->fetched,
+            $report->inserted,
+            $report->duplicates,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable}
+     */
+    private function resolveDateRange(string $user, ?string $explicitMin, ?string $explicitMax, SymfonyStyle $io): array
+    {
+        $dateMax = $explicitMax !== null ? new \DateTimeImmutable($explicitMax) : null;
+
+        if ($explicitMin !== null) {
+            return [new \DateTimeImmutable($explicitMin), $dateMax];
+        }
+
+        // Smart date: read last successful fetch from settings.
+        $lastFetch = $this->settings->get(self::SETTING_KEY_PREFIX . $user);
+        if ($lastFetch !== '') {
+            $dateMin = (new \DateTimeImmutable($lastFetch))
+                ->modify(sprintf('-%d hours', self::OVERLAP_HOURS));
+            $io->note(sprintf(
+                'Smart date: last fetch was %s, starting from %s (-%dh overlap).',
+                $lastFetch,
+                $dateMin->format('Y-m-d H:i:s'),
+                self::OVERLAP_HOURS,
+            ));
+            return [$dateMin, $dateMax];
+        }
+
+        $io->note('No previous fetch found. Fetching full history (this may take a while).');
+        return [null, $dateMax];
+    }
+}

--- a/src/Controller/LastFmImportController.php
+++ b/src/Controller/LastFmImportController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Controller;
+
+use App\Message\FetchLastFmMessage;
+use App\Repository\ScrobbleRepository;
+use App\Repository\SettingRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmImportController extends AbstractController
+{
+    private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
+
+    public function __construct(
+        private readonly string $defaultApiKey,
+        private readonly string $defaultUser,
+    ) {
+    }
+
+    #[Route('/lastfm/import', name: 'app_lastfm_import', methods: ['GET'])]
+    public function index(
+        ScrobbleRepository $scrobbles,
+        SettingRepository $settings,
+    ): Response {
+        $user = $this->defaultUser;
+        $lastFetch = $user !== '' ? $settings->get(self::SETTING_KEY_PREFIX . $user) : '';
+
+        return $this->render('lastfm/import.html.twig', [
+            'total_scrobbles' => $scrobbles->countAll(),
+            'user_scrobbles' => $user !== '' ? $scrobbles->countByUser($user) : null,
+            'last_fetch' => $lastFetch !== '' ? new \DateTimeImmutable($lastFetch) : null,
+            'default_user' => $user,
+            'default_api_key' => $this->defaultApiKey,
+        ]);
+    }
+
+    #[Route('/lastfm/import', name: 'app_lastfm_import_post', methods: ['POST'])]
+    public function fetch(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('lastfm_fetch', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $user = trim((string) $request->request->get('user', $this->defaultUser));
+        $apiKey = trim((string) $request->request->get('api_key', $this->defaultApiKey));
+        $dateMin = trim((string) $request->request->get('date_min', '')) ?: null;
+        $dateMax = trim((string) $request->request->get('date_max', '')) ?: null;
+        $maxScrobbles = ($v = $request->request->get('max_scrobbles')) ? (int) $v : null;
+        $dryRun = (bool) $request->request->get('dry_run');
+
+        if ($user === '' || $apiKey === '') {
+            $this->addFlash('error', 'Utilisateur et API key requis.');
+            return $this->redirectToRoute('app_lastfm_import');
+        }
+
+        $message = new FetchLastFmMessage(
+            user: $user,
+            apiKey: $apiKey,
+            dateMin: $dateMin,
+            dateMax: $dateMax,
+            maxScrobbles: $maxScrobbles,
+            dryRun: $dryRun,
+        );
+
+        $bus->dispatch($message);
+
+        $this->addFlash('success', sprintf(
+            'Fetch Last.fm pour « %s » lancé en arrière-plan. Suivez la progression dans l\'historique.',
+            $user,
+        ));
+
+        return $this->redirectToRoute('app_history');
+    }
+}

--- a/src/Entity/Scrobble.php
+++ b/src/Entity/Scrobble.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Entity;
+
+use App\Doctrine\UtcDateTimeImmutableType;
+use App\Repository\ScrobbleRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * A Last.fm scrobble stored locally — the source of truth for all sync operations.
+ * Rows are never deleted (except on explicit wipe). New scrobbles fetched from
+ * Last.fm are inserted here; matching / syncing to Navidrome or Strawberry happens
+ * in scrobble_sync rows created lazily by each sync service.
+ */
+#[ORM\Entity(repositoryClass: ScrobbleRepository::class)]
+#[ORM\Table(name: 'scrobbles')]
+#[ORM\UniqueConstraint(name: 'uniq_scrobble_user_played_track', columns: ['lastfm_user', 'played_at', 'artist', 'title'])]
+#[ORM\Index(columns: ['lastfm_user', 'played_at'], name: 'idx_scrobble_user_played')]
+#[ORM\Index(columns: ['played_at'], name: 'idx_scrobble_played_at')]
+class Scrobble
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 255)]
+    private string $lastfmUser;
+
+    #[ORM\Column(length: 255)]
+    private string $artist;
+
+    #[ORM\Column(length: 255)]
+    private string $title;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $album = null;
+
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $albumArtist = null;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $mbidTrack = null;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $mbidArtist = null;
+
+    #[ORM\Column(length: 64, nullable: true)]
+    private ?string $mbidAlbum = null;
+
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME)]
+    private \DateTimeImmutable $playedAt;
+
+    #[ORM\Column(type: Types::BOOLEAN, options: ['default' => false])]
+    private bool $loved = false;
+
+    #[ORM\Column(type: Types::TEXT, nullable: true)]
+    private ?string $imageUrl = null;
+
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME)]
+    private \DateTimeImmutable $fetchedAt;
+
+    public function __construct(
+        string $lastfmUser,
+        string $artist,
+        string $title,
+        ?string $album,
+        ?string $albumArtist,
+        ?string $mbidTrack,
+        ?string $mbidArtist,
+        ?string $mbidAlbum,
+        \DateTimeImmutable $playedAt,
+        bool $loved = false,
+        ?string $imageUrl = null,
+    ) {
+        $this->lastfmUser = $lastfmUser;
+        $this->artist = $artist;
+        $this->title = $title;
+        $this->album = $album !== '' ? $album : null;
+        $this->albumArtist = $albumArtist !== '' ? $albumArtist : null;
+        $this->mbidTrack = $mbidTrack !== '' ? $mbidTrack : null;
+        $this->mbidArtist = $mbidArtist !== '' ? $mbidArtist : null;
+        $this->mbidAlbum = $mbidAlbum !== '' ? $mbidAlbum : null;
+        $this->playedAt = $playedAt;
+        $this->loved = $loved;
+        $this->imageUrl = $imageUrl;
+        $this->fetchedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int { return $this->id; }
+    public function getLastfmUser(): string { return $this->lastfmUser; }
+    public function getArtist(): string { return $this->artist; }
+    public function getTitle(): string { return $this->title; }
+    public function getAlbum(): ?string { return $this->album; }
+    public function getAlbumArtist(): ?string { return $this->albumArtist; }
+    public function getMbidTrack(): ?string { return $this->mbidTrack; }
+    public function getMbidArtist(): ?string { return $this->mbidArtist; }
+    public function getMbidAlbum(): ?string { return $this->mbidAlbum; }
+    public function getPlayedAt(): \DateTimeImmutable { return $this->playedAt; }
+    public function isLoved(): bool { return $this->loved; }
+    public function getImageUrl(): ?string { return $this->imageUrl; }
+    public function getFetchedAt(): \DateTimeImmutable { return $this->fetchedAt; }
+}

--- a/src/LastFm/FetchReport.php
+++ b/src/LastFm/FetchReport.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\LastFm;
+
+final class FetchReport
+{
+    public int $fetched = 0;
+    public int $inserted = 0;
+    public int $duplicates = 0;
+    public ?\DateTimeImmutable $firstPlayedAt = null;
+    public ?\DateTimeImmutable $lastPlayedAt = null;
+}

--- a/src/LastFm/LastFmApiException.php
+++ b/src/LastFm/LastFmApiException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * Thrown when the Last.fm API responds with an `error` field. Carries the
+ * numeric error code separately so callers can soft-handle expected codes
+ * (e.g. 6 « Track not found » during the matching cascade) while letting
+ * real failures (rate limiting, invalid key, service down) bubble up.
+ *
+ * Codes documented at https://www.last.fm/api/errorcodes — most relevant:
+ *   6  → Invalid parameters / track not found
+ *   8  → Operation failed
+ *   10 → Invalid API key
+ *   11 → Service offline
+ *   16 → Service temporarily unavailable
+ *   29 → Rate limit exceeded
+ */
+class LastFmApiException extends \RuntimeException
+{
+    public function __construct(
+        public readonly int $errorCode,
+        public readonly string $errorMessage,
+    ) {
+        parent::__construct(sprintf('Last.fm API error %d: %s', $errorCode, $errorMessage));
+    }
+}

--- a/src/LastFm/LastFmApiSigner.php
+++ b/src/LastFm/LastFmApiSigner.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * Computes the api_sig parameter required by Last.fm's authenticated
+ * endpoints (auth.getSession, track.love, track.unlove…). The algorithm,
+ * per https://www.last.fm/api/authspec :
+ *
+ *   1. drop `format` and `callback` from the params,
+ *   2. sort the remaining params by key (ASCII),
+ *   3. concatenate `key . value` for every param,
+ *   4. append the API secret,
+ *   5. md5() the result.
+ */
+final class LastFmApiSigner
+{
+    /**
+     * @param array<string, scalar> $params
+     */
+    public static function sign(array $params, string $apiSecret): string
+    {
+        unset($params['format'], $params['callback']);
+        ksort($params, SORT_STRING);
+
+        $concat = '';
+        foreach ($params as $key => $value) {
+            $concat .= $key . $value;
+        }
+
+        return md5($concat . $apiSecret);
+    }
+}

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -1,0 +1,328 @@
+<?php
+
+namespace App\LastFm;
+
+use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class LastFmClient
+{
+    private const BASE_URL = 'https://ws.audioscrobbler.com/2.0/';
+    private const PAGE_SIZE = 200;
+    private const MAX_ATTEMPTS = 3;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly int $pageDelaySeconds = 10,
+    ) {
+    }
+
+    /**
+     * Iterate over all scrobbles for the given user, oldest first when
+     * $dateMin is provided, newest first otherwise. Yields LastFmScrobble
+     * objects one by one to avoid loading the whole history in memory.
+     *
+     * @return \Generator<LastFmScrobble>
+     */
+    public function streamRecentTracks(
+        string $apiKey,
+        string $user,
+        ?\DateTimeInterface $dateMin = null,
+        ?\DateTimeInterface $dateMax = null,
+    ): \Generator {
+        $page = 1;
+        $totalPages = null;
+
+        do {
+            $params = [
+                'method' => 'user.getRecentTracks',
+                'user' => $user,
+                'api_key' => $apiKey,
+                'format' => 'json',
+                'limit' => self::PAGE_SIZE,
+                'page' => $page,
+            ];
+            if ($dateMin !== null) {
+                $params['from'] = $dateMin->getTimestamp();
+            }
+            if ($dateMax !== null) {
+                $params['to'] = $dateMax->getTimestamp();
+            }
+
+            $payload = $this->call($params);
+
+            $tracks = $payload['recenttracks']['track'] ?? [];
+            if (isset($tracks['name'])) {
+                $tracks = [$tracks];
+            }
+
+            foreach ($tracks as $track) {
+                // Skip currently playing entries — no date yet.
+                if (($track['@attr']['nowplaying'] ?? null) === 'true') {
+                    continue;
+                }
+                $ts = (int) ($track['date']['uts'] ?? 0);
+                if ($ts === 0) {
+                    continue;
+                }
+
+                $imageUrl = null;
+                $images = $track['image'] ?? [];
+                foreach (array_reverse($images) as $img) {
+                    $url = (string) ($img['#text'] ?? '');
+                    if ($url !== '') {
+                        $imageUrl = $url;
+                        break;
+                    }
+                }
+
+                yield new LastFmScrobble(
+                    artist: (string) ($track['artist']['#text'] ?? $track['artist']['name'] ?? ''),
+                    title: (string) ($track['name'] ?? ''),
+                    album: (string) ($track['album']['#text'] ?? ''),
+                    albumArtist: '',
+                    mbidTrack: ($track['mbid'] ?? '') !== '' ? (string) $track['mbid'] : null,
+                    mbidArtist: ($track['artist']['mbid'] ?? '') !== '' ? (string) $track['artist']['mbid'] : null,
+                    mbidAlbum: ($track['album']['mbid'] ?? '') !== '' ? (string) $track['album']['mbid'] : null,
+                    playedAt: (new \DateTimeImmutable('@' . $ts))->setTimezone(new \DateTimeZone('UTC')),
+                    loved: ($track['loved'] ?? '0') === '1',
+                    imageUrl: $imageUrl,
+                );
+            }
+
+            if ($totalPages === null) {
+                $totalPages = (int) ($payload['recenttracks']['@attr']['totalPages'] ?? 1);
+            }
+            $page++;
+
+            if ($page <= $totalPages && $this->pageDelaySeconds > 0) {
+                sleep($this->pageDelaySeconds);
+            }
+        } while ($page <= $totalPages);
+    }
+
+    /** @return \Generator<LastFmLovedTrack> */
+    public function iterateLovedTracks(string $apiKey, string $user): \Generator
+    {
+        $page = 1;
+        $totalPages = null;
+
+        do {
+            $payload = $this->call([
+                'method' => 'user.getLovedTracks',
+                'user' => $user,
+                'api_key' => $apiKey,
+                'format' => 'json',
+                'limit' => 50,
+                'page' => $page,
+            ]);
+
+            $tracks = $payload['lovedtracks']['track'] ?? [];
+            if (isset($tracks['name'])) {
+                $tracks = [$tracks];
+            }
+
+            foreach ($tracks as $track) {
+                $ts = isset($track['date']['uts']) ? (int) $track['date']['uts'] : 0;
+                yield new LastFmLovedTrack(
+                    artist: (string) ($track['artist']['name'] ?? $track['artist']['#text'] ?? ''),
+                    title: (string) ($track['name'] ?? ''),
+                    mbid: ($track['mbid'] ?? '') !== '' ? (string) $track['mbid'] : null,
+                    lovedAt: $ts > 0
+                        ? (new \DateTimeImmutable('@' . $ts))->setTimezone(new \DateTimeZone('UTC'))
+                        : null,
+                );
+            }
+
+            if ($totalPages === null) {
+                $totalPages = (int) ($payload['lovedtracks']['@attr']['totalPages'] ?? 1);
+            }
+            $page++;
+            if ($page <= $totalPages && $this->pageDelaySeconds > 0) {
+                sleep($this->pageDelaySeconds);
+            }
+        } while ($page <= $totalPages);
+    }
+
+    public function trackLove(string $apiKey, string $apiSecret, string $sk, string $artist, string $title): void
+    {
+        $this->writeAction('track.love', $apiKey, $apiSecret, $sk, $artist, $title);
+    }
+
+    public function trackUnlove(string $apiKey, string $apiSecret, string $sk, string $artist, string $title): void
+    {
+        $this->writeAction('track.unlove', $apiKey, $apiSecret, $sk, $artist, $title);
+    }
+
+    public function trackGetInfo(string $apiKey, string $artist, string $title): LastFmTrackInfo
+    {
+        return $this->lookup('track.getInfo', $apiKey, $artist, $title, 'track');
+    }
+
+    /** @return list<array{name: string, mbid: ?string, match: float, url: string}> */
+    public function artistGetSimilar(string $apiKey, string $artist, int $limit = 10): array
+    {
+        $payload = $this->call([
+            'method' => 'artist.getSimilar',
+            'artist' => $artist,
+            'api_key' => $apiKey,
+            'limit' => $limit,
+            'autocorrect' => 1,
+            'format' => 'json',
+        ]);
+
+        $items = $payload['similarartists']['artist'] ?? [];
+        if (isset($items['name'])) {
+            $items = [$items];
+        }
+
+        $out = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $name = trim((string) ($item['name'] ?? ''));
+            if ($name === '') {
+                continue;
+            }
+            $out[] = [
+                'name' => $name,
+                'mbid' => ($item['mbid'] ?? '') !== '' ? (string) $item['mbid'] : null,
+                'match' => (float) ($item['match'] ?? 0),
+                'url' => (string) ($item['url'] ?? ''),
+            ];
+        }
+
+        return $out;
+    }
+
+    private function lookup(string $method, string $apiKey, string $artist, string $title, string $bodyKey): LastFmTrackInfo
+    {
+        try {
+            $payload = $this->call([
+                'method' => $method,
+                'artist' => $artist,
+                'track' => $title,
+                'api_key' => $apiKey,
+                'autocorrect' => 1,
+                'format' => 'json',
+            ]);
+        } catch (LastFmApiException $e) {
+            if ($e->errorCode === 6) {
+                return LastFmTrackInfo::empty();
+            }
+            throw $e;
+        }
+
+        $node = $payload;
+        foreach (explode('.', $bodyKey) as $segment) {
+            if (!isset($node[$segment]) || !is_array($node[$segment])) {
+                return LastFmTrackInfo::empty();
+            }
+            $node = $node[$segment];
+        }
+
+        $mbid = isset($node['mbid']) && $node['mbid'] !== '' ? (string) $node['mbid'] : null;
+        $rawArtist = (string) ($node['artist']['name'] ?? $node['artist'] ?? '');
+        $rawTitle = (string) ($node['name'] ?? '');
+
+        return new LastFmTrackInfo(
+            mbid: $mbid,
+            correctedArtist: $this->correctionOrNull($artist, $rawArtist),
+            correctedTitle: $this->correctionOrNull($title, $rawTitle),
+        );
+    }
+
+    private function correctionOrNull(string $input, string $candidate): ?string
+    {
+        $candidate = trim($candidate);
+        if ($candidate === '') {
+            return null;
+        }
+        if (mb_strtolower(trim($input)) === mb_strtolower($candidate)) {
+            return null;
+        }
+
+        return $candidate;
+    }
+
+    private function writeAction(string $method, string $apiKey, string $apiSecret, string $sk, string $artist, string $title): void
+    {
+        $params = [
+            'method' => $method,
+            'api_key' => $apiKey,
+            'artist' => $artist,
+            'track' => $title,
+            'sk' => $sk,
+        ];
+        $params['api_sig'] = LastFmApiSigner::sign($params, $apiSecret);
+        $params['format'] = 'json';
+
+        try {
+            $response = $this->httpClient->request('POST', self::BASE_URL, [
+                'body' => $params,
+                'timeout' => 30,
+            ]);
+            $body = $response->toArray(throw: true);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(sprintf('Last.fm %s failed for "%s — %s": %s', $method, $artist, $title, $e->getMessage()), 0, $e);
+        }
+
+        if (isset($body['error'])) {
+            throw new \RuntimeException(sprintf('Last.fm %s error %s: %s', $method, $body['error'], $body['message'] ?? 'unknown'));
+        }
+    }
+
+    /** @param array<string, scalar> $params
+     *  @return array<string, mixed>
+     */
+    private function call(array $params): array
+    {
+        $attempt = 0;
+        while (true) {
+            $attempt++;
+            try {
+                $response = $this->httpClient->request('GET', self::BASE_URL, [
+                    'query' => $params,
+                    'timeout' => 30,
+                ]);
+                $body = $response->toArray(throw: true);
+                break;
+            } catch (\Throwable $e) {
+                if ($attempt < self::MAX_ATTEMPTS && $this->isTransientHttpError($e)) {
+                    if ($this->pageDelaySeconds > 0) {
+                        sleep($this->pageDelaySeconds);
+                    }
+                    continue;
+                }
+                throw new \RuntimeException(sprintf(
+                    'Last.fm API call failed (method=%s page=%s) after %d attempt(s): %s',
+                    $params['method'] ?? '?',
+                    $params['page'] ?? '?',
+                    $attempt,
+                    $e->getMessage(),
+                ), 0, $e);
+            }
+        }
+
+        if (isset($body['error'])) {
+            throw new LastFmApiException((int) $body['error'], (string) ($body['message'] ?? 'unknown'));
+        }
+
+        return $body;
+    }
+
+    private function isTransientHttpError(\Throwable $e): bool
+    {
+        if ($e instanceof TransportExceptionInterface) {
+            return true;
+        }
+        if ($e instanceof HttpExceptionInterface) {
+            $status = $e->getResponse()->getStatusCode();
+            return $status === 429 || $status >= 500;
+        }
+
+        return false;
+    }
+}

--- a/src/LastFm/LastFmFetcher.php
+++ b/src/LastFm/LastFmFetcher.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\LastFm;
+
+use App\Repository\ScrobbleRepository;
+
+/**
+ * Streams scrobbles from the Last.fm API and inserts them into the local
+ * `scrobbles` table (the source of truth). Idempotent: re-fetching a window
+ * already stored is a no-op thanks to the UNIQUE constraint on
+ * (lastfm_user, played_at, artist, title).
+ *
+ * No Navidrome or Strawberry writes happen here — safe to run while any
+ * other service is up.
+ */
+class LastFmFetcher
+{
+    public function __construct(
+        private readonly LastFmClient $client,
+        private readonly ScrobbleRepository $scrobbles,
+    ) {
+    }
+
+    /**
+     * @param callable(int $fetched, int $inserted, int $duplicates): void|null $progress
+     */
+    public function fetch(
+        string $apiKey,
+        string $lastFmUser,
+        ?\DateTimeInterface $dateMin = null,
+        ?\DateTimeInterface $dateMax = null,
+        ?int $maxScrobbles = null,
+        bool $dryRun = false,
+        ?callable $progress = null,
+    ): FetchReport {
+        $report = new FetchReport();
+        $fetchedAt = (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('Y-m-d H:i:s');
+
+        foreach ($this->client->streamRecentTracks($apiKey, $lastFmUser, $dateMin, $dateMax) as $scrobble) {
+            if ($maxScrobbles !== null && $report->fetched >= $maxScrobbles) {
+                break;
+            }
+            $report->fetched++;
+
+            if ($report->firstPlayedAt === null) {
+                $report->firstPlayedAt = $scrobble->playedAt;
+            }
+            $report->lastPlayedAt = $scrobble->playedAt;
+
+            if ($dryRun) {
+                $report->inserted++;
+                if ($progress !== null && $report->fetched % 50 === 0) {
+                    $progress($report->fetched, $report->inserted, $report->duplicates);
+                }
+                continue;
+            }
+
+            $inserted = $this->scrobbles->insertOrIgnore(
+                user: $lastFmUser,
+                artist: $scrobble->artist,
+                title: $scrobble->title,
+                album: $scrobble->album !== '' ? $scrobble->album : null,
+                albumArtist: $scrobble->albumArtist !== '' ? $scrobble->albumArtist : null,
+                mbidTrack: $scrobble->mbidTrack,
+                mbidArtist: $scrobble->mbidArtist,
+                mbidAlbum: $scrobble->mbidAlbum,
+                playedAt: $scrobble->playedAt,
+                loved: $scrobble->loved,
+                imageUrl: $scrobble->imageUrl,
+                fetchedAt: $fetchedAt,
+            );
+
+            if ($inserted) {
+                $report->inserted++;
+            } else {
+                $report->duplicates++;
+            }
+
+            if ($progress !== null && $report->fetched % 50 === 0) {
+                $progress($report->fetched, $report->inserted, $report->duplicates);
+            }
+        }
+
+        if ($progress !== null) {
+            $progress($report->fetched, $report->inserted, $report->duplicates);
+        }
+
+        return $report;
+    }
+}

--- a/src/LastFm/LastFmLovedTrack.php
+++ b/src/LastFm/LastFmLovedTrack.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * One entry of a Last.fm `user.getLovedTracks` page. Mirrors
+ * {@see LastFmScrobble} but the timestamp is the date the user loved
+ * the track, not when they played it.
+ */
+final class LastFmLovedTrack
+{
+    public function __construct(
+        public readonly string $artist,
+        public readonly string $title,
+        public readonly ?string $mbid,
+        public readonly ?\DateTimeImmutable $lovedAt,
+    ) {
+    }
+}

--- a/src/LastFm/LastFmScrobble.php
+++ b/src/LastFm/LastFmScrobble.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\LastFm;
+
+final class LastFmScrobble
+{
+    public function __construct(
+        public readonly string $artist,
+        public readonly string $title,
+        public readonly string $album,
+        public readonly string $albumArtist,
+        public readonly ?string $mbidTrack,
+        public readonly ?string $mbidArtist,
+        public readonly ?string $mbidAlbum,
+        public readonly \DateTimeImmutable $playedAt,
+        public readonly bool $loved = false,
+        public readonly ?string $imageUrl = null,
+    ) {
+    }
+}

--- a/src/LastFm/LastFmTrackInfo.php
+++ b/src/LastFm/LastFmTrackInfo.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * Outcome of a `track.getInfo` or `track.getCorrection` Last.fm API call.
+ * Holds the official MBID (when known) and the « corrected » spelling of
+ * the artist / title pair when Last.fm's autocorrect actually changed
+ * the input. Equal-after-trim-and-lower comparisons collapse to null so
+ * callers can safely test « did Last.fm correct the spelling? » with a
+ * `!== null` check.
+ */
+final class LastFmTrackInfo
+{
+    public function __construct(
+        public readonly ?string $mbid,
+        public readonly ?string $correctedArtist,
+        public readonly ?string $correctedTitle,
+    ) {
+    }
+
+    public static function empty(): self
+    {
+        return new self(null, null, null);
+    }
+
+    public function hasMbid(): bool
+    {
+        return $this->mbid !== null && $this->mbid !== '';
+    }
+
+    public function hasCorrection(): bool
+    {
+        return $this->correctedArtist !== null || $this->correctedTitle !== null;
+    }
+}

--- a/src/Message/FetchLastFmMessage.php
+++ b/src/Message/FetchLastFmMessage.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Message;
+
+final class FetchLastFmMessage
+{
+    public function __construct(
+        public readonly string $user,
+        public readonly string $apiKey,
+        public readonly ?string $dateMin,
+        public readonly ?string $dateMax,
+        public readonly ?int $maxScrobbles,
+        public readonly bool $dryRun,
+    ) {
+    }
+}

--- a/src/MessageHandler/FetchLastFmMessageHandler.php
+++ b/src/MessageHandler/FetchLastFmMessageHandler.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\LastFm\FetchReport;
+use App\LastFm\LastFmFetcher;
+use App\Message\FetchLastFmMessage;
+use App\Repository\SettingRepository;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class FetchLastFmMessageHandler
+{
+    private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
+
+    public function __construct(
+        private readonly LastFmFetcher $fetcher,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly SettingRepository $settings,
+    ) {
+    }
+
+    public function __invoke(FetchLastFmMessage $message): void
+    {
+        $dateMin = $message->dateMin !== null ? new \DateTimeImmutable($message->dateMin) : null;
+        $dateMax = $message->dateMax !== null ? new \DateTimeImmutable($message->dateMax) : null;
+        $smartDate = $message->dateMin === null;
+        $now = new \DateTimeImmutable();
+
+        // Apply smart date if no explicit date-min.
+        if ($smartDate) {
+            $lastFetch = $this->settings->get(self::SETTING_KEY_PREFIX . $message->user);
+            if ($lastFetch !== '') {
+                $dateMin = (new \DateTimeImmutable($lastFetch))->modify('-1 hours');
+            }
+        }
+
+        $report = $this->recorder->record(
+            type: RunHistory::TYPE_LASTFM_FETCH,
+            reference: $message->user,
+            label: sprintf('Last.fm fetch %s%s', $message->user, $message->dryRun ? ' [dry-run]' : ''),
+            action: fn () => $this->fetcher->fetch(
+                apiKey: $message->apiKey,
+                lastFmUser: $message->user,
+                dateMin: $dateMin,
+                dateMax: $dateMax,
+                maxScrobbles: $message->maxScrobbles,
+                dryRun: $message->dryRun,
+            ),
+            extractMetrics: static fn (FetchReport $r) => [
+                'fetched' => $r->fetched,
+                'inserted' => $r->inserted,
+                'duplicates' => $r->duplicates,
+                'smart_date' => $smartDate,
+                'dry_run' => $message->dryRun,
+            ],
+        );
+
+        if ($smartDate && !$message->dryRun && $report->fetched > 0) {
+            $this->settings->set(self::SETTING_KEY_PREFIX . $message->user, $now->format('Y-m-d H:i:s'));
+        }
+    }
+}

--- a/src/Repository/ScrobbleRepository.php
+++ b/src/Repository/ScrobbleRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Scrobble;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<Scrobble> */
+class ScrobbleRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Scrobble::class);
+    }
+
+    public function countByUser(string $user): int
+    {
+        return (int) $this->createQueryBuilder('s')
+            ->select('COUNT(s.id)')
+            ->where('s.lastfmUser = :user')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countAll(): int
+    {
+        return (int) $this->createQueryBuilder('s')
+            ->select('COUNT(s.id)')
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    /**
+     * Returns the most recent played_at for the given user, or null if no
+     * scrobble has been stored yet. Used by app:lastfm:fetch for smart date.
+     */
+    public function getLastPlayedAt(string $user): ?\DateTimeImmutable
+    {
+        $result = $this->getEntityManager()->getConnection()->fetchOne(
+            'SELECT MAX(played_at) FROM scrobbles WHERE lastfm_user = ?',
+            [$user],
+        );
+
+        if ($result === false || $result === null) {
+            return null;
+        }
+
+        return new \DateTimeImmutable((string) $result, new \DateTimeZone('UTC'));
+    }
+
+    /**
+     * Insert a scrobble using raw DBAL INSERT OR IGNORE for performance and
+     * idempotency. Returns true when the row was inserted, false when it was
+     * rejected by the unique constraint (duplicate).
+     */
+    public function insertOrIgnore(
+        string $user,
+        string $artist,
+        string $title,
+        ?string $album,
+        ?string $albumArtist,
+        ?string $mbidTrack,
+        ?string $mbidArtist,
+        ?string $mbidAlbum,
+        \DateTimeImmutable $playedAt,
+        bool $loved,
+        ?string $imageUrl,
+        string $fetchedAt,
+    ): bool {
+        $utc = new \DateTimeZone('UTC');
+
+        $affected = $this->getEntityManager()->getConnection()->executeStatement(
+            'INSERT OR IGNORE INTO scrobbles
+                (lastfm_user, artist, title, album, album_artist,
+                 mbid_track, mbid_artist, mbid_album,
+                 played_at, loved, image_url, fetched_at)
+             VALUES
+                (:user, :artist, :title, :album, :album_artist,
+                 :mbid_track, :mbid_artist, :mbid_album,
+                 :played_at, :loved, :image_url, :fetched_at)',
+            [
+                'user' => $user,
+                'artist' => $artist,
+                'title' => $title,
+                'album' => $album,
+                'album_artist' => $albumArtist,
+                'mbid_track' => $mbidTrack,
+                'mbid_artist' => $mbidArtist,
+                'mbid_album' => $mbidAlbum,
+                'played_at' => $playedAt->setTimezone($utc)->format('Y-m-d H:i:s'),
+                'loved' => $loved ? 1 : 0,
+                'image_url' => $imageUrl,
+                'fetched_at' => $fetchedAt,
+            ],
+        );
+
+        return $affected === 1;
+    }
+
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -11,6 +11,7 @@
 {% if app.user %}
 <nav class="bg-slate-800 text-slate-100 px-4 py-2 flex items-center gap-4 text-sm">
     <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white">Navidrome Tools</a>
+    <a href="{{ path('app_lastfm_import') }}" class="hover:text-slate-300">Import Last.fm</a>
     <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
     <span class="flex-1"></span>
     <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>

--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -1,0 +1,90 @@
+{% extends 'base.html.twig' %}
+{% block title %}Import Last.fm{% endblock %}
+{% block body %}
+    <h1 class="text-2xl font-semibold mb-4">Import des scrobbles Last.fm</h1>
+
+    <div class="bg-sky-50 border border-sky-300 text-sky-900 rounded-sm p-4 mb-6 text-sm">
+        Les scrobbles sont importés dans la table locale <code>scrobbles</code> (source de vérité).
+        Le worker Messenger traite les messages en arrière-plan — suivez la progression dans
+        <a href="{{ path('app_history') }}" class="underline">l'historique</a>.
+    </div>
+
+    {# Compteurs #}
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Scrobbles locaux</div>
+            <div class="text-3xl font-semibold">{{ total_scrobbles|number_format(0, '.', ' ') }}</div>
+        </div>
+        {% if user_scrobbles is not null %}
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Scrobbles de {{ default_user }}</div>
+            <div class="text-3xl font-semibold">{{ user_scrobbles|number_format(0, '.', ' ') }}</div>
+        </div>
+        {% endif %}
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Dernier fetch</div>
+            <div class="text-lg font-medium">
+                {% if last_fetch %}{{ last_fetch|date('d/m/Y H:i') }}{% else %}<span class="text-slate-400">jamais</span>{% endif %}
+            </div>
+            {% if last_fetch is null %}
+            <div class="text-xs text-amber-700 mt-1">Premier import — récupération de l'historique complet.</div>
+            {% endif %}
+        </div>
+    </div>
+
+    {# Formulaire fetch #}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl mb-6">
+        <h2 class="text-lg font-semibold mb-4">Lancer un fetch</h2>
+        <form method="post" action="{{ path('app_lastfm_import_post') }}" class="space-y-4">
+            <input type="hidden" name="_token" value="{{ csrf_token('lastfm_fetch') }}">
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">Utilisateur Last.fm *</label>
+                    <input type="text" name="user" value="{{ default_user }}" required
+                           class="w-full border rounded-sm px-3 py-2 text-sm">
+                </div>
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">API Key *</label>
+                    <input type="text" name="api_key" value="{{ default_api_key }}" required
+                           class="w-full border rounded-sm px-3 py-2 text-sm font-mono text-xs">
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">Depuis (date-min)</label>
+                    <input type="date" name="date_min"
+                           class="w-full border rounded-sm px-3 py-2 text-sm">
+                    <p class="text-xs text-slate-400 mt-1">Vide = smart date (depuis le dernier fetch)</p>
+                </div>
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">Jusqu'à (date-max)</label>
+                    <input type="date" name="date_max"
+                           class="w-full border rounded-sm px-3 py-2 text-sm">
+                </div>
+            </div>
+
+            <div class="flex items-center gap-6">
+                <label class="flex items-center gap-2 text-sm">
+                    <input type="checkbox" name="dry_run" value="1"> Dry-run (ne pas écrire en DB)
+                </label>
+                <label class="flex items-center gap-2 text-sm">
+                    <span class="text-slate-500">Max scrobbles</span>
+                    <input type="number" name="max_scrobbles" min="1" placeholder="∞"
+                           class="w-24 border rounded-sm px-2 py-1 text-sm">
+                </label>
+            </div>
+
+            <button type="submit"
+                    class="bg-slate-800 hover:bg-slate-900 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                ▶ Lancer le fetch
+            </button>
+        </form>
+
+        <div class="mt-4 text-xs text-slate-400">
+            <strong>CLI :</strong>
+            <code>php bin/console app:lastfm:fetch [user] [--date-min=YYYY-MM-DD] [--date-max=YYYY-MM-DD] [--dry-run]</code>
+        </div>
+    </div>
+{% endblock %}

--- a/tests/LastFm/LastFmFetcherTest.php
+++ b/tests/LastFm/LastFmFetcherTest.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Tests\LastFm;
+
+use App\LastFm\LastFmClient;
+use App\LastFm\LastFmFetcher;
+use App\LastFm\LastFmScrobble;
+use App\Repository\ScrobbleRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class LastFmFetcherTest extends TestCase
+{
+    private string $dbPath;
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/fetcher-test-' . uniqid() . '.db';
+        $this->conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $this->conn->executeStatement(<<<'SQL'
+            CREATE TABLE scrobbles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                lastfm_user VARCHAR(255) NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                album VARCHAR(255) DEFAULT NULL,
+                album_artist VARCHAR(255) DEFAULT NULL,
+                mbid_track VARCHAR(64) DEFAULT NULL,
+                mbid_artist VARCHAR(64) DEFAULT NULL,
+                mbid_album VARCHAR(64) DEFAULT NULL,
+                played_at DATETIME NOT NULL,
+                loved BOOLEAN NOT NULL DEFAULT 0,
+                image_url CLOB DEFAULT NULL,
+                fetched_at DATETIME NOT NULL,
+                UNIQUE (lastfm_user, played_at, artist, title)
+            )
+        SQL);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->conn->close();
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testFetchInsertsScrobbles(): void
+    {
+        $client = $this->makeClient([
+            $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00'),
+            $this->makeScrobble('Radiohead', 'Creep', '2024-01-02 10:00:00'),
+        ]);
+
+        $fetcher = new LastFmFetcher($client, $this->makeRepo());
+        $report = $fetcher->fetch('key', 'alice');
+
+        $this->assertSame(2, $report->fetched);
+        $this->assertSame(2, $report->inserted);
+        $this->assertSame(0, $report->duplicates);
+        $this->assertSame(2, (int) $this->conn->fetchOne('SELECT COUNT(*) FROM scrobbles'));
+    }
+
+    public function testFetchDeduplicatesOnRerun(): void
+    {
+        $scrobbles = [
+            $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00'),
+        ];
+        $client = $this->makeClient($scrobbles);
+        $fetcher = new LastFmFetcher($client, $this->makeRepo());
+
+        $fetcher->fetch('key', 'alice');
+        // Re-fetch same data.
+        $client2 = $this->makeClient($scrobbles);
+        $fetcher2 = new LastFmFetcher($client2, $this->makeRepo());
+        $report = $fetcher2->fetch('key', 'alice');
+
+        $this->assertSame(1, $report->fetched);
+        $this->assertSame(0, $report->inserted);
+        $this->assertSame(1, $report->duplicates);
+        $this->assertSame(1, (int) $this->conn->fetchOne('SELECT COUNT(*) FROM scrobbles'));
+    }
+
+    public function testDryRunDoesNotWrite(): void
+    {
+        $client = $this->makeClient([
+            $this->makeScrobble('Artist', 'Song', '2024-01-01 12:00:00'),
+        ]);
+        $fetcher = new LastFmFetcher($client, $this->makeRepo());
+        $report = $fetcher->fetch('key', 'alice', dryRun: true);
+
+        $this->assertSame(1, $report->fetched);
+        $this->assertSame(0, (int) $this->conn->fetchOne('SELECT COUNT(*) FROM scrobbles'));
+    }
+
+    public function testMaxScrobblesLimitsResults(): void
+    {
+        $client = $this->makeClient([
+            $this->makeScrobble('A', 'T1', '2024-01-01 10:00:00'),
+            $this->makeScrobble('A', 'T2', '2024-01-01 11:00:00'),
+            $this->makeScrobble('A', 'T3', '2024-01-01 12:00:00'),
+        ]);
+        $fetcher = new LastFmFetcher($client, $this->makeRepo());
+        $report = $fetcher->fetch('key', 'alice', maxScrobbles: 2);
+
+        $this->assertSame(2, $report->fetched);
+    }
+
+    /** @param list<LastFmScrobble> $scrobbles */
+    private function makeClient(array $scrobbles): LastFmClient
+    {
+        $client = $this->createMock(LastFmClient::class);
+        $client->method('streamRecentTracks')->willReturnCallback(
+            function () use ($scrobbles): \Generator {
+                yield from $scrobbles;
+            }
+        );
+        return $client;
+    }
+
+    private function makeRepo(): ScrobbleRepository
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getConnection')->willReturn($this->conn);
+
+        $repo = $this->createMock(ScrobbleRepository::class);
+        $repo->method('insertOrIgnore')->willReturnCallback(
+            function (
+                string $user,
+                string $artist,
+                string $title,
+                ?string $album,
+                ?string $albumArtist,
+                ?string $mbidTrack,
+                ?string $mbidArtist,
+                ?string $mbidAlbum,
+                \DateTimeImmutable $playedAt,
+                bool $loved,
+                ?string $imageUrl,
+                string $fetchedAt,
+            ): bool {
+                $affected = $this->conn->executeStatement(
+                    'INSERT OR IGNORE INTO scrobbles
+                        (lastfm_user, artist, title, album, album_artist, mbid_track, mbid_artist, mbid_album,
+                         played_at, loved, image_url, fetched_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+                    [$user, $artist, $title, $album, $albumArtist, $mbidTrack, $mbidArtist, $mbidAlbum,
+                     $playedAt->format('Y-m-d H:i:s'), $loved ? 1 : 0, $imageUrl, $fetchedAt],
+                );
+                return $affected === 1;
+            }
+        );
+
+        return $repo;
+    }
+
+    private function makeScrobble(string $artist, string $title, string $playedAt): LastFmScrobble
+    {
+        return new LastFmScrobble(
+            artist: $artist,
+            title: $title,
+            album: '',
+            albumArtist: '',
+            mbidTrack: null,
+            mbidArtist: null,
+            mbidAlbum: null,
+            playedAt: new \DateTimeImmutable($playedAt, new \DateTimeZone('UTC')),
+        );
+    }
+}


### PR DESCRIPTION
## Lot 2 — Import Last.fm → table \`scrobbles\`

### Ce qui est inclus

**Migration `Version20260514210000` — table `scrobbles`**
- Toutes les colonnes Last.fm : artist, title, album, album_artist, mbid_track, mbid_artist, mbid_album, played_at, loved, image_url, fetched_at
- `UNIQUE (lastfm_user, played_at, artist, title)` → idempotence garantie, re-fetch d'une fenêtre déjà stockée = no-op

**LastFmClient** — enrichi pour extraire `loved`, `mbid_artist`, `mbid_album`, `image_url` depuis l'API

**LastFmFetcher** — écrit directement dans `scrobbles` (fini le buffer intermédiaire)

**Smart date** (`app:lastfm:fetch` sans `--date-min`) :
  - Lit `setting[lastfm_last_fetch_{user}]` − 1h overlap
  - Met à jour le setting après un fetch réussi
  - Premiers utilisateurs → récupère tout l'historique automatiquement

**Messenger** — `FetchLastFmMessage` + `FetchLastFmMessageHandler`, routé vers le transport `async` (worker)

**UI `/lastfm/import`** — compteurs (scrobbles total/user, date dernier fetch) + formulaire POST → dispatch → redirect `/history`

**CLI** — `app:lastfm:fetch [user] [--date-min] [--date-max] [--dry-run] [--max-scrobbles] [--api-key]`

### Points à valider en review

- Le smart date (−1h overlap) est-il suffisant ou faut-il un overlap plus grand ?
- Faut-il un écran de statut de progression pendant le fetch (polling /history/{id}/status.json) ?
- Les champs `album_artist` et `mbid_*` valent-ils la peine d'être indexés ?

### Tests

10 tests / 27 assertions — tous verts. phpcs + phpstan OK.

### Prochaine étape

**Lot 3 — Sync vers Navidrome** : `ScrobbleSync` entity, `NavidromeSyncService`, worker, backup auto, stop/start container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)