### PR TITLE
feat(lot-3): sync vers Navidrome — ScrobbleSync, matching, backup auto, worker

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -13,3 +13,4 @@ framework:
 
         routing:
             'App\Message\FetchLastFmMessage': async
+            'App\Message\SyncNavidromeMessage': async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -107,3 +107,19 @@ services:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
             $defaultUser: '%lastfm.user%'
+
+    App\LastFm\ScrobbleMatcher:
+        arguments:
+            $fuzzyMaxDistance: '%lastfm.fuzzy_max_distance%'
+            $cacheTtlDays: '%lastfm.match_cache_ttl_days%'
+            $lastFmApiKey: '%lastfm.api_key%'
+
+    App\Docker\NavidromeContainerConfig:
+        arguments:
+            $containerName: '%navidrome.container_name%'
+            $stopTimeoutSeconds: '%navidrome.container_stop_timeout%'
+            $stopWaitCeilingSeconds: '%navidrome.container_stop_wait_ceiling%'
+
+    App\Navidrome\NavidromeDbBackup:
+        arguments:
+            $dbPath: '%navidrome.db_path%'

--- a/migrations/Version20260514220000.php
+++ b/migrations/Version20260514220000.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260514220000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add scrobble_sync table: tracks sync status per scrobble per target (navidrome, strawberry).';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE scrobble_sync (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                scrobble_id INTEGER NOT NULL REFERENCES scrobbles(id) ON DELETE CASCADE,
+                target VARCHAR(32) NOT NULL,
+                status VARCHAR(16) NOT NULL DEFAULT 'pending',
+                target_id VARCHAR(255) DEFAULT NULL,
+                strategy VARCHAR(32) DEFAULT NULL,
+                attempted_at DATETIME DEFAULT NULL,
+                synced_at DATETIME DEFAULT NULL,
+                run_id INTEGER DEFAULT NULL REFERENCES run_history(id) ON DELETE SET NULL
+            )
+        SQL);
+        $this->addSql('CREATE UNIQUE INDEX uniq_scrobble_sync_scrobble_target ON scrobble_sync (scrobble_id, target)');
+        $this->addSql('CREATE INDEX idx_scrobble_sync_target_status ON scrobble_sync (target, status)');
+        $this->addSql('CREATE INDEX idx_scrobble_sync_run ON scrobble_sync (run_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE scrobble_sync');
+    }
+}

--- a/src/Command/SyncNavidromeCommand.php
+++ b/src/Command/SyncNavidromeCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Command;
+
+use App\Docker\NavidromeContainerException;
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Navidrome\NavidromeSyncReport;
+use App\Navidrome\NavidromeSyncService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:scrobbles:sync-navidrome',
+    description: 'Match pending scrobbles against Navidrome and insert them into the Navidrome scrobbles table.',
+)]
+class SyncNavidromeCommand extends Command
+{
+    public function __construct(
+        private readonly NavidromeSyncService $syncService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly NavidromeContainerManager $container,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Compute matches without writing to Navidrome.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Process at most N pending rows (0 = no limit).', '0')
+            ->addOption('tolerance', null, InputOption::VALUE_REQUIRED, 'Dedup tolerance in seconds.', '60')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Bypass Navidrome container pre-flight check.')
+            ->addOption('auto-stop', null, InputOption::VALUE_NONE, 'Stop Navidrome, sync, restart (always, even on error).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit = max(0, (int) $input->getOption('limit'));
+        $tolerance = max(0, (int) $input->getOption('tolerance'));
+        $force = (bool) $input->getOption('force');
+        $autoStop = (bool) $input->getOption('auto-stop');
+
+        if (!$dryRun && !$autoStop) {
+            try {
+                $this->container->assertSafeToWrite($force);
+            } catch (NavidromeContainerException $e) {
+                $io->error($e->getMessage());
+                return Command::FAILURE;
+            }
+        }
+
+        $label = 'Navidrome sync' . ($dryRun ? ' [dry-run]' : '');
+
+        try {
+            $runProcess = fn () => $this->recorder->record(
+                type: RunHistory::TYPE_NAVIDROME_SYNC,
+                reference: 'scrobbles',
+                label: $label,
+                action: fn (RunHistory $entry) => $this->syncService->process(
+                    limit: $limit,
+                    dryRun: $dryRun,
+                    toleranceSeconds: $tolerance,
+                    run: $entry,
+                    progress: function (int $c, int $m, int $d, int $u) use ($io): void {
+                        $io->writeln(sprintf('  considered=%d matched=%d duplicates=%d unmatched=%d', $c, $m, $d, $u));
+                    },
+                ),
+                extractMetrics: static fn (NavidromeSyncReport $r) => [
+                    'prepared' => $r->prepared,
+                    'considered' => $r->considered,
+                    'matched' => $r->matched,
+                    'duplicates' => $r->duplicates,
+                    'unmatched' => $r->unmatched,
+                    'skipped' => $r->skipped,
+                    'backup' => $r->backupPath,
+                    'dry_run' => $r->dryRun,
+                ],
+            );
+
+            $report = $autoStop && !$dryRun
+                ? $this->container->runWithNavidromeStopped($runProcess)
+                : $runProcess();
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->newLine();
+        $io->success(sprintf(
+            '%s done. prepared=%d considered=%d matched=%d duplicates=%d unmatched=%d skipped=%d',
+            $dryRun ? 'Dry-run' : 'Sync',
+            $report->prepared,
+            $report->considered,
+            $report->matched,
+            $report->duplicates,
+            $report->unmatched,
+            $report->skipped,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\ScrobbleSync;
+use App\Message\SyncNavidromeMessage;
+use App\Repository\ScrobbleSyncRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+class NavidromeSyncController extends AbstractController
+{
+    #[Route('/navidrome/sync', name: 'app_navidrome_sync', methods: ['GET'])]
+    public function index(ScrobbleSyncRepository $syncRepo): Response
+    {
+        return $this->render('navidrome/sync.html.twig', [
+            'pending' => $syncRepo->countPendingForTarget(ScrobbleSync::TARGET_NAVIDROME),
+            'matched' => $syncRepo->countByTargetStatus(ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_MATCHED),
+            'unmatched' => $syncRepo->countByTargetStatus(ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_UNMATCHED),
+            'duplicates' => $syncRepo->countByTargetStatus(ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_DUPLICATE),
+        ]);
+    }
+
+    #[Route('/navidrome/sync', name: 'app_navidrome_sync_post', methods: ['POST'])]
+    public function sync(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_sync', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $dryRun = (bool) $request->request->get('dry_run');
+        $autoStop = (bool) $request->request->get('auto_stop');
+        $limit = max(0, (int) $request->request->get('limit', 0));
+        $tolerance = max(0, (int) $request->request->get('tolerance', 60));
+
+        $bus->dispatch(new SyncNavidromeMessage(
+            limit: $limit,
+            dryRun: $dryRun,
+            toleranceSeconds: $tolerance,
+            autoStop: $autoStop,
+        ));
+
+        $this->addFlash('success', 'Sync Navidrome lancé en arrière-plan. Suivez la progression dans l\'historique.');
+
+        return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/navidrome/unmatched', name: 'app_navidrome_unmatched', methods: ['GET'])]
+    public function unmatched(Request $request, ScrobbleSyncRepository $syncRepo): Response
+    {
+        $page = max(1, (int) $request->query->get('page', 1));
+        $perPage = 50;
+
+        $rows = $syncRepo->aggregateUnmatched(ScrobbleSync::TARGET_NAVIDROME, $perPage, ($page - 1) * $perPage);
+        $total = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
+
+        return $this->render('navidrome/unmatched.html.twig', [
+            'rows' => $rows,
+            'total' => $total,
+            'page' => $page,
+            'pages' => max(1, (int) ceil($total / $perPage)),
+        ]);
+    }
+}

--- a/src/Docker/ContainerStatus.php
+++ b/src/Docker/ContainerStatus.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Docker;
+
+enum ContainerStatus: string
+{
+    case Disabled = 'disabled';
+    case Running = 'running';
+    case Stopped = 'stopped';
+    case NotFound = 'notfound';
+    case Unknown = 'unknown';
+
+    public function isSafeToWrite(): bool
+    {
+        return match ($this) {
+            self::Running, self::Unknown => false,
+            self::Stopped, self::NotFound, self::Disabled => true,
+        };
+    }
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Disabled => 'Désactivé',
+            self::Running => 'En cours',
+            self::Stopped => 'Arrêté',
+            self::NotFound => 'Introuvable',
+            self::Unknown => 'Indéterminé',
+        };
+    }
+}

--- a/src/Docker/DockerCli.php
+++ b/src/Docker/DockerCli.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Docker;
+
+use Symfony\Component\Process\Exception\RuntimeException as ProcessRuntimeException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Thin wrapper around `docker` CLI invocations. Made non-final so tests can
+ * override `runProcess()` with a fake — the manager is the unit of behaviour
+ * we care about, the CLI binary is a transport detail.
+ */
+class DockerCli
+{
+    public function __construct(
+        private readonly string $binary = 'docker',
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>|null  null when the container does not exist
+     */
+    public function inspectState(string $containerName): ?array
+    {
+        $result = $this->runProcess(
+            [$this->binary, 'inspect', $containerName, '--format', '{{json .State}}'],
+            5,
+        );
+
+        if ($result['exitCode'] !== 0) {
+            $stderr = $result['stderr'];
+            // Docker prints "Error: No such object: <name>" when the container is unknown.
+            if (stripos($stderr, 'no such object') !== false) {
+                return null;
+            }
+            throw new NavidromeContainerException(sprintf(
+                'docker inspect a échoué (code %d) : %s',
+                $result['exitCode'],
+                trim($stderr) !== '' ? trim($stderr) : trim($result['stdout']),
+            ));
+        }
+
+        $decoded = json_decode(trim($result['stdout']), true);
+        if (!is_array($decoded)) {
+            throw new NavidromeContainerException('Sortie JSON inattendue depuis `docker inspect`.');
+        }
+
+        return $decoded;
+    }
+
+    public function start(string $containerName): void
+    {
+        $result = $this->runProcess([$this->binary, 'start', $containerName], 30);
+        if ($result['exitCode'] !== 0) {
+            throw new NavidromeContainerException(sprintf(
+                'docker start a échoué : %s',
+                trim($result['stderr']) !== '' ? trim($result['stderr']) : trim($result['stdout']),
+            ));
+        }
+    }
+
+    public function stop(string $containerName, int $timeoutSeconds = 10): void
+    {
+        $result = $this->runProcess(
+            [$this->binary, 'stop', '-t', (string) $timeoutSeconds, $containerName],
+            max(30, $timeoutSeconds + 20),
+        );
+        if ($result['exitCode'] !== 0) {
+            throw new NavidromeContainerException(sprintf(
+                'docker stop a échoué : %s',
+                trim($result['stderr']) !== '' ? trim($result['stderr']) : trim($result['stdout']),
+            ));
+        }
+    }
+
+    /**
+     * @param  list<string>                                      $command
+     * @return array{exitCode: int, stdout: string, stderr: string}
+     */
+    protected function runProcess(array $command, int $timeoutSeconds): array
+    {
+        $process = new Process($command);
+        $process->setTimeout($timeoutSeconds);
+        try {
+            $process->run();
+        } catch (ProcessRuntimeException $e) {
+            // Most common: the docker binary is missing from PATH.
+            throw new NavidromeContainerException(sprintf(
+                'Impossible d\'exécuter `%s` : %s',
+                $command[0] ?? 'docker',
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        return [
+            'exitCode' => $process->getExitCode() ?? -1,
+            'stdout' => $process->getOutput(),
+            'stderr' => $process->getErrorOutput(),
+        ];
+    }
+}

--- a/src/Docker/NavidromeContainerConfig.php
+++ b/src/Docker/NavidromeContainerConfig.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Docker;
+
+final class NavidromeContainerConfig
+{
+    public function __construct(
+        public readonly string $containerName,
+        public readonly int $stopTimeoutSeconds = 60,
+        public readonly int $stopWaitCeilingSeconds = 30,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->containerName !== '';
+    }
+}

--- a/src/Docker/NavidromeContainerException.php
+++ b/src/Docker/NavidromeContainerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Docker;
+
+class NavidromeContainerException extends \RuntimeException
+{
+}

--- a/src/Docker/NavidromeContainerManager.php
+++ b/src/Docker/NavidromeContainerManager.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Docker;
+
+use App\Navidrome\NavidromeDbBackup;
+
+class NavidromeContainerManager
+{
+    public function __construct(
+        private readonly DockerCli $cli,
+        private readonly NavidromeContainerConfig $config,
+        private readonly NavidromeDbBackup $backup,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->config->isConfigured();
+    }
+
+    public function getStatus(): ContainerStatus
+    {
+        if (!$this->config->isConfigured()) {
+            return ContainerStatus::Disabled;
+        }
+
+        try {
+            $state = $this->cli->inspectState($this->config->containerName);
+        } catch (NavidromeContainerException) {
+            return ContainerStatus::Unknown;
+        }
+
+        if ($state === null) {
+            return ContainerStatus::NotFound;
+        }
+
+        $running = $state['Running'] ?? null;
+        if ($running === true) {
+            return ContainerStatus::Running;
+        }
+
+        return ContainerStatus::Stopped;
+    }
+
+    public function start(): void
+    {
+        if (!$this->config->isConfigured()) {
+            throw new NavidromeContainerException('NAVIDROME_CONTAINER_NAME n\'est pas renseignée.');
+        }
+        $this->cli->start($this->config->containerName);
+    }
+
+    public function stop(): void
+    {
+        if (!$this->config->isConfigured()) {
+            throw new NavidromeContainerException('NAVIDROME_CONTAINER_NAME n\'est pas renseignée.');
+        }
+        $this->cli->stop($this->config->containerName, $this->config->stopTimeoutSeconds);
+    }
+
+    /**
+     * Throws when it would be unsafe to write to the Navidrome database.
+     *
+     * - Container running → always unsafe (unless $force).
+     * - Container status unknown (socket missing, daemon down…) → unsafe by
+     *   default, since we can't confirm Navidrome is stopped.
+     * - Container stopped / not found / feature disabled → safe.
+     */
+    public function assertSafeToWrite(bool $force = false): void
+    {
+        if ($force) {
+            return;
+        }
+
+        $status = $this->getStatus();
+        if ($status->isSafeToWrite()) {
+            return;
+        }
+
+        $name = $this->config->containerName;
+        $message = match ($status) {
+            ContainerStatus::Running => sprintf(
+                'Le conteneur Navidrome « %s » tourne actuellement. Arrêtez-le depuis le dashboard ou via `docker stop %s` avant de lancer une opération qui écrit dans la DB Navidrome.',
+                $name,
+                $name,
+            ),
+            ContainerStatus::Unknown => sprintf(
+                'Impossible de vérifier l\'état du conteneur Navidrome « %s » (socket Docker non monté ou inaccessible). Par sécurité l\'opération est bloquée. Utilisez --force en CLI pour outrepasser, ou videz NAVIDROME_CONTAINER_NAME pour désactiver le check.',
+                $name,
+            ),
+            default => 'Pré-flight Navidrome impossible.',
+        };
+
+        throw new NavidromeContainerException($message);
+    }
+
+    /**
+     * Run $action with Navidrome guaranteed stopped, then restart it if
+     * we stopped it ourselves. Restart happens in a finally-equivalent
+     * block, so an action that throws still leaves Navidrome running —
+     * unless the post-action quick_check detects corruption, in which
+     * case we restore the pre-action snapshot before restart.
+     *
+     * Defense in depth around $action():
+     *  1. `docker stop -t <NAVIDROME_STOP_TIMEOUT_SECONDS>` — long enough
+     *     for Navidrome's SQLite WAL to checkpoint cleanly (default 60s,
+     *     vs Docker's 10s default which used to SIGKILL mid-flush and
+     *     leave a half-written WAL — the corruption pattern from #118).
+     *  2. Poll `docker inspect` until Running=false — we never trust
+     *     `docker stop` returning success alone.
+     *  3. Snapshot the SQLite file (and its `-wal`/`-shm` siblings) to
+     *     `<dbPath>.backup-<ts>` so any future write that goes wrong is
+     *     recoverable with a single `cp`. Last 3 by default (configurable).
+     *  4. PRE-action `PRAGMA quick_check` — if the DB is already broken
+     *     (e.g. from a previous bad shutdown) we abort before writing
+     *     into it and making it worse. Skippable via $skipPreCheck for
+     *     `app:navidrome:db:restore` which by definition runs on a DB
+     *     that's already in trouble.
+     *  5. POST-action `PRAGMA quick_check` — catches the case where
+     *     $action() crashed mid-write and left the DB inconsistent. If
+     *     it fails we automatically restore the pre-action snapshot
+     *     (step 3) before restarting Navidrome, so Navidrome never
+     *     reopens a corrupt DB.
+     *
+     * - Feature disabled (`NAVIDROME_CONTAINER_NAME` empty) → run as-is,
+     *   skip all the above (we don't know the DB lifecycle).
+     * - Status `Stopped` / `NotFound` → still backup + quickCheck before
+     *   the action (same risk profile), but don't restart something we
+     *   didn't stop.
+     * - Status `Running` → stop, wait, backup, check, run, post-check,
+     *   restart (always, unless restore failed and DB is in limbo).
+     * - Status `Unknown` → throw, since we can't safely orchestrate
+     *   stop/start without confirming current state.
+     *
+     * If both the action and the restart fail, the restart failure is
+     * raised with the action error chained as `previous`. If the
+     * post-action quickCheck fails AND the restore fails, Navidrome is
+     * NOT restarted (DB in unknown state) and the user is told to run
+     * `app:navidrome:db:restore` manually.
+     *
+     * @template T
+     * @param  callable(): T $action
+     * @param  bool $skipPreCheck Skip the pre-action `PRAGMA quick_check`
+     *                            — reserved for `app:navidrome:db:restore`
+     *                            which needs to operate on a DB that the
+     *                            check would refuse to open.
+     * @return T
+     */
+    public function runWithNavidromeStopped(callable $action, bool $skipPreCheck = false): mixed
+    {
+        if (!$this->config->isConfigured()) {
+            return $action();
+        }
+
+        $status = $this->getStatus();
+        if ($status === ContainerStatus::Unknown) {
+            throw new NavidromeContainerException(sprintf(
+                'Statut du conteneur Navidrome « %s » indéterminé — impossible d\'orchestrer un stop/restart automatique. Vérifier le mount /var/run/docker.sock.',
+                $this->config->containerName,
+            ));
+        }
+
+        $weStoppedIt = false;
+        if ($status === ContainerStatus::Running) {
+            $this->stop();
+            $weStoppedIt = true;
+            $this->waitUntilStopped($this->config->stopWaitCeilingSeconds);
+        }
+
+        // Backup + quick_check apply whether we stopped Navidrome ourselves
+        // or it was already down — either way we're about to mutate the
+        // file and we want a rollback artefact + a sanity check first.
+        $this->backup->backup();
+
+        $actionException = null;
+        $actionRan = false;
+        $result = null;
+        try {
+            if (!$skipPreCheck) {
+                $this->backup->quickCheck();
+            }
+            $actionRan = true;
+            $result = $action();
+        } catch (\Throwable $e) {
+            $actionException = $e;
+        }
+
+        // Post-action quickCheck only if the action actually ran. When the
+        // pre-check failed, the DB was already corrupt before our action,
+        // there's no new information to gather and we shouldn't try to
+        // overwrite the existing state.
+        $postCheckFailure = null;
+        if ($actionRan) {
+            try {
+                $this->backup->quickCheck();
+            } catch (\Throwable $e) {
+                $postCheckFailure = $e;
+            }
+        }
+
+        if ($postCheckFailure !== null) {
+            return $this->handlePostActionCorruption(
+                actionException: $actionException,
+                postCheckFailure: $postCheckFailure,
+                weStoppedIt: $weStoppedIt,
+            );
+        }
+
+        if ($weStoppedIt) {
+            try {
+                $this->start();
+            } catch (\Throwable $startException) {
+                if ($actionException !== null) {
+                    throw new NavidromeContainerException(
+                        sprintf(
+                            '%s — et le redémarrage du conteneur Navidrome a aussi échoué : %s',
+                            $actionException->getMessage(),
+                            $startException->getMessage(),
+                        ),
+                        0,
+                        $actionException,
+                    );
+                }
+                throw $startException;
+            }
+        }
+
+        if ($actionException !== null) {
+            throw $actionException;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reached when the post-action quick_check detected corruption. We
+     * always try to restore the pre-action snapshot before letting
+     * Navidrome reopen the file. Two terminal states :
+     *  - restore OK + restart OK → throw an explicit corruption error so
+     *    the user knows the action was rolled back ;
+     *  - restore failed → throw compound error, do NOT restart Navidrome
+     *    (it would reopen a broken DB and propagate the corruption).
+     *
+     * Always throws ; the `mixed` return type just satisfies the parent
+     * method's signature.
+     */
+    private function handlePostActionCorruption(
+        ?\Throwable $actionException,
+        \Throwable $postCheckFailure,
+        bool $weStoppedIt,
+    ): mixed {
+        try {
+            $restoredFrom = $this->backup->restore(null);
+        } catch (\Throwable $restoreException) {
+            throw new NavidromeContainerException(
+                sprintf(
+                    'DB Navidrome corrompue après l\'action ET la restore automatique a échoué : %s. Restaurez manuellement (`app:navidrome:db:restore`) avant de redémarrer Navidrome.',
+                    $restoreException->getMessage(),
+                ),
+                0,
+                $actionException ?? $postCheckFailure,
+            );
+        }
+
+        if ($weStoppedIt) {
+            try {
+                $this->start();
+            } catch (\Throwable $startException) {
+                throw new NavidromeContainerException(
+                    sprintf(
+                        'DB Navidrome corrompue après l\'action — restaurée depuis %s, mais le redémarrage du conteneur a échoué : %s',
+                        $restoredFrom,
+                        $startException->getMessage(),
+                    ),
+                    0,
+                    $actionException ?? $postCheckFailure,
+                );
+            }
+        }
+
+        $actionDetail = $actionException !== null
+            ? sprintf(' Erreur d\'origine de l\'action : %s', $actionException->getMessage())
+            : '';
+
+        throw new NavidromeContainerException(
+            sprintf(
+                'DB Navidrome corrompue après l\'action — restaurée automatiquement depuis %s.%s',
+                $restoredFrom,
+                $actionDetail,
+            ),
+            0,
+            $actionException ?? $postCheckFailure,
+        );
+    }
+
+    /**
+     * Block until `docker inspect` reports Running=false, or the ceiling
+     * (in seconds) is reached. The first probe runs immediately so a
+     * cleanly-stopped container exits without a sleep ; subsequent probes
+     * are spaced 500ms apart. Throws on ceiling so the caller never
+     * proceeds to write while Navidrome is still alive.
+     */
+    private function waitUntilStopped(int $maxSeconds): void
+    {
+        $deadline = microtime(true) + max(1, $maxSeconds);
+
+        while (true) {
+            try {
+                $state = $this->cli->inspectState($this->config->containerName);
+            } catch (NavidromeContainerException $e) {
+                throw new NavidromeContainerException(sprintf(
+                    'Impossible de confirmer l\'arrêt du conteneur Navidrome « %s » : %s. Abandon avant écriture pour éviter la corruption.',
+                    $this->config->containerName,
+                    $e->getMessage(),
+                ), 0, $e);
+            }
+
+            // null = container vanished (compose down) ; Running:false = stopped.
+            if ($state === null || ($state['Running'] ?? null) !== true) {
+                return;
+            }
+
+            if (microtime(true) >= $deadline) {
+                throw new NavidromeContainerException(sprintf(
+                    'Le conteneur Navidrome « %s » est toujours en cours %ds après `docker stop`. Abandon avant écriture pour éviter la corruption SQLite.',
+                    $this->config->containerName,
+                    $maxSeconds,
+                ));
+            }
+
+            usleep(500_000);
+        }
+    }
+}

--- a/src/Entity/ScrobbleSync.php
+++ b/src/Entity/ScrobbleSync.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Entity;
+
+use App\Doctrine\UtcDateTimeImmutableType;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Tracks the sync status of a scrobble for a given target (navidrome, strawberry).
+ * Created lazily when a sync command runs for the first time on a target.
+ *
+ * UNIQUE (scrobble_id, target) ensures one status row per scrobble per target.
+ */
+#[ORM\Entity(repositoryClass: ScrobbleSyncRepository::class)]
+#[ORM\Table(name: 'scrobble_sync')]
+#[ORM\UniqueConstraint(name: 'uniq_scrobble_sync_scrobble_target', columns: ['scrobble_id', 'target'])]
+#[ORM\Index(columns: ['target', 'status'], name: 'idx_scrobble_sync_target_status')]
+#[ORM\Index(columns: ['run_id'], name: 'idx_scrobble_sync_run')]
+class ScrobbleSync
+{
+    public const TARGET_NAVIDROME = 'navidrome';
+    public const TARGET_STRAWBERRY = 'strawberry';
+
+    public const STATUS_PENDING = 'pending';
+    public const STATUS_MATCHED = 'matched';
+    public const STATUS_DUPLICATE = 'duplicate';
+    public const STATUS_UNMATCHED = 'unmatched';
+    public const STATUS_SKIPPED = 'skipped';
+
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\ManyToOne(targetEntity: Scrobble::class)]
+    #[ORM\JoinColumn(nullable: false, onDelete: 'CASCADE')]
+    private Scrobble $scrobble;
+
+    #[ORM\Column(length: 32)]
+    private string $target;
+
+    #[ORM\Column(length: 16)]
+    private string $status = self::STATUS_PENDING;
+
+    /** Navidrome media_file_id or Strawberry rowid, depending on target. */
+    #[ORM\Column(length: 255, nullable: true)]
+    private ?string $targetId = null;
+
+    /** Which matching heuristic resolved this scrobble (mbid, triplet, couple…). */
+    #[ORM\Column(length: 32, nullable: true)]
+    private ?string $strategy = null;
+
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME, nullable: true)]
+    private ?\DateTimeImmutable $attemptedAt = null;
+
+    #[ORM\Column(type: UtcDateTimeImmutableType::NAME, nullable: true)]
+    private ?\DateTimeImmutable $syncedAt = null;
+
+    #[ORM\ManyToOne(targetEntity: RunHistory::class)]
+    #[ORM\JoinColumn(nullable: true, onDelete: 'SET NULL')]
+    private ?RunHistory $run = null;
+
+    public function __construct(Scrobble $scrobble, string $target)
+    {
+        $this->scrobble = $scrobble;
+        $this->target = $target;
+    }
+
+    public function getId(): ?int { return $this->id; }
+    public function getScrobble(): Scrobble { return $this->scrobble; }
+    public function getTarget(): string { return $this->target; }
+    public function getStatus(): string { return $this->status; }
+    public function getTargetId(): ?string { return $this->targetId; }
+    public function getStrategy(): ?string { return $this->strategy; }
+    public function getAttemptedAt(): ?\DateTimeImmutable { return $this->attemptedAt; }
+    public function getSyncedAt(): ?\DateTimeImmutable { return $this->syncedAt; }
+    public function getRun(): ?RunHistory { return $this->run; }
+
+    public function markMatched(string $targetId, string $strategy, ?RunHistory $run = null): void
+    {
+        $this->status = self::STATUS_MATCHED;
+        $this->targetId = $targetId;
+        $this->strategy = $strategy;
+        $this->attemptedAt = new \DateTimeImmutable();
+        $this->syncedAt = new \DateTimeImmutable();
+        $this->run = $run;
+    }
+
+    public function markDuplicate(string $targetId, string $strategy, ?RunHistory $run = null): void
+    {
+        $this->status = self::STATUS_DUPLICATE;
+        $this->targetId = $targetId;
+        $this->strategy = $strategy;
+        $this->attemptedAt = new \DateTimeImmutable();
+        $this->run = $run;
+    }
+
+    public function markUnmatched(?RunHistory $run = null): void
+    {
+        $this->status = self::STATUS_UNMATCHED;
+        $this->attemptedAt = new \DateTimeImmutable();
+        $this->run = $run;
+    }
+
+    public function markSkipped(?RunHistory $run = null): void
+    {
+        $this->status = self::STATUS_SKIPPED;
+        $this->attemptedAt = new \DateTimeImmutable();
+        $this->run = $run;
+    }
+
+    public function resetToPending(): void
+    {
+        $this->status = self::STATUS_PENDING;
+        $this->attemptedAt = null;
+        $this->syncedAt = null;
+        $this->run = null;
+    }
+}

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -82,7 +82,7 @@ class LastFmClient
                     title: (string) ($track['name'] ?? ''),
                     album: (string) ($track['album']['#text'] ?? ''),
                     albumArtist: '',
-                    mbidTrack: ($track['mbid'] ?? '') !== '' ? (string) $track['mbid'] : null,
+                    mbid: ($track['mbid'] ?? '') !== '' ? (string) $track['mbid'] : null,
                     mbidArtist: ($track['artist']['mbid'] ?? '') !== '' ? (string) $track['artist']['mbid'] : null,
                     mbidAlbum: ($track['album']['mbid'] ?? '') !== '' ? (string) $track['album']['mbid'] : null,
                     playedAt: (new \DateTimeImmutable('@' . $ts))->setTimezone(new \DateTimeZone('UTC')),

--- a/src/LastFm/LastFmFetcher.php
+++ b/src/LastFm/LastFmFetcher.php
@@ -61,7 +61,7 @@ class LastFmFetcher
                 title: $scrobble->title,
                 album: $scrobble->album !== '' ? $scrobble->album : null,
                 albumArtist: $scrobble->albumArtist !== '' ? $scrobble->albumArtist : null,
-                mbidTrack: $scrobble->mbidTrack,
+                mbidTrack: $scrobble->mbid,
                 mbidArtist: $scrobble->mbidArtist,
                 mbidAlbum: $scrobble->mbidAlbum,
                 playedAt: $scrobble->playedAt,

--- a/src/LastFm/LastFmScrobble.php
+++ b/src/LastFm/LastFmScrobble.php
@@ -2,17 +2,22 @@
 
 namespace App\LastFm;
 
+/**
+ * Lightweight DTO used by the matching cascade (ScrobbleMatcher).
+ * For storage, see App\Entity\Scrobble which carries the full API payload.
+ */
 final class LastFmScrobble
 {
     public function __construct(
         public readonly string $artist,
         public readonly string $title,
         public readonly string $album,
-        public readonly string $albumArtist,
-        public readonly ?string $mbidTrack,
-        public readonly ?string $mbidArtist,
-        public readonly ?string $mbidAlbum,
+        public readonly ?string $mbid,
         public readonly \DateTimeImmutable $playedAt,
+        // Additional fields stored in Scrobble but not used by ScrobbleMatcher.
+        public readonly string $albumArtist = '',
+        public readonly ?string $mbidArtist = null,
+        public readonly ?string $mbidAlbum = null,
         public readonly bool $loved = false,
         public readonly ?string $imageUrl = null,
     ) {

--- a/src/LastFm/MatchResult.php
+++ b/src/LastFm/MatchResult.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\LastFm;
+
+final class MatchResult
+{
+    public const STATUS_MATCHED = 'matched';
+    public const STATUS_SKIPPED = 'skipped';
+    public const STATUS_UNMATCHED = 'unmatched';
+
+    public const CACHE_HIT_POSITIVE = 'hit-positive';
+    public const CACHE_HIT_NEGATIVE = 'hit-negative';
+    public const CACHE_MISS = 'miss';
+
+    private function __construct(
+        public readonly string $status,
+        public readonly ?string $mediaFileId,
+        public readonly ?string $strategy = null,
+        public readonly ?string $cacheStatus = null,
+    ) {
+    }
+
+    public static function matched(string $mediaFileId, ?string $strategy = null, ?string $cacheStatus = null): self
+    {
+        return new self(self::STATUS_MATCHED, $mediaFileId, $strategy, $cacheStatus);
+    }
+
+    public static function skipped(): self
+    {
+        return new self(self::STATUS_SKIPPED, null);
+    }
+
+    public static function unmatched(?string $cacheStatus = null): self
+    {
+        return new self(self::STATUS_UNMATCHED, null, null, $cacheStatus);
+    }
+}

--- a/src/LastFm/ScrobbleMatcher.php
+++ b/src/LastFm/ScrobbleMatcher.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\LastFm;
+
+use App\Entity\LastFmMatchCacheEntry;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmAliasRepository;
+use App\Repository\LastFmArtistAliasRepository;
+use App\Repository\LastFmMatchCacheRepository;
+
+/**
+ * Encapsulates the matching cascade Last.fm scrobble → Navidrome media_file.
+ * Used by the buffer processor ({@see LastFmBufferProcessor}) and the
+ * rematch service ({@see \App\Service\LastFmRematchService}) so the cascade
+ * lives in one place.
+ *
+ * Cascade order (each step short-circuits on success) :
+ *   1. Track-level manual alias → STATUS_MATCHED or STATUS_SKIPPED (skips cache)
+ *   2. Artist-level alias       → rewrite artist name, fall through to next step
+ *   3. Match cache lookup       → positive hit returns matched, negative
+ *                                 (non-stale) hit returns unmatched. Skips
+ *                                 the cascade so we don't re-run SQL or call
+ *                                 Last.fm `track.getInfo` for known answers.
+ *   4. MBID                     → STATUS_MATCHED
+ *   5. Triplet (artist, title, album) when album is non-empty → STATUS_MATCHED
+ *   6. Couple (artist, title) with strip-feat / strip-version-markers / etc.
+ *   7. Last.fm `track.getInfo`  → recovers a missing MBID or applies the
+ *                                 « autocorrect » spelling (re-runs steps
+ *                                 4-6 against the corrected names)
+ *   8. Fuzzy Levenshtein (opt-in via fuzzyMaxDistance > 0)
+ *   → STATUS_UNMATCHED if everything fails. Both successes and failures are
+ *   memoized in the cache so subsequent runs short-circuit at step 3.
+ */
+class ScrobbleMatcher
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly ?LastFmAliasRepository $aliasRepository = null,
+        private readonly int $fuzzyMaxDistance = 0,
+        private readonly ?LastFmArtistAliasRepository $artistAliasRepository = null,
+        private readonly ?LastFmMatchCacheRepository $cacheRepository = null,
+        private readonly int $cacheTtlDays = 30,
+        private readonly ?LastFmClient $lastFmClient = null,
+        private readonly ?string $lastFmApiKey = null,
+    ) {
+    }
+
+    public function match(LastFmScrobble $scrobble): MatchResult
+    {
+        // Track-level manual alias overrides every heuristic (including
+        // the cache). A `null` target means « ignore this scrobble silently »
+        // (skipped). We don't write to the cache here — the alias is the
+        // source of truth, no need to memoize.
+        $alias = $this->aliasRepository?->findByScrobble($scrobble->artist, $scrobble->title);
+        if ($alias !== null) {
+            if ($alias->isSkip()) {
+                return MatchResult::skipped();
+            }
+            $mfid = $alias->getTargetMediaFileId();
+            if ($mfid !== null) {
+                return MatchResult::matched($mfid);
+            }
+        }
+
+        // Artist-level alias: rewrite the source artist before any
+        // heuristic. Lets a single mapping cover ALL tracks of a renamed
+        // artist (e.g. "La Ruda Salska" → "La Ruda" matches every La Ruda
+        // track in the library without needing a per-track alias). We
+        // re-key on the rewritten artist for the cache lookup below —
+        // that's what the cascade sees, so the cache stays consistent.
+        $resolvedArtist = $this->artistAliasRepository?->resolve($scrobble->artist);
+        if ($resolvedArtist !== null && $resolvedArtist !== '' && $resolvedArtist !== $scrobble->artist) {
+            $scrobble = new LastFmScrobble(
+                artist: $resolvedArtist,
+                title: $scrobble->title,
+                album: $scrobble->album,
+                mbid: $scrobble->mbid,
+                playedAt: $scrobble->playedAt,
+            );
+        }
+
+        // Match cache lookup. Positive entries are trusted forever (until
+        // an alias mutation invalidates them) ; negatives expire after
+        // `cacheTtlDays` so we eventually retry the cascade for scrobbles
+        // whose answer might have changed (e.g. user added the track).
+        if ($this->cacheRepository !== null) {
+            $cached = $this->cacheRepository->findByCouple($scrobble->artist, $scrobble->title);
+            if ($cached !== null) {
+                if ($cached->isPositive()) {
+                    /** @var string $mfid (positive entries always have a non-null target) */
+                    $mfid = $cached->getTargetMediaFileId();
+
+                    return MatchResult::matched($mfid, $cached->getStrategy(), MatchResult::CACHE_HIT_POSITIVE);
+                }
+                if (!$cached->isStale($this->cacheTtlDays)) {
+                    return MatchResult::unmatched(MatchResult::CACHE_HIT_NEGATIVE);
+                }
+                // Stale negative: fall through to the cascade. The next
+                // recordPositive/Negative below will overwrite this row.
+            }
+        }
+
+        $cacheStatus = $this->cacheRepository !== null ? MatchResult::CACHE_MISS : null;
+        [$mfid, $strategy] = $this->runCascade($scrobble);
+
+        if ($mfid !== null && $strategy !== null) {
+            $this->cacheRepository?->recordPositive($scrobble->artist, $scrobble->title, $mfid, $strategy);
+
+            return MatchResult::matched($mfid, $strategy, $cacheStatus);
+        }
+
+        $this->cacheRepository?->recordNegative($scrobble->artist, $scrobble->title);
+
+        return MatchResult::unmatched($cacheStatus);
+    }
+
+    /**
+     * Runs the cascade past the alias / cache short-circuits. Returns
+     * `[mediaFileId, strategy]` on a hit, or `[null, null]` on miss. The
+     * strategy string matches one of `LastFmMatchCacheEntry::STRATEGY_*`
+     * so `match()` can persist it as-is.
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function runCascade(LastFmScrobble $scrobble): array
+    {
+        // Local-only steps : MBID, triplet, couple. Cheap, no API call.
+        $result = $this->runDbCascade($scrobble);
+        if ($result[0] !== null) {
+            return $result;
+        }
+
+        // Last.fm `track.getInfo` step : recovers scrobbles with no MBID
+        // (or a wrong text spelling) by asking Last.fm for the canonical
+        // form. Wrapped in an opt-in guard so test harnesses that don't
+        // configure the client don't make HTTP calls. Negative results
+        // get cached (in the caller) so we don't re-query on every
+        // rematch run — that's what makes #17 scale beyond the rate limit.
+        if ($this->lastFmClient !== null && $this->lastFmApiKey !== null && $this->lastFmApiKey !== '') {
+            $info = $this->lastFmClient->trackGetInfo(
+                $this->lastFmApiKey,
+                $scrobble->artist,
+                $scrobble->title,
+            );
+            // (a) Try the official MBID Last.fm gave us, even when the
+            //     scrobble already had one — Last.fm sometimes maps the
+            //     scrobble's recording-MBID to the canonical track-MBID.
+            if ($info->hasMbid()) {
+                /** @var string $mbid (hasMbid() guards against null/empty) */
+                $mbid = $info->mbid;
+                $mfid = $this->navidrome->findMediaFileByMbid($mbid);
+                if ($mfid !== null) {
+                    return [$mfid, LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION];
+                }
+            }
+            // (b) Try the autocorrected spelling. We re-run the local
+            //     DB cascade — but NOT the getInfo step itself, which
+            //     would loop. The artist alias was already applied
+            //     upstream, so the corrected names go straight to MBID
+            //     / triplet / couple lookups.
+            if ($info->hasCorrection()) {
+                $corrected = new LastFmScrobble(
+                    artist: $info->correctedArtist ?? $scrobble->artist,
+                    title: $info->correctedTitle ?? $scrobble->title,
+                    album: $scrobble->album,
+                    mbid: $info->mbid ?? $scrobble->mbid,
+                    playedAt: $scrobble->playedAt,
+                );
+                $result = $this->runDbCascade($corrected);
+                if ($result[0] !== null) {
+                    return [$result[0], LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION];
+                }
+            }
+        }
+
+        // Last resort: fuzzy Levenshtein, opt-in via LASTFM_FUZZY_MAX_DISTANCE.
+        if ($this->fuzzyMaxDistance > 0) {
+            $mfid = $this->navidrome->findMediaFileFuzzy(
+                $scrobble->artist,
+                $scrobble->title,
+                $this->fuzzyMaxDistance,
+            );
+            if ($mfid !== null) {
+                return [$mfid, LastFmMatchCacheEntry::STRATEGY_FUZZY];
+            }
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * Local-only sub-cascade : MBID → triplet → couple. Used both by the
+     * primary cascade and by the `track.getInfo` step (re-running on the
+     * autocorrected scrobble).
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function runDbCascade(LastFmScrobble $scrobble): array
+    {
+        if ($scrobble->mbid !== null) {
+            $mfid = $this->navidrome->findMediaFileByMbid($scrobble->mbid);
+            if ($mfid !== null) {
+                return [$mfid, LastFmMatchCacheEntry::STRATEGY_MBID];
+            }
+        }
+
+        // Try the artist+title+album triplet before the bare couple — the
+        // same song can live on a studio album AND a compilation AND a
+        // single, and the album disambiguates which row the user played.
+        if ($scrobble->album !== '') {
+            $mfid = $this->navidrome->findMediaFileByArtistTitleAlbum(
+                $scrobble->artist,
+                $scrobble->title,
+                $scrobble->album,
+            );
+            if ($mfid !== null) {
+                return [$mfid, LastFmMatchCacheEntry::STRATEGY_TRIPLET];
+            }
+        }
+
+        $mfid = $this->navidrome->findMediaFileByArtistTitle($scrobble->artist, $scrobble->title);
+        if ($mfid !== null) {
+            return [$mfid, LastFmMatchCacheEntry::STRATEGY_COUPLE];
+        }
+
+        return [null, null];
+    }
+}

--- a/src/Message/SyncNavidromeMessage.php
+++ b/src/Message/SyncNavidromeMessage.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Message;
+
+final class SyncNavidromeMessage
+{
+    public function __construct(
+        public readonly int $limit,
+        public readonly bool $dryRun,
+        public readonly int $toleranceSeconds,
+        public readonly bool $autoStop,
+    ) {
+    }
+}

--- a/src/MessageHandler/SyncNavidromeMessageHandler.php
+++ b/src/MessageHandler/SyncNavidromeMessageHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Message\SyncNavidromeMessage;
+use App\Navidrome\NavidromeSyncReport;
+use App\Navidrome\NavidromeSyncService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SyncNavidromeMessageHandler
+{
+    public function __construct(
+        private readonly NavidromeSyncService $syncService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly NavidromeContainerManager $container,
+    ) {
+    }
+
+    public function __invoke(SyncNavidromeMessage $message): void
+    {
+        $runProcess = fn () => $this->recorder->record(
+            type: RunHistory::TYPE_NAVIDROME_SYNC,
+            reference: 'scrobbles',
+            label: 'Navidrome sync' . ($message->dryRun ? ' [dry-run]' : ''),
+            action: fn (RunHistory $entry) => $this->syncService->process(
+                limit: $message->limit,
+                dryRun: $message->dryRun,
+                toleranceSeconds: $message->toleranceSeconds,
+                run: $entry,
+            ),
+            extractMetrics: static fn (NavidromeSyncReport $r) => [
+                'prepared' => $r->prepared,
+                'considered' => $r->considered,
+                'matched' => $r->matched,
+                'duplicates' => $r->duplicates,
+                'unmatched' => $r->unmatched,
+                'skipped' => $r->skipped,
+                'dry_run' => $r->dryRun,
+            ],
+        );
+
+        if ($message->autoStop && !$message->dryRun) {
+            $this->container->runWithNavidromeStopped($runProcess);
+        } else {
+            $runProcess();
+        }
+    }
+}

--- a/src/Navidrome/NavidromeDbBackup.php
+++ b/src/Navidrome/NavidromeDbBackup.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace App\Navidrome;
+
+/**
+ * Safety net around the Navidrome SQLite file. Three responsibilities:
+ *
+ *  1. {@see backup()} copies `<dbPath>` (and its `-wal` / `-shm` siblings
+ *     when present) to `<dbPath>.backup-<unix_ts>` just before any
+ *     write-mutating operation (`app:lastfm:process --auto-stop`,
+ *     `app:lastfm:rematch --auto-stop`, etc.). Old backups beyond
+ *     `$retention` are pruned.
+ *  2. {@see quickCheck()} opens the file SQLite read-only and runs
+ *     `PRAGMA quick_check` — a lightweight structural sanity test that
+ *     catches a half-flushed WAL or a SIGKILL-truncated header *before*
+ *     we open the DB for writes (which would aggravate the corruption).
+ *  3. {@see restore()} copies a previously-taken backup back over the
+ *     live DB (with sibling WAL/SHM handling). Sanity-checks the backup
+ *     first to refuse a zombie restore. Caller must ensure Navidrome is
+ *     stopped — this class does no orchestration.
+ *
+ * Used by `NavidromeContainerManager::runWithNavidromeStopped()` for the
+ * pre-action snapshot + post-action restore-on-corruption, and by
+ * `app:navidrome:db:restore` for manual rollbacks. Not a Doctrine
+ * connection: stays out of the DBAL UDF setup (`np_normalize`) so it can
+ * run on a potentially broken file without dragging the whole
+ * repository's machinery in.
+ */
+class NavidromeDbBackup
+{
+    public function __construct(
+        private readonly string $dbPath,
+        private readonly int $retention = 3,
+    ) {
+    }
+
+    /**
+     * Returns the path of the backup just created, or null when the source
+     * file does not exist (Navidrome never started, fresh install — the
+     * caller can decide to skip rather than fail).
+     */
+    public function backup(): ?string
+    {
+        if (!is_file($this->dbPath)) {
+            return null;
+        }
+
+        $timestamp = (new \DateTimeImmutable())->format('YmdHis');
+        $target = $this->dbPath . '.backup-' . $timestamp;
+
+        $this->copyAtomic($this->dbPath, $target);
+        // Copy WAL/SHM siblings so the restore replicates the *exact* state
+        // SQLite was in. Missing siblings = clean DB, nothing to copy.
+        foreach (['-wal', '-shm'] as $suffix) {
+            $sibling = $this->dbPath . $suffix;
+            if (is_file($sibling)) {
+                $this->copyAtomic($sibling, $target . $suffix);
+            }
+        }
+
+        $this->prune();
+
+        return $target;
+    }
+
+    /**
+     * Throws when the live DB fails the structural sanity test.
+     * No-op when the file is missing (treated as « nothing to check »).
+     */
+    public function quickCheck(): void
+    {
+        if (!is_file($this->dbPath)) {
+            return;
+        }
+
+        $this->quickCheckFile($this->dbPath);
+    }
+
+    /**
+     * Copies a previously-taken backup over the live DB. Verifies the
+     * backup is itself sound before clobbering anything — restoring a
+     * corrupted snapshot would be worse than the situation we're trying
+     * to recover from. Handles WAL/SHM siblings:
+     *  - if the backup has them, restore them too;
+     *  - if it doesn't, wipe any live siblings so SQLite doesn't try to
+     *    replay a stale WAL on top of the restored main DB.
+     *
+     * @param string|null $timestamp Backup timestamp `YYYYMMDDHHMMSS`.
+     *                               `null` = use the most recent backup.
+     * @return string Path of the backup that was used as the source.
+     * @throws \RuntimeException If no backup matches, the backup itself
+     *                           fails quick_check, or the copy/rename
+     *                           fails. The live DB is left untouched on
+     *                           any pre-write failure.
+     */
+    public function restore(?string $timestamp = null): string
+    {
+        $backupPath = $this->resolveBackup($timestamp);
+
+        // Sanity-check the backup BEFORE clobbering the live DB.
+        $this->quickCheckFile($backupPath);
+
+        $this->copyAtomic($backupPath, $this->dbPath);
+
+        // Sync siblings: the backup either has them (replicate) or
+        // doesn't (drop the live ones to avoid a stale-WAL replay).
+        foreach (['-wal', '-shm'] as $suffix) {
+            $backupSibling = $backupPath . $suffix;
+            $liveSibling = $this->dbPath . $suffix;
+            if (is_file($backupSibling)) {
+                $this->copyAtomic($backupSibling, $liveSibling);
+            } elseif (is_file($liveSibling)) {
+                @unlink($liveSibling);
+            }
+        }
+
+        // Confirm the live DB is sound after restore. If something went
+        // wrong (FS issue, partial copy), surface it now rather than at
+        // the next Navidrome start.
+        $this->quickCheck();
+
+        return $backupPath;
+    }
+
+    /**
+     * @return list<string> backup paths sorted from oldest to newest
+     */
+    public function listBackups(): array
+    {
+        $matches = glob($this->dbPath . '.backup-*') ?: [];
+        // Drop the -wal / -shm siblings — we only want the main backup files
+        // for retention bookkeeping.
+        $main = array_values(array_filter(
+            $matches,
+            static fn (string $p): bool => preg_match('/\.backup-\d+$/', $p) === 1,
+        ));
+        sort($main);
+
+        return $main;
+    }
+
+    /**
+     * Returns the timestamp (`YYYYMMDDHHMMSS`) of the most recent backup,
+     * or `null` if none exist. Convenience for CLI listings.
+     */
+    public function latestBackup(): ?string
+    {
+        $backups = $this->listBackups();
+        if ($backups === []) {
+            return null;
+        }
+        $path = end($backups);
+        if (preg_match('/\.backup-(\d+)$/', $path, $m) === 1) {
+            return $m[1];
+        }
+        return null;
+    }
+
+    private function resolveBackup(?string $timestamp): string
+    {
+        if ($timestamp !== null) {
+            $candidate = $this->dbPath . '.backup-' . $timestamp;
+            if (!is_file($candidate)) {
+                throw new \RuntimeException(sprintf(
+                    'Aucun backup trouvé pour le timestamp « %s » (cherché : %s).',
+                    $timestamp,
+                    $candidate,
+                ));
+            }
+            return $candidate;
+        }
+
+        $backups = $this->listBackups();
+        if ($backups === []) {
+            throw new \RuntimeException(sprintf(
+                'Aucun backup disponible à côté de %s.',
+                $this->dbPath,
+            ));
+        }
+
+        return end($backups);
+    }
+
+    private function quickCheckFile(string $path): void
+    {
+        try {
+            // URI form `mode=ro` opens the DB strictly read-only — without
+            // it, PDO defaults to RW which would have SQLite truncate or
+            // delete an unrecognized -wal sibling (we hit this with fake
+            // siblings during backup-restore round-trips). Read-only also
+            // suffices for `PRAGMA quick_check`.
+            $pdo = new \PDO('sqlite:file:' . $path . '?mode=ro', null, null, [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+            ]);
+            $stmt = $pdo->query('PRAGMA quick_check');
+            $result = $stmt !== false ? $stmt->fetchColumn() : false;
+        } catch (\PDOException $e) {
+            throw new \RuntimeException(sprintf(
+                'Le fichier SQLite %s est illisible : %s.',
+                $path,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        if ($result !== 'ok') {
+            throw new \RuntimeException(sprintf(
+                'PRAGMA quick_check a échoué sur %s : « %s ».',
+                $path,
+                is_string($result) ? $result : 'résultat inattendu',
+            ));
+        }
+    }
+
+    private function prune(): void
+    {
+        if ($this->retention <= 0) {
+            return;
+        }
+
+        $backups = $this->listBackups();
+        $excess = count($backups) - $this->retention;
+        if ($excess <= 0) {
+            return;
+        }
+
+        foreach (array_slice($backups, 0, $excess) as $stale) {
+            @unlink($stale);
+            @unlink($stale . '-wal');
+            @unlink($stale . '-shm');
+        }
+    }
+
+    private function copyAtomic(string $source, string $target): void
+    {
+        $tmp = $target . '.tmp';
+        if (!@copy($source, $tmp)) {
+            throw new \RuntimeException(sprintf('Backup impossible : copie %s → %s a échoué.', $source, $tmp));
+        }
+        if (!@rename($tmp, $target)) {
+            @unlink($tmp);
+            throw new \RuntimeException(sprintf('Backup impossible : rename %s → %s a échoué.', $tmp, $target));
+        }
+    }
+}

--- a/src/Navidrome/NavidromeSyncReport.php
+++ b/src/Navidrome/NavidromeSyncReport.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Navidrome;
+
+final class NavidromeSyncReport
+{
+    public int $prepared = 0;
+    public int $considered = 0;
+    public int $matched = 0;
+    public int $duplicates = 0;
+    public int $unmatched = 0;
+    public int $skipped = 0;
+    public bool $dryRun = false;
+    public ?string $backupPath = null;
+}

--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace App\Navidrome;
+
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\LastFm\LastFmScrobble;
+use App\LastFm\MatchResult;
+use App\LastFm\ScrobbleMatcher;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Matches pending scrobble_sync rows for the Navidrome target and writes
+ * the matched scrobbles into the Navidrome `scrobbles` table.
+ *
+ * Pre-conditions (enforced by the caller):
+ *  - Navidrome must be stopped (write to its SQLite while it runs corrupts WAL)
+ *  - A backup of navidrome.db should be taken before the first write
+ *
+ * Crash safety: each batch of BATCH_SIZE rows is committed atomically via
+ * BEGIN IMMEDIATE → INSERT → COMMIT. Doctrine ORM flush happens only after the
+ * Navidrome commit, so a crash between the two steps leaves the scrobble_sync
+ * row in `pending` and will be retried on the next run (dedup via
+ * scrobbleExistsNear).
+ */
+class NavidromeSyncService
+{
+    private const BATCH_SIZE = 100;
+
+    public function __construct(
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly ScrobbleMatcher $matcher,
+        private readonly NavidromeRepository $navidrome,
+        private readonly NavidromeDbBackup $backup,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    public function process(
+        int $limit = 0,
+        bool $dryRun = false,
+        int $toleranceSeconds = 60,
+        ?RunHistory $run = null,
+        ?callable $progress = null,
+    ): NavidromeSyncReport {
+        if (!$this->navidrome->hasScrobblesTable()) {
+            throw new \RuntimeException('Navidrome scrobbles table not found. Upgrade Navidrome to >= 0.55.');
+        }
+
+        $report = new NavidromeSyncReport();
+        $report->dryRun = $dryRun;
+
+        // 1. Prepare pending rows for any scrobbles not yet in scrobble_sync.
+        $report->prepared = $this->syncRepo->prepareForTarget(ScrobbleSync::TARGET_NAVIDROME);
+
+        $userId = $this->navidrome->resolveUserId();
+        $backupTaken = false;
+
+        /** @var list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch */
+        $batch = [];
+
+        try {
+            foreach ($this->syncRepo->streamPending(ScrobbleSync::TARGET_NAVIDROME, $limit) as $sync) {
+                $report->considered++;
+                $scrobble = $sync->getScrobble();
+
+                $lfmScrobble = new LastFmScrobble(
+                    artist: $scrobble->getArtist(),
+                    title: $scrobble->getTitle(),
+                    album: $scrobble->getAlbum() ?? '',
+                    mbid: $scrobble->getMbidTrack(),
+                    playedAt: $scrobble->getPlayedAt(),
+                );
+
+                $result = $this->matcher->match($lfmScrobble);
+
+                [$status, $matchedId, $strategy, $willInsert] = $this->classify(
+                    $result,
+                    $userId,
+                    $scrobble->getPlayedAt(),
+                    $toleranceSeconds,
+                    $batch,
+                    $dryRun,
+                    $report,
+                );
+
+                if (!$dryRun) {
+                    $batch[] = [
+                        'sync' => $sync,
+                        'matchedId' => $matchedId,
+                        'status' => $status,
+                        'strategy' => $strategy,
+                        'willInsert' => $willInsert,
+                    ];
+                }
+
+                if ($this->em->contains($sync)) {
+                    $this->em->detach($sync);
+                }
+
+                if (!$dryRun && count($batch) >= self::BATCH_SIZE) {
+                    if (!$backupTaken) {
+                        $report->backupPath = $this->backup->backup();
+                        $backupTaken = true;
+                    }
+                    $this->flushBatch($batch, $userId, $run);
+                    $batch = [];
+                }
+
+                if ($progress !== null && $report->considered % 50 === 0) {
+                    $progress($report->considered, $report->matched, $report->duplicates, $report->unmatched);
+                }
+            }
+
+            if (!$dryRun && $batch !== []) {
+                if (!$backupTaken) {
+                    $report->backupPath = $this->backup->backup();
+                }
+                $this->flushBatch($batch, $userId, $run);
+            }
+
+            if ($progress !== null) {
+                $progress($report->considered, $report->matched, $report->duplicates, $report->unmatched);
+            }
+        } finally {
+            $this->navidrome->walCheckpointTruncate();
+            $this->navidrome->closeWriteConnection();
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch
+     * @return array{0: string, 1: ?string, 2: ?string, 3: bool}
+     */
+    private function classify(
+        MatchResult $result,
+        string $userId,
+        \DateTimeImmutable $playedAt,
+        int $toleranceSeconds,
+        array $batch,
+        bool $dryRun,
+        NavidromeSyncReport $report,
+    ): array {
+        if ($result->status === MatchResult::STATUS_SKIPPED) {
+            $report->skipped++;
+            return [ScrobbleSync::STATUS_SKIPPED, null, null, false];
+        }
+
+        if ($result->mediaFileId === null) {
+            $report->unmatched++;
+            return [ScrobbleSync::STATUS_UNMATCHED, null, null, false];
+        }
+
+        $mediaFileId = $result->mediaFileId;
+
+        $isDuplicate = $this->navidrome->scrobbleExistsNear($userId, $mediaFileId, $playedAt, $toleranceSeconds)
+            || $this->batchHasNearScrobble($batch, $mediaFileId, $playedAt, $toleranceSeconds);
+
+        if ($isDuplicate) {
+            $report->duplicates++;
+            return [ScrobbleSync::STATUS_DUPLICATE, $mediaFileId, $result->strategy, false];
+        }
+
+        $report->matched++;
+        $willInsert = !$dryRun;
+        return [ScrobbleSync::STATUS_MATCHED, $mediaFileId, $result->strategy, $willInsert];
+    }
+
+    /**
+     * @param list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch
+     */
+    private function batchHasNearScrobble(array $batch, string $mediaFileId, \DateTimeImmutable $playedAt, int $toleranceSeconds): bool
+    {
+        $ts = $playedAt->getTimestamp();
+        foreach ($batch as $row) {
+            if (!$row['willInsert'] || $row['matchedId'] !== $mediaFileId) {
+                continue;
+            }
+            if (abs($row['sync']->getScrobble()->getPlayedAt()->getTimestamp() - $ts) <= $toleranceSeconds) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch
+     */
+    private function flushBatch(array $batch, string $userId, ?RunHistory $run): void
+    {
+        if ($batch === []) {
+            return;
+        }
+
+        // 1. Write to Navidrome atomically.
+        $this->navidrome->beginWriteTransaction();
+        try {
+            foreach ($batch as $row) {
+                if ($row['willInsert'] && $row['matchedId'] !== null) {
+                    $this->navidrome->insertScrobble($userId, $row['matchedId'], $row['sync']->getScrobble()->getPlayedAt());
+                }
+            }
+            $this->navidrome->commitWrite();
+        } catch (\Throwable $e) {
+            try {
+                $this->navidrome->rollbackWrite();
+            } catch (\Throwable) {
+            }
+            throw $e;
+        }
+
+        // 2. Update scrobble_sync rows and flush app-DB.
+        foreach ($batch as $row) {
+            $sync = $row['sync'];
+            match ($row['status']) {
+                ScrobbleSync::STATUS_MATCHED => $sync->markMatched((string) $row['matchedId'], (string) $row['strategy'], $run),
+                ScrobbleSync::STATUS_DUPLICATE => $sync->markDuplicate((string) $row['matchedId'], (string) $row['strategy'], $run),
+                ScrobbleSync::STATUS_UNMATCHED => $sync->markUnmatched($run),
+                ScrobbleSync::STATUS_SKIPPED => $sync->markSkipped($run),
+                default => null,
+            };
+            $this->em->persist($sync);
+        }
+        $this->em->flush();
+    }
+}

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Scrobble;
+use App\Entity\ScrobbleSync;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+/** @extends ServiceEntityRepository<ScrobbleSync> */
+class ScrobbleSyncRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry, private readonly EntityManagerInterface $em)
+    {
+        parent::__construct($registry, ScrobbleSync::class);
+    }
+
+    /**
+     * Create pending ScrobbleSync rows for every scrobble that doesn't have
+     * one yet for $target. Returns the number of rows created.
+     *
+     * Uses DBAL INSERT OR IGNORE for performance on large libraries.
+     */
+    public function prepareForTarget(string $target): int
+    {
+        return (int) $this->em->getConnection()->executeStatement(
+            'INSERT OR IGNORE INTO scrobble_sync (scrobble_id, target, status)
+             SELECT s.id, :target, :status
+             FROM scrobbles s
+             WHERE NOT EXISTS (
+                 SELECT 1 FROM scrobble_sync ss
+                 WHERE ss.scrobble_id = s.id AND ss.target = :target
+             )',
+            ['target' => $target, 'status' => ScrobbleSync::STATUS_PENDING],
+        );
+    }
+
+    /**
+     * Stream pending rows for $target, oldest scrobble first.
+     *
+     * @return iterable<ScrobbleSync>
+     */
+    public function streamPending(string $target, int $limit = 0): iterable
+    {
+        $qb = $this->createQueryBuilder('ss')
+            ->join('ss.scrobble', 's')
+            ->where('ss.target = :target')
+            ->andWhere('ss.status = :status')
+            ->setParameter('target', $target)
+            ->setParameter('status', ScrobbleSync::STATUS_PENDING)
+            ->orderBy('s.playedAt', 'ASC');
+
+        if ($limit > 0) {
+            $qb->setMaxResults($limit);
+        }
+
+        return $qb->getQuery()->toIterable();
+    }
+
+    public function countByTargetStatus(string $target, string $status): int
+    {
+        return (int) $this->createQueryBuilder('ss')
+            ->select('COUNT(ss.id)')
+            ->where('ss.target = :target')
+            ->andWhere('ss.status = :status')
+            ->setParameter('target', $target)
+            ->setParameter('status', $status)
+            ->getQuery()
+            ->getSingleScalarResult();
+    }
+
+    public function countPendingForTarget(string $target): int
+    {
+        return $this->countByTargetStatus($target, ScrobbleSync::STATUS_PENDING);
+    }
+
+    public function countUnmatchedForTarget(string $target): int
+    {
+        return $this->countByTargetStatus($target, ScrobbleSync::STATUS_UNMATCHED);
+    }
+
+    /**
+     * Reset unmatched rows for $target back to pending (for rematch).
+     */
+    public function resetUnmatchedToPending(string $target): int
+    {
+        return (int) $this->em->getConnection()->executeStatement(
+            'UPDATE scrobble_sync SET status = :pending, attempted_at = NULL, synced_at = NULL, run_id = NULL
+             WHERE target = :target AND status = :unmatched',
+            [
+                'pending' => ScrobbleSync::STATUS_PENDING,
+                'target' => $target,
+                'unmatched' => ScrobbleSync::STATUS_UNMATCHED,
+            ],
+        );
+    }
+
+    /**
+     * Aggregate unmatched rows grouped by (artist, title, album) for display.
+     *
+     * @return list<array{artist: string, title: string, album: string|null, count: int, last_played_at: string}>
+     */
+    public function aggregateUnmatched(string $target, int $limit = 50, int $offset = 0): array
+    {
+        /** @var list<array{artist: string, title: string, album: string|null, count: int, last_played_at: string}> */
+        return $this->em->getConnection()->fetchAllAssociative(
+            'SELECT s.artist, s.title, s.album, COUNT(*) AS count, MAX(s.played_at) AS last_played_at
+             FROM scrobble_sync ss
+             JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE ss.target = :target AND ss.status = :status
+             GROUP BY s.artist, s.title, s.album
+             ORDER BY count DESC, last_played_at DESC
+             LIMIT :lim OFFSET :off',
+            [
+                'target' => $target,
+                'status' => ScrobbleSync::STATUS_UNMATCHED,
+                'lim' => $limit,
+                'off' => $offset,
+            ],
+        );
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -12,6 +12,7 @@
 <nav class="bg-slate-800 text-slate-100 px-4 py-2 flex items-center gap-4 text-sm">
     <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white">Navidrome Tools</a>
     <a href="{{ path('app_lastfm_import') }}" class="hover:text-slate-300">Import Last.fm</a>
+    <a href="{{ path('app_navidrome_sync') }}" class="hover:text-slate-300">Sync Navidrome</a>
     <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
     <span class="flex-1"></span>
     <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>

--- a/templates/navidrome/sync.html.twig
+++ b/templates/navidrome/sync.html.twig
@@ -1,0 +1,73 @@
+{% extends 'base.html.twig' %}
+{% block title %}Sync Navidrome{% endblock %}
+{% block body %}
+    <h1 class="text-2xl font-semibold mb-4">Synchronisation → Navidrome</h1>
+
+    <div class="bg-amber-50 border border-amber-300 rounded-sm p-4 mb-6 text-sm text-amber-900">
+        <strong>Navidrome doit être arrêté</strong> pour éviter toute corruption SQLite.
+        Utilisez <code>--auto-stop</code> en CLI ou cochez la case ci-dessous
+        (requiert <code>NAVIDROME_CONTAINER_NAME</code> configuré).
+    </div>
+
+    {# Compteurs #}
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">En attente</div>
+            <div class="text-3xl font-semibold {{ pending > 0 ? 'text-amber-600' : '' }}">{{ pending|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Matchés</div>
+            <div class="text-3xl font-semibold text-emerald-600">{{ matched|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Doublons</div>
+            <div class="text-3xl font-semibold text-slate-500">{{ duplicates|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">
+                <a href="{{ path('app_navidrome_unmatched') }}" class="underline hover:no-underline">Non matchés</a>
+            </div>
+            <div class="text-3xl font-semibold {{ unmatched > 0 ? 'text-rose-600' : '' }}">{{ unmatched|number_format(0, '.', ' ') }}</div>
+        </div>
+    </div>
+
+    {# Formulaire sync #}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mb-6">
+        <h2 class="text-lg font-semibold mb-4">Lancer la synchronisation</h2>
+        <form method="post" action="{{ path('app_navidrome_sync_post') }}" class="space-y-4">
+            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_sync') }}">
+
+            <div class="flex flex-col gap-2">
+                <label class="flex items-center gap-2 text-sm">
+                    <input type="checkbox" name="auto_stop" value="1"> Auto-stop Navidrome (requiert NAVIDROME_CONTAINER_NAME)
+                </label>
+                <label class="flex items-center gap-2 text-sm">
+                    <input type="checkbox" name="dry_run" value="1"> Dry-run (matching sans écriture)
+                </label>
+            </div>
+
+            <div class="grid grid-cols-2 gap-4">
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">Limite (0 = tout)</label>
+                    <input type="number" name="limit" value="0" min="0"
+                           class="w-full border rounded-sm px-3 py-2 text-sm">
+                </div>
+                <div>
+                    <label class="block text-xs uppercase text-slate-500 mb-1">Tolérance dedup (s)</label>
+                    <input type="number" name="tolerance" value="60" min="0"
+                           class="w-full border rounded-sm px-3 py-2 text-sm">
+                </div>
+            </div>
+
+            <button type="submit"
+                    class="bg-slate-800 hover:bg-slate-900 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                ▶ Lancer la sync
+            </button>
+        </form>
+
+        <div class="mt-4 text-xs text-slate-400">
+            <strong>CLI :</strong>
+            <code>php bin/console app:scrobbles:sync-navidrome [--auto-stop] [--dry-run] [--limit=N]</code>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -1,0 +1,54 @@
+{% extends 'base.html.twig' %}
+{% block title %}Non matchés — Navidrome{% endblock %}
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_navidrome_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Navidrome</a>
+    </div>
+
+    <div class="flex items-center justify-between mb-4">
+        <h1 class="text-2xl font-semibold">Scrobbles non matchés — Navidrome</h1>
+        <span class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }}</span>
+    </div>
+
+    <p class="text-sm text-slate-500 mb-4">
+        Ces scrobbles n'ont pas trouvé de correspondance dans Navidrome. Créez un alias ou ajoutez les morceaux
+        à votre bibliothèque, puis relancez la sync avec <code>--retry-unmatched</code>.
+    </p>
+
+    {% if rows is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun scrobble non matché 🎉</div>
+    {% else %}
+    <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+        <table class="w-full text-sm">
+            <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                <tr>
+                    <th class="px-3 py-2 text-left">Artiste</th>
+                    <th class="px-3 py-2 text-left">Titre</th>
+                    <th class="px-3 py-2 text-left">Album</th>
+                    <th class="px-3 py-2 text-right">Scrobbles</th>
+                    <th class="px-3 py-2 text-right">Dernier joué</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y">
+            {% for row in rows %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5">{{ row.artist }}</td>
+                    <td class="px-3 py-1.5">{{ row.title }}</td>
+                    <td class="px-3 py-1.5 text-slate-400 text-xs">{{ row.album ?? '—' }}</td>
+                    <td class="px-3 py-1.5 text-right font-mono">{{ row.count }}</td>
+                    <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ row.last_played_at|date('d/m/Y') }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    {% if pages > 1 %}
+    <div class="flex gap-2 items-center text-sm">
+        {% if page > 1 %}<a href="{{ path('app_navidrome_unmatched', {page: page - 1}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
+        <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
+        {% if page < pages %}<a href="{{ path('app_navidrome_unmatched', {page: page + 1}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
+    </div>
+    {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/LastFm/LastFmFetcherTest.php
+++ b/tests/LastFm/LastFmFetcherTest.php
@@ -164,7 +164,7 @@ class LastFmFetcherTest extends TestCase
             title: $title,
             album: '',
             albumArtist: '',
-            mbidTrack: null,
+            mbid: null,
             mbidArtist: null,
             mbidAlbum: null,
             playedAt: new \DateTimeImmutable($playedAt, new \DateTimeZone('UTC')),

--- a/tests/Navidrome/NavidromeFixtureFactory.php
+++ b/tests/Navidrome/NavidromeFixtureFactory.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+
+/**
+ * Builds a minimal Navidrome-compatible SQLite DB on disk for tests.
+ */
+final class NavidromeFixtureFactory
+{
+    public static function createDatabase(string $path, bool $withScrobbles = true): Connection
+    {
+        if (file_exists($path)) {
+            unlink($path);
+        }
+        $conn = DriverManager::getConnection([
+            'driver' => 'pdo_sqlite',
+            'path' => $path,
+        ]);
+
+        $conn->executeStatement(<<<'SQL'
+            CREATE TABLE user (
+                id VARCHAR(255) PRIMARY KEY NOT NULL,
+                user_name VARCHAR(255) NOT NULL UNIQUE,
+                name VARCHAR(255) DEFAULT '' NOT NULL,
+                email VARCHAR(255) DEFAULT '' NOT NULL,
+                password VARCHAR(255) DEFAULT '' NOT NULL,
+                is_admin BOOL DEFAULT 0 NOT NULL,
+                last_login_at DATETIME,
+                last_access_at DATETIME,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+        SQL);
+        $conn->executeStatement(<<<'SQL'
+            CREATE TABLE media_file (
+                id VARCHAR(255) PRIMARY KEY NOT NULL,
+                path VARCHAR(1024) DEFAULT '' NOT NULL,
+                title VARCHAR(255) DEFAULT '' NOT NULL,
+                album VARCHAR(255) DEFAULT '' NOT NULL,
+                artist VARCHAR(255) DEFAULT '' NOT NULL,
+                artist_id VARCHAR(255) DEFAULT '' NOT NULL,
+                album_artist VARCHAR(255) DEFAULT '' NOT NULL,
+                album_id VARCHAR(255) DEFAULT '' NOT NULL,
+                duration INTEGER DEFAULT 0 NOT NULL,
+                year INTEGER DEFAULT 0 NOT NULL,
+                genre VARCHAR(255) DEFAULT '' NOT NULL,
+                mbz_track_id VARCHAR(255) DEFAULT '',
+                mbz_recording_id VARCHAR(255) DEFAULT '',
+                mbz_album_id VARCHAR(255) DEFAULT NULL,
+                mbz_album_artist_id VARCHAR(255) DEFAULT NULL
+            )
+        SQL);
+        $conn->executeStatement(<<<'SQL'
+            CREATE TABLE annotation (
+                ann_id VARCHAR(255) PRIMARY KEY NOT NULL,
+                user_id VARCHAR(255) DEFAULT '' NOT NULL,
+                item_id VARCHAR(255) DEFAULT '' NOT NULL,
+                item_type VARCHAR(255) DEFAULT '' NOT NULL,
+                play_count INTEGER,
+                play_date DATETIME,
+                rating INTEGER,
+                starred BOOL DEFAULT 0 NOT NULL,
+                starred_at DATETIME
+            )
+        SQL);
+
+        if ($withScrobbles) {
+            // Mirror the real Navidrome 0.55+ schema where submission_time is
+            // an INTEGER unix timestamp (was DATETIME prior to 0.55).
+            // `client` (Subsonic client name: DSub, Symfonium, web…) is
+            // optional in tests — left NULL when callers don't pass it.
+            $conn->executeStatement(<<<'SQL'
+                CREATE TABLE scrobbles (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    media_file_id VARCHAR(255) NOT NULL,
+                    user_id VARCHAR(255) NOT NULL,
+                    submission_time INTEGER NOT NULL,
+                    client VARCHAR(255) DEFAULT NULL
+                )
+            SQL);
+        }
+
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $conn->executeStatement(
+            "INSERT INTO user (id, user_name, name, email, password, created_at, updated_at)
+             VALUES ('user-1', 'admin', 'Admin', 'a@a', '', :now, :now)",
+            ['now' => $now]
+        );
+
+        return $conn;
+    }
+
+    public static function insertTrack(
+        Connection $conn,
+        string $id,
+        string $title,
+        string $artist = 'Artist',
+        int $duration = 180,
+        string $album = 'Album',
+        ?string $albumArtist = null,
+        string $path = '',
+        ?string $mbzTrackId = null,
+        ?string $mbzRecordingId = null,
+        ?string $mbzAlbumId = null,
+    ): void {
+        $artistId = 'artist-' . md5($artist);
+        $conn->executeStatement(
+            'INSERT INTO media_file (id, path, title, artist, album, artist_id, album_artist, duration, mbz_track_id, mbz_recording_id, mbz_album_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+            [
+                $id,
+                $path,
+                $title,
+                $artist,
+                $album,
+                $artistId,
+                $albumArtist ?? $artist,
+                $duration,
+                $mbzTrackId,
+                $mbzRecordingId,
+                $mbzAlbumId,
+            ],
+        );
+    }
+
+    public static function insertAnnotation(Connection $conn, string $userId, string $mediaId, int $playCount, string $playDate): void
+    {
+        $conn->executeStatement(
+            'INSERT INTO annotation (ann_id, user_id, item_id, item_type, play_count, play_date)
+             VALUES (?, ?, ?, ?, ?, ?)',
+            [bin2hex(random_bytes(8)), $userId, $mediaId, 'media_file', $playCount, $playDate],
+        );
+    }
+
+    public static function insertScrobble(
+        Connection $conn,
+        string $userId,
+        string $mediaId,
+        string $time,
+        ?string $client = null,
+    ): void {
+        $ts = strtotime($time);
+        if ($ts === false) {
+            throw new \InvalidArgumentException(sprintf('Invalid scrobble time "%s".', $time));
+        }
+        $conn->executeStatement(
+            'INSERT INTO scrobbles (media_file_id, user_id, submission_time, client) VALUES (?, ?, ?, ?)',
+            [$mediaId, $userId, $ts, $client],
+            [2 => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+    }
+}

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Entity\Scrobble;
+use App\Entity\ScrobbleSync;
+use App\LastFm\MatchResult;
+use App\LastFm\ScrobbleMatcher;
+use App\Navidrome\NavidromeDbBackup;
+use App\Navidrome\NavidromeRepository;
+use App\Navidrome\NavidromeSyncService;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class NavidromeSyncServiceTest extends TestCase
+{
+    private string $ndDbPath;
+
+    protected function setUp(): void
+    {
+        $this->ndDbPath = sys_get_temp_dir() . '/nd-sync-test-' . uniqid() . '.db';
+        $conn = NavidromeFixtureFactory::createDatabase($this->ndDbPath, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Get Lucky', 'Daft Punk');
+        $conn->close();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->ndDbPath, $this->ndDbPath . '-wal', $this->ndDbPath . '-shm'] as $f) {
+            if (file_exists($f)) {
+                unlink($f);
+            }
+        }
+    }
+
+    public function testSyncMatchedScrobbleIsInsertedInNavidrome(): void
+    {
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process();
+
+        $this->assertSame(1, $report->considered);
+        $this->assertSame(1, $report->matched);
+        $this->assertSame(0, $report->unmatched);
+
+        $ndConn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->ndDbPath]);
+        $count = (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles');
+        $this->assertSame(1, $count);
+        $ndConn->close();
+    }
+
+    public function testSyncDryRunDoesNotWriteToNavidrome(): void
+    {
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process(dryRun: true);
+
+        $this->assertSame(1, $report->matched);
+
+        $ndConn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->ndDbPath]);
+        $count = (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles');
+        $this->assertSame(0, $count);
+        $ndConn->close();
+    }
+
+    public function testUnmatchedScrobbleDoesNotInsert(): void
+    {
+        $scrobble = $this->makeScrobble('Unknown Artist', 'Unknown Song', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::unmatched(null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process();
+
+        $this->assertSame(0, $report->matched);
+        $this->assertSame(1, $report->unmatched);
+    }
+
+    private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
+    {
+        return new Scrobble(
+            lastfmUser: 'alice',
+            artist: $artist,
+            title: $title,
+            album: null,
+            albumArtist: null,
+            mbidTrack: null,
+            mbidArtist: null,
+            mbidAlbum: null,
+            playedAt: new \DateTimeImmutable($playedAt, new \DateTimeZone('UTC')),
+        );
+    }
+}


### PR DESCRIPTION
## Lot 3 — Sync vers Navidrome

### Ce qui est inclus

**Migration `Version20260514220000` — table `scrobble_sync`**
- FK `scrobble_id → scrobbles ON DELETE CASCADE` + `run_id → run_history ON DELETE SET NULL`
- États : `pending` → `matched` / `duplicate` / `unmatched` / `skipped`
- UNIQUE `(scrobble_id, target)` — une row par scrobble par cible

**`ScrobbleSyncRepository`** — `prepareForTarget` (INSERT OR IGNORE de masse), `streamPending`, `countByTargetStatus`, `aggregateUnmatched`, `resetUnmatchedToPending`

**Portés depuis poc-v0 (0 modification) :**
- `ScrobbleMatcher` — cascade : alias track → alias artist → cache → MBID → triplet → couple → fuzzy
- `MatchResult` DTO
- `NavidromeContainerManager` + `NavidromeContainerConfig` + `DockerCli` + `ContainerStatus`
- `NavidromeDbBackup` — backup pre-write + `quickCheck` + `restore`

**`NavidromeSyncService`** :
- `prepareForTarget` → INSERT OR IGNORE de masse (nouveaux scrobbles non encore dans `scrobble_sync`)
- Batch de 100 : match → `BEGIN IMMEDIATE` → `INSERT INTO scrobbles` → `COMMIT` → flush `scrobble_sync`
- Backup automatique avant la première écriture du run
- `walCheckpointTruncate` + `closeWriteConnection` en `finally`

**CLI** — `app:scrobbles:sync-navidrome [--auto-stop] [--force] [--dry-run] [--limit] [--tolerance]`

**Messenger** — `SyncNavidromeMessage` + `SyncNavidromeMessageHandler`, routé `async`

**UI** — `/navidrome/sync` (GET : compteurs + formulaire, POST : dispatch) + `/navidrome/unmatched` (agrégat paginé)

### Points à valider en review

1. `prepareForTarget` fait une requête de masse INSERT OR IGNORE — OK pour 100k+ scrobbles ?
2. Le backup est déclenché avant la **première** écriture du run. Besoin d'un backup périodique en cours de run aussi ?
3. Faut-il une page d'alias (`/lastfm/alias`) dès ce lot ou peut attendre ?

### Tests

13 tests / 35 assertions — tous verts. phpcs + phpstan OK.

### Prochaine étape

**Lot 4 — Sync Strawberry** : `StrawberrySyncService`, adaptation `ScrobbleSyncRepository` pour target=strawberry, upload/download.

🤖 Generated with [Claude Code](https://claude.com/claude-code)