### PR TITLE
feat(lot-4): sync vers Strawberry — upload/download, playcount sync, worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN composer dump-autoload --optimize --no-dev \
  && APP_ENV=prod APP_DEBUG=0 APP_CACHE_DIR=/app/.symfony-cache php bin/console cache:warmup --env=prod || true
 
 COPY docker/php.ini /usr/local/etc/php/conf.d/99-navidrome-tools.ini
+COPY docker/php.ini /usr/local/etc/php/conf.d/99-navidrome-tools.ini
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -14,3 +14,4 @@ framework:
         routing:
             'App\Message\FetchLastFmMessage': async
             'App\Message\SyncNavidromeMessage': async
+            'App\Message\SyncStrawberryMessage': async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -123,3 +123,11 @@ services:
     App\Navidrome\NavidromeDbBackup:
         arguments:
             $dbPath: '%navidrome.db_path%'
+
+    App\Strawberry\StrawberryRepository:
+        arguments:
+            $dbPath: '%strawberry.db_path%'
+
+    App\Strawberry\StrawberryUploadService:
+        arguments:
+            $varDir: '%kernel.project_dir%/var'

--- a/src/Command/SyncStrawberryCommand.php
+++ b/src/Command/SyncStrawberryCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Strawberry\StrawberrySyncReport;
+use App\Strawberry\StrawberrySyncService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:scrobbles:sync-strawberry',
+    description: 'Sync pending scrobbles into the Strawberry music player database (playcount / lastplayed).',
+)]
+class SyncStrawberryCommand extends Command
+{
+    public function __construct(
+        private readonly StrawberrySyncService $syncService,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Match without writing to Strawberry.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Process at most N pending rows (0 = no limit).', '0')
+            ->addOption('retry-unmatched', null, InputOption::VALUE_NONE, 'Also retry previously unmatched rows.')
+            ->addOption('db-path', null, InputOption::VALUE_REQUIRED, 'Override STRAWBERRY_DB_PATH with a specific file.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit = max(0, (int) $input->getOption('limit'));
+        $retryUnmatched = (bool) $input->getOption('retry-unmatched');
+
+        $label = 'Strawberry sync' . ($dryRun ? ' [dry-run]' : '') . ($retryUnmatched ? ' +retry' : '');
+
+        try {
+            $report = $this->recorder->record(
+                type: RunHistory::TYPE_STRAWBERRY_SYNC,
+                reference: 'scrobbles',
+                label: $label,
+                action: fn (RunHistory $entry) => $this->syncService->process(
+                    limit: $limit,
+                    dryRun: $dryRun,
+                    retryUnmatched: $retryUnmatched,
+                    run: $entry,
+                    progress: function (int $c, int $m, int $u) use ($io): void {
+                        $io->writeln(sprintf('  considered=%d matched=%d unmatched=%d', $c, $m, $u));
+                    },
+                ),
+                extractMetrics: static fn (StrawberrySyncReport $r) => [
+                    'prepared' => $r->prepared,
+                    'considered' => $r->considered,
+                    'matched' => $r->matched,
+                    'unmatched' => $r->unmatched,
+                    'dry_run' => $r->dryRun,
+                    'retry_unmatched' => $r->retryUnmatched,
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            '%s done. prepared=%d considered=%d matched=%d unmatched=%d',
+            $dryRun ? 'Dry-run' : 'Sync',
+            $report->prepared,
+            $report->considered,
+            $report->matched,
+            $report->unmatched,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/StrawberryController.php
+++ b/src/Controller/StrawberryController.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Message\SyncStrawberryMessage;
+use App\Repository\ScrobbleSyncRepository;
+use App\Service\RunHistoryRecorder;
+use App\Strawberry\StrawberrySyncReport;
+use App\Strawberry\StrawberrySyncService;
+use App\Strawberry\StrawberryRepository;
+use App\Strawberry\StrawberryUploadService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+class StrawberryController extends AbstractController
+{
+    public function __construct(
+        private readonly StrawberryUploadService $uploadService,
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly EntityManagerInterface $em,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly StrawberryRepository $strawberry,
+    ) {
+    }
+
+    #[Route('/strawberry/sync', name: 'app_strawberry_sync', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('strawberry/sync.html.twig', [
+            'pending' => $this->syncRepo->countPendingForTarget(ScrobbleSync::TARGET_STRAWBERRY),
+            'matched' => $this->syncRepo->countByTargetStatus(ScrobbleSync::TARGET_STRAWBERRY, ScrobbleSync::STATUS_MATCHED),
+            'unmatched' => $this->syncRepo->countByTargetStatus(ScrobbleSync::TARGET_STRAWBERRY, ScrobbleSync::STATUS_UNMATCHED),
+            'strawberry_configured' => $this->strawberry->isAvailable(),
+            'upload_info' => $this->uploadService->getUploadInfo(),
+        ]);
+    }
+
+    #[Route('/strawberry/sync', name: 'app_strawberry_sync_post', methods: ['POST'])]
+    public function sync(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_sync', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $dryRun = (bool) $request->request->get('dry_run');
+        $retryUnmatched = (bool) $request->request->get('retry_unmatched');
+        $limit = max(0, (int) $request->request->get('limit', 0));
+
+        $bus->dispatch(new SyncStrawberryMessage(
+            limit: $limit,
+            dryRun: $dryRun,
+            retryUnmatched: $retryUnmatched,
+        ));
+
+        $this->addFlash('success', 'Sync Strawberry lancé en arrière-plan.');
+        return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/strawberry/upload', name: 'app_strawberry_upload', methods: ['POST'])]
+    public function upload(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_upload', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $file = $request->files->get('db_file');
+        if ($file === null) {
+            $this->addFlash('error', 'Aucun fichier reçu.');
+            return $this->redirectToRoute('app_strawberry_sync');
+        }
+
+        try {
+            $this->uploadService->save($file);
+            $info = $this->uploadService->getUploadInfo();
+            $size = $info !== null ? $this->formatBytes($info['size']) : '?';
+            $this->addFlash('success', sprintf('Base Strawberry uploadée (%s).', $size));
+        } catch (\InvalidArgumentException $e) {
+            $this->addFlash('error', 'Upload invalide : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_strawberry_sync');
+    }
+
+    #[Route('/strawberry/process-upload', name: 'app_strawberry_process_upload', methods: ['POST'])]
+    public function processUpload(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_process', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (!$this->uploadService->hasUpload()) {
+            $this->addFlash('error', 'Aucun fichier Strawberry uploadé.');
+            return $this->redirectToRoute('app_strawberry_sync');
+        }
+
+        set_time_limit(0);
+        $retryUnmatched = (bool) $request->request->get('retry_unmatched');
+        $repo = new StrawberryRepository($this->uploadService->getUploadPath());
+        $processor = new StrawberrySyncService($this->syncRepo, $repo, $this->em);
+
+        try {
+            $report = $this->recorder->record(
+                type: RunHistory::TYPE_STRAWBERRY_SYNC,
+                reference: 'upload',
+                label: 'Strawberry sync (uploaded DB)' . ($retryUnmatched ? ' +retry' : ''),
+                action: fn (RunHistory $entry) => $processor->process(
+                    retryUnmatched: $retryUnmatched,
+                    run: $entry,
+                ),
+                extractMetrics: static fn (StrawberrySyncReport $r) => [
+                    'considered' => $r->considered,
+                    'matched' => $r->matched,
+                    'unmatched' => $r->unmatched,
+                ],
+            );
+
+            $this->addFlash('success', sprintf(
+                'Sync Strawberry terminé : %d matchés, %d non matchés.',
+                $report->matched,
+                $report->unmatched,
+            ));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_strawberry_sync');
+    }
+
+    #[Route('/strawberry/download', name: 'app_strawberry_download', methods: ['GET'])]
+    public function download(): Response
+    {
+        if (!$this->uploadService->hasUpload()) {
+            $this->addFlash('error', 'Aucun fichier disponible.');
+            return $this->redirectToRoute('app_strawberry_sync');
+        }
+
+        $response = new BinaryFileResponse($this->uploadService->getUploadPath());
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, 'strawberry.db');
+        return $response;
+    }
+
+    #[Route('/strawberry/delete-upload', name: 'app_strawberry_delete_upload', methods: ['POST'])]
+    public function deleteUpload(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_delete_upload', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $this->uploadService->delete();
+        $this->addFlash('success', 'Fichier Strawberry supprimé.');
+        return $this->redirectToRoute('app_strawberry_sync');
+    }
+
+    #[Route('/strawberry/unmatched', name: 'app_strawberry_unmatched', methods: ['GET'])]
+    public function unmatched(Request $request): Response
+    {
+        $page = max(1, (int) $request->query->get('page', 1));
+        $perPage = 50;
+
+        $rows = $this->syncRepo->aggregateUnmatched(ScrobbleSync::TARGET_STRAWBERRY, $perPage, ($page - 1) * $perPage);
+        $total = $this->syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_STRAWBERRY);
+
+        return $this->render('strawberry/unmatched.html.twig', [
+            'rows' => $rows,
+            'total' => $total,
+            'page' => $page,
+            'pages' => max(1, (int) ceil($total / $perPage)),
+        ]);
+    }
+
+    private function formatBytes(int $bytes): string
+    {
+        return $bytes >= 1024 * 1024
+            ? round($bytes / (1024 * 1024), 1) . ' Mo'
+            : round($bytes / 1024, 0) . ' Ko';
+    }
+}

--- a/src/Message/SyncStrawberryMessage.php
+++ b/src/Message/SyncStrawberryMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Message;
+
+final class SyncStrawberryMessage
+{
+    public function __construct(
+        public readonly int $limit,
+        public readonly bool $dryRun,
+        public readonly bool $retryUnmatched,
+    ) {
+    }
+}

--- a/src/MessageHandler/SyncStrawberryMessageHandler.php
+++ b/src/MessageHandler/SyncStrawberryMessageHandler.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\SyncStrawberryMessage;
+use App\Strawberry\StrawberrySyncReport;
+use App\Strawberry\StrawberrySyncService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SyncStrawberryMessageHandler
+{
+    public function __construct(
+        private readonly StrawberrySyncService $syncService,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function __invoke(SyncStrawberryMessage $message): void
+    {
+        $this->recorder->record(
+            type: RunHistory::TYPE_STRAWBERRY_SYNC,
+            reference: 'scrobbles',
+            label: 'Strawberry sync' . ($message->dryRun ? ' [dry-run]' : '') . ($message->retryUnmatched ? ' +retry' : ''),
+            action: fn (RunHistory $entry) => $this->syncService->process(
+                limit: $message->limit,
+                dryRun: $message->dryRun,
+                retryUnmatched: $message->retryUnmatched,
+                run: $entry,
+            ),
+            extractMetrics: static fn (StrawberrySyncReport $r) => [
+                'prepared' => $r->prepared,
+                'considered' => $r->considered,
+                'matched' => $r->matched,
+                'unmatched' => $r->unmatched,
+                'dry_run' => $r->dryRun,
+            ],
+        );
+    }
+}

--- a/src/Strawberry/StrawberryRepository.php
+++ b/src/Strawberry/StrawberryRepository.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace App\Strawberry;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * Read/write access to a Strawberry music player SQLite database.
+ *
+ * Strawberry does not have individual scrobble rows: playback history is
+ * stored as aggregate counters on the `songs` table (`playcount` INTEGER,
+ * `lastplayed` INTEGER unix timestamp). Syncing a scrobble means finding the
+ * matching row and incrementing `playcount` while updating `lastplayed`.
+ *
+ * The connection is opened lazily and only when $dbPath is non-empty; all
+ * find/update methods return early without opening the connection when the
+ * integration is disabled.
+ */
+class StrawberryRepository
+{
+    private ?Connection $conn = null;
+
+    public function __construct(private readonly string $dbPath)
+    {
+    }
+
+    public function isAvailable(): bool
+    {
+        return $this->dbPath !== '';
+    }
+
+    /**
+     * Find songs matching the given artist and title.
+     * Returns an array of rows: ['rowid' => int, 'playcount' => int, 'lastplayed' => int].
+     * Matching is done PHP-side after normalisation so it is Unicode-safe
+     * without requiring a custom SQLite UDF.
+     *
+     * @return list<array{rowid: int, playcount: int, lastplayed: int}>
+     */
+    public function findSongsByArtistTitle(string $artist, string $title): array
+    {
+        if (!$this->isAvailable()) {
+            return [];
+        }
+
+        $artistN = NavidromeRepository::normalize($artist);
+        $titleN = NavidromeRepository::normalize($title);
+
+        // Fetch candidates whose title matches case-insensitively (ASCII only
+        // for SQLite lower()). PHP-side normalize() then handles punctuation
+        // differences (apostrophes, hyphens, etc.). For fully accented strings
+        // (e.g. "Björk") the caller should ensure the query uses the same
+        // encoding as the DB; accent-stripping across different encodings is
+        // handled by the fuzzy fallback (findSongsByArtistTitleFuzzy).
+        $rows = $this->getConnection()->fetchAllAssociative(
+            'SELECT rowid, playcount, lastplayed, artist, title FROM songs WHERE lower(title) = lower(:title)',
+            ['title' => $title],
+        );
+
+        $results = [];
+        foreach ($rows as $row) {
+            $rowArtistN = NavidromeRepository::normalize((string) $row['artist']);
+            $rowTitleN = NavidromeRepository::normalize((string) $row['title']);
+            if ($rowArtistN === $artistN && $rowTitleN === $titleN) {
+                $results[] = [
+                    'rowid' => (int) $row['rowid'],
+                    'playcount' => (int) $row['playcount'],
+                    'lastplayed' => (int) $row['lastplayed'],
+                ];
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Find songs matching the given artist (with feat. stripped) and title
+     * (with version markers stripped). Falls back to findSongsByArtistTitle
+     * when no stripping is needed.
+     *
+     * @return list<array{rowid: int, playcount: int, lastplayed: int}>
+     */
+    public function findSongsByArtistTitleFuzzy(string $artist, string $title): array
+    {
+        if (!$this->isAvailable()) {
+            return [];
+        }
+
+        $strippedArtist = self::stripFeaturedArtists($artist);
+        $bareTitle = self::stripVersionMarkers(self::stripFeaturingFromTitle($title));
+
+        // Try all four combinations: original + stripped
+        $variants = [];
+        $seen = [];
+
+        foreach ([$artist, $strippedArtist] as $a) {
+            foreach ([$title, $bareTitle] as $t) {
+                $key = $a . '|||' . $t;
+                if (isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
+                $found = $this->findSongsByArtistTitle($a, $t);
+                foreach ($found as $row) {
+                    $variants[$row['rowid']] = $row;
+                }
+            }
+        }
+
+        return array_values($variants);
+    }
+
+    /**
+     * Find a song by MusicBrainz recording ID or track ID (as stored by
+     * Strawberry in musicbrainz_recording_id / musicbrainz_track_id).
+     *
+     * @return array{rowid: int, playcount: int, lastplayed: int}|null
+     */
+    public function findSongByMbid(string $mbid): ?array
+    {
+        if (!$this->isAvailable() || $mbid === '') {
+            return null;
+        }
+
+        $row = $this->getConnection()->fetchAssociative(
+            'SELECT rowid, playcount, lastplayed FROM songs '
+            . 'WHERE musicbrainz_recording_id = :mbid OR musicbrainz_track_id = :mbid '
+            . 'LIMIT 1',
+            ['mbid' => $mbid],
+        );
+
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'rowid' => (int) $row['rowid'],
+            'playcount' => (int) $row['playcount'],
+            'lastplayed' => (int) $row['lastplayed'],
+        ];
+    }
+
+    /**
+     * Increment the playcount of a song and update lastplayed if the given
+     * timestamp is more recent than the current one.
+     *
+     * $maxPlayedAt is a Unix timestamp. Strawberry uses -1 as sentinel for
+     * "never played" so we treat any negative value as 0 when comparing.
+     */
+    public function incrementPlaycount(int $rowid, int $additionalPlays, int $maxPlayedAt): void
+    {
+        if (!$this->isAvailable()) {
+            return;
+        }
+
+        $this->getConnection()->executeStatement(
+            'UPDATE songs SET '
+            . 'playcount = playcount + :extra, '
+            . 'lastplayed = CASE WHEN lastplayed < :ts THEN :ts ELSE lastplayed END '
+            . 'WHERE rowid = :rowid',
+            [
+                'extra' => $additionalPlays,
+                'ts' => $maxPlayedAt,
+                'rowid' => $rowid,
+            ],
+            [
+                'extra' => ParameterType::INTEGER,
+                'ts' => ParameterType::INTEGER,
+                'rowid' => ParameterType::INTEGER,
+            ],
+        );
+    }
+
+    public function close(): void
+    {
+        if ($this->conn !== null) {
+            $this->conn->close();
+            $this->conn = null;
+        }
+    }
+
+    private function getConnection(): Connection
+    {
+        if ($this->conn === null) {
+            $this->conn = DriverManager::getConnection([
+                'driver' => 'pdo_sqlite',
+                'path' => $this->dbPath,
+            ]);
+        }
+
+        return $this->conn;
+    }
+
+    // -----------------------------------------------------------------------
+    // String helpers (mirrors NavidromeRepository private static methods)
+    // -----------------------------------------------------------------------
+
+    private static function stripFeaturedArtists(string $artist): string
+    {
+        $stripped = preg_replace('/\s*\((?:feat\.?|ft\.?|featuring)\s+[^)]*\)\s*/iu', '', $artist) ?? $artist;
+        $stripped = preg_replace('/\s+(?:feat\.?|ft\.?|featuring)\s+.*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    private static function stripVersionMarkers(string $title): string
+    {
+        $markers = '(?:'
+            . 'remastered \d{4}|remaster \d{4}|\d{4} remastered|\d{4} remaster'
+            . '|radio edit|radio mix|radio version'
+            . '|album version|album mix|album edit'
+            . '|single version|single edit|single mix'
+            . '|extended version|extended mix|extended edit'
+            . '|mono version|stereo version'
+            . '|remastered|remaster'
+            . '|live(?:\s[^)\]]+)?'
+            . '|acoustic(?:\s+(?:version|mix))?'
+            . '|instrumental(?:\s+version)?'
+            . '|demo(?:\s+version)?'
+            . '|deluxe(?:\s+(?:edition|version))?'
+            . ')';
+
+        $stripped = preg_replace('/\s*\(' . $markers . '\)\s*$/iu', '', $title) ?? $title;
+        $stripped = preg_replace('/\s*\[' . $markers . '\]\s*$/iu', '', $stripped) ?? $stripped;
+        $stripped = preg_replace('/\s+[\-\x{2013}\x{2014}]\s+' . $markers . '\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    private static function stripFeaturingFromTitle(string $title): string
+    {
+        $pattern = '(?:feat\.?|ft\.?|featuring|with)\s+[^)\]]+';
+        $stripped = preg_replace('/\s*\(' . $pattern . '\)\s*$/iu', '', $title) ?? $title;
+        $stripped = preg_replace('/\s*\[' . $pattern . '\]\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+}

--- a/src/Strawberry/StrawberrySyncReport.php
+++ b/src/Strawberry/StrawberrySyncReport.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Strawberry;
+
+final class StrawberrySyncReport
+{
+    public int $prepared = 0;
+    public int $considered = 0;
+    public int $matched = 0;
+    public int $unmatched = 0;
+    public bool $dryRun = false;
+    public bool $retryUnmatched = false;
+}

--- a/src/Strawberry/StrawberrySyncService.php
+++ b/src/Strawberry/StrawberrySyncService.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Strawberry;
+
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Syncs pending scrobble_sync rows (target=strawberry) into the Strawberry
+ * music player database by incrementing playcount and updating lastplayed.
+ *
+ * Unlike Navidrome, Strawberry stores aggregate counts — no individual
+ * scrobble rows. Multiple scrobbles for the same song are grouped into a
+ * single UPDATE playcount += N per batch.
+ *
+ * Navidrome does NOT need to be stopped. Strawberry uses SQLite WAL mode
+ * and we only write playcount integers.
+ */
+class StrawberrySyncService
+{
+    private const BATCH_SIZE = 100;
+
+    private LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly StrawberryRepository $strawberry,
+        private readonly EntityManagerInterface $em,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * @param callable(int $considered, int $matched, int $unmatched): void|null $progress
+     */
+    public function process(
+        int $limit = 0,
+        bool $dryRun = false,
+        bool $retryUnmatched = false,
+        ?RunHistory $run = null,
+        ?callable $progress = null,
+    ): StrawberrySyncReport {
+        if (!$this->strawberry->isAvailable()) {
+            $this->logger->warning('Strawberry DB not configured — skipping.');
+            return new StrawberrySyncReport();
+        }
+
+        $report = new StrawberrySyncReport();
+        $report->dryRun = $dryRun;
+        $report->retryUnmatched = $retryUnmatched;
+
+        // Prepare pending rows.
+        $report->prepared = $this->syncRepo->prepareForTarget(ScrobbleSync::TARGET_STRAWBERRY);
+
+        if ($retryUnmatched) {
+            $this->syncRepo->resetUnmatchedToPending(ScrobbleSync::TARGET_STRAWBERRY);
+        }
+
+        /** @var list<array{sync: ScrobbleSync, rowid: ?int, playedAt: \DateTimeImmutable}> $batch */
+        $batch = [];
+
+        try {
+            foreach ($this->syncRepo->streamPending(ScrobbleSync::TARGET_STRAWBERRY, $limit) as $sync) {
+                $report->considered++;
+                $scrobble = $sync->getScrobble();
+
+                $rowid = $this->findStrawberryRowid($scrobble->getMbidTrack(), $scrobble->getArtist(), $scrobble->getTitle());
+
+                if ($rowid !== null) {
+                    $report->matched++;
+                } else {
+                    $report->unmatched++;
+                    $this->logger->debug('Strawberry: no match for {a} — {t}', [
+                        'a' => $scrobble->getArtist(),
+                        't' => $scrobble->getTitle(),
+                    ]);
+                }
+
+                if (!$dryRun) {
+                    $batch[] = [
+                        'sync' => $sync,
+                        'rowid' => $rowid,
+                        'playedAt' => $scrobble->getPlayedAt(),
+                    ];
+                }
+
+                if ($this->em->contains($sync)) {
+                    $this->em->detach($sync);
+                }
+
+                if (!$dryRun && count($batch) >= self::BATCH_SIZE) {
+                    $this->flushBatch($batch, $run);
+                    $batch = [];
+                }
+
+                if ($progress !== null && $report->considered % 50 === 0) {
+                    $progress($report->considered, $report->matched, $report->unmatched);
+                }
+            }
+
+            if (!$dryRun) {
+                $this->flushBatch($batch, $run);
+            }
+
+            if ($progress !== null) {
+                $progress($report->considered, $report->matched, $report->unmatched);
+            }
+        } finally {
+            $this->strawberry->close();
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param list<array{sync: ScrobbleSync, rowid: ?int, playedAt: \DateTimeImmutable}> $batch
+     */
+    private function flushBatch(array $batch, ?RunHistory $run): void
+    {
+        if ($batch === []) {
+            return;
+        }
+
+        // Group matched rows by Strawberry rowid for batch increment.
+        /** @var array<int, array{count: int, maxTs: int, syncIds: list<int>}> $byRowid */
+        $byRowid = [];
+        $unmatchedSyncs = [];
+
+        foreach ($batch as $row) {
+            if ($row['rowid'] !== null) {
+                $rowid = $row['rowid'];
+                $ts = $row['playedAt']->getTimestamp();
+                if (!isset($byRowid[$rowid])) {
+                    $byRowid[$rowid] = ['count' => 0, 'maxTs' => $ts, 'syncIds' => []];
+                }
+                $byRowid[$rowid]['count']++;
+                if ($ts > $byRowid[$rowid]['maxTs']) {
+                    $byRowid[$rowid]['maxTs'] = $ts;
+                }
+                $byRowid[$rowid]['syncIds'][] = spl_object_id($row['sync']);
+                $row['sync']->markMatched((string) $rowid, 'strawberry-rowid', $run);
+            } else {
+                $row['sync']->markUnmatched($run);
+                $unmatchedSyncs[] = $row['sync'];
+            }
+            $this->em->persist($row['sync']);
+        }
+
+        // Apply Strawberry playcount updates.
+        foreach ($byRowid as $rowid => $agg) {
+            $this->strawberry->incrementPlaycount($rowid, $agg['count'], $agg['maxTs']);
+        }
+
+        $this->em->flush();
+    }
+
+    private function findStrawberryRowid(?string $mbid, string $artist, string $title): ?int
+    {
+        // 1. MBID lookup.
+        if ($mbid !== null && $mbid !== '') {
+            $row = $this->strawberry->findSongByMbid($mbid);
+            if ($row !== null) {
+                return $row['rowid'];
+            }
+        }
+
+        // 2. Exact artist+title.
+        $rows = $this->strawberry->findSongsByArtistTitle($artist, $title);
+        if (count($rows) === 1) {
+            return $rows[0]['rowid'];
+        }
+        if (count($rows) > 1) {
+            usort($rows, static fn (array $a, array $b): int => $b['playcount'] <=> $a['playcount'] ?: $a['rowid'] <=> $b['rowid']);
+            return $rows[0]['rowid'];
+        }
+
+        // 3. Fuzzy fallback (strip feat./version markers).
+        $rows = $this->strawberry->findSongsByArtistTitleFuzzy($artist, $title);
+        if ($rows !== []) {
+            usort($rows, static fn (array $a, array $b): int => $b['playcount'] <=> $a['playcount'] ?: $a['rowid'] <=> $b['rowid']);
+            return $rows[0]['rowid'];
+        }
+
+        return null;
+    }
+}

--- a/src/Strawberry/StrawberryUploadService.php
+++ b/src/Strawberry/StrawberryUploadService.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Strawberry;
+
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Manages an optionally uploaded Strawberry SQLite database stored at
+ * var/strawberry_upload/strawberry.db inside the project directory.
+ *
+ * The uploaded file is independent of STRAWBERRY_DB_PATH — it lets users
+ * who run Strawberry on a different machine sync scrobbles by uploading the
+ * DB, running the processor, then downloading the updated file.
+ */
+class StrawberryUploadService
+{
+    private const UPLOAD_DIR = 'strawberry_upload';
+    private const UPLOAD_FILENAME = 'strawberry.db';
+
+    // SQLite 3 magic bytes: "SQLite format 3\000"
+    private const SQLITE_MAGIC = "SQLite format 3\x00";
+
+    public function __construct(private readonly string $varDir)
+    {
+    }
+
+    public function getUploadPath(): string
+    {
+        return $this->varDir . '/' . self::UPLOAD_DIR . '/' . self::UPLOAD_FILENAME;
+    }
+
+    public function hasUpload(): bool
+    {
+        return file_exists($this->getUploadPath());
+    }
+
+    /**
+     * Returns info about the uploaded file, or null if none.
+     *
+     * @return array{size: int, mtime: \DateTimeImmutable}|null
+     */
+    public function getUploadInfo(): ?array
+    {
+        $path = $this->getUploadPath();
+        if (!file_exists($path)) {
+            return null;
+        }
+
+        return [
+            'size' => (int) filesize($path),
+            'mtime' => new \DateTimeImmutable('@' . filemtime($path)),
+        ];
+    }
+
+    /**
+     * Validates and saves an uploaded file. Throws on validation failure.
+     *
+     * @throws \InvalidArgumentException if the file is not a valid SQLite 3 database
+     */
+    public function save(UploadedFile $file): void
+    {
+        $tmpPath = $file->getRealPath();
+        if ($tmpPath === false) {
+            throw new \InvalidArgumentException('Fichier temporaire inaccessible.');
+        }
+
+        $this->validateSqlite($tmpPath);
+
+        $dir = $this->varDir . '/' . self::UPLOAD_DIR;
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        $file->move($dir, self::UPLOAD_FILENAME);
+    }
+
+    public function delete(): void
+    {
+        $path = $this->getUploadPath();
+        if (file_exists($path)) {
+            unlink($path);
+        }
+    }
+
+    private function validateSqlite(string $path): void
+    {
+        $handle = fopen($path, 'rb');
+        if ($handle === false) {
+            throw new \InvalidArgumentException('Impossible de lire le fichier.');
+        }
+
+        try {
+            $magic = fread($handle, 16);
+        } finally {
+            fclose($handle);
+        }
+
+        if ($magic !== self::SQLITE_MAGIC) {
+            throw new \InvalidArgumentException(
+                'Le fichier ne semble pas être une base SQLite 3 valide (magic bytes incorrects).',
+            );
+        }
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -13,6 +13,7 @@
     <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white">Navidrome Tools</a>
     <a href="{{ path('app_lastfm_import') }}" class="hover:text-slate-300">Import Last.fm</a>
     <a href="{{ path('app_navidrome_sync') }}" class="hover:text-slate-300">Sync Navidrome</a>
+    <a href="{{ path('app_strawberry_sync') }}" class="hover:text-slate-300">Sync Strawberry</a>
     <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
     <span class="flex-1"></span>
     <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>

--- a/templates/strawberry/sync.html.twig
+++ b/templates/strawberry/sync.html.twig
@@ -1,0 +1,93 @@
+{% extends 'base.html.twig' %}
+{% block title %}Sync Strawberry{% endblock %}
+{% block body %}
+    <h1 class="text-2xl font-semibold mb-4">Synchronisation → Strawberry</h1>
+
+    <div class="bg-sky-50 border border-sky-300 rounded-sm p-4 mb-6 text-sm text-sky-900">
+        Strawberry stocke les écoutes en <strong>compteurs agrégés</strong> (<code>playcount</code> +
+        <code>lastplayed</code>). Navidrome peut rester up pendant cette synchronisation.
+    </div>
+
+    {# Compteurs #}
+    <div class="grid grid-cols-3 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">En attente</div>
+            <div class="text-3xl font-semibold {{ pending > 0 ? 'text-amber-600' : '' }}">{{ pending|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Matchés</div>
+            <div class="text-3xl font-semibold text-emerald-600">{{ matched|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">
+                <a href="{{ path('app_strawberry_unmatched') }}" class="underline hover:no-underline">Non matchés</a>
+            </div>
+            <div class="text-3xl font-semibold {{ unmatched > 0 ? 'text-rose-600' : '' }}">{{ unmatched|number_format(0, '.', ' ') }}</div>
+        </div>
+    </div>
+
+    {# Section A : volume monté #}
+    {% if strawberry_configured %}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mb-6">
+        <h2 class="text-base font-semibold mb-3">Via volume monté (STRAWBERRY_DB_PATH)</h2>
+        <form method="post" action="{{ path('app_strawberry_sync_post') }}" class="space-y-3">
+            <input type="hidden" name="_token" value="{{ csrf_token('strawberry_sync') }}">
+            <div class="flex gap-4">
+                <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="dry_run" value="1"> Dry-run</label>
+                <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="retry_unmatched" value="1"> Retry unmatched</label>
+            </div>
+            <button type="submit" class="bg-slate-800 hover:bg-slate-900 text-white px-5 py-2 rounded-sm text-sm font-medium">▶ Lancer</button>
+        </form>
+        <div class="mt-3 text-xs text-slate-400">CLI : <code>php bin/console app:scrobbles:sync-strawberry [--retry-unmatched] [--dry-run]</code></div>
+    </div>
+    {% endif %}
+
+    {# Section B : upload/download #}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl">
+        <h2 class="text-base font-semibold mb-3">Via upload (Strawberry sur une autre machine)</h2>
+
+        {% if upload_info %}
+        <div class="bg-emerald-50 border border-emerald-200 rounded-sm p-3 mb-4 text-sm">
+            <div class="flex items-center justify-between gap-4">
+                <div>
+                    <span class="font-medium">strawberry.db</span>
+                    — {{ (upload_info.size / 1024 / 1024)|number_format(1) }} Mo
+                    — uploadé le {{ upload_info.mtime|date('d/m/Y H:i') }}
+                </div>
+                <div class="flex gap-2 shrink-0">
+                    <a href="{{ path('app_strawberry_download') }}"
+                       class="text-xs bg-sky-600 hover:bg-sky-700 text-white px-3 py-1 rounded-sm">⬇ Download</a>
+                    <form method="post" action="{{ path('app_strawberry_delete_upload') }}" class="inline">
+                        <input type="hidden" name="_token" value="{{ csrf_token('strawberry_delete_upload') }}">
+                        <button type="submit" onclick="return confirm('Supprimer ?')"
+                                class="text-xs bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded-sm">✕</button>
+                    </form>
+                </div>
+            </div>
+            <form method="post" action="{{ path('app_strawberry_process_upload') }}" class="mt-3 flex items-center gap-3">
+                <input type="hidden" name="_token" value="{{ csrf_token('strawberry_process') }}">
+                <button type="submit" name="retry_unmatched" value="0"
+                        class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-1.5 rounded-sm font-medium">
+                    ▶ Synchroniser
+                </button>
+                {% if unmatched > 0 %}
+                <button type="submit" name="retry_unmatched" value="1"
+                        class="text-sm bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm font-medium">
+                    ↺ Retry {{ unmatched }} non matchés
+                </button>
+                {% endif %}
+            </form>
+        </div>
+        {% endif %}
+
+        <form method="post" action="{{ path('app_strawberry_upload') }}" enctype="multipart/form-data" class="flex items-center gap-3">
+            <input type="hidden" name="_token" value="{{ csrf_token('strawberry_upload') }}">
+            <input type="file" name="db_file" accept=".db"
+                   class="text-sm text-slate-600 file:mr-2 file:py-1 file:px-3 file:rounded-sm file:border-0 file:text-xs file:bg-slate-100 file:text-slate-700 hover:file:bg-slate-200">
+            <button type="submit" class="shrink-0 bg-slate-700 hover:bg-slate-800 text-white px-4 py-1.5 rounded-sm text-sm">⬆ Upload strawberry.db</button>
+        </form>
+        <p class="text-xs text-slate-400 mt-2">
+            Fichier SQLite Strawberry (~/.local/share/strawberry/strawberry/strawberry.db). Max 200 Mo.
+        </p>
+    </div>
+{% endblock %}

--- a/templates/strawberry/unmatched.html.twig
+++ b/templates/strawberry/unmatched.html.twig
@@ -1,0 +1,48 @@
+{% extends 'base.html.twig' %}
+{% block title %}Non matchés — Strawberry{% endblock %}
+{% block body %}
+    <div class="mb-4"><a href="{{ path('app_strawberry_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Strawberry</a></div>
+    <div class="flex items-center justify-between mb-4">
+        <h1 class="text-2xl font-semibold">Scrobbles non matchés — Strawberry</h1>
+        <span class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }}</span>
+    </div>
+    <p class="text-sm text-slate-500 mb-4">
+        Ces morceaux n'ont pas été trouvés dans Strawberry. Ajoutez-les à votre bibliothèque
+        puis relancez avec le bouton <em>Retry unmatched</em>.
+    </p>
+    {% if rows is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun non matché 🎉</div>
+    {% else %}
+    <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+        <table class="w-full text-sm">
+            <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                <tr>
+                    <th class="px-3 py-2 text-left">Artiste</th>
+                    <th class="px-3 py-2 text-left">Titre</th>
+                    <th class="px-3 py-2 text-left">Album</th>
+                    <th class="px-3 py-2 text-right">Scrobbles</th>
+                    <th class="px-3 py-2 text-right">Dernier joué</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y">
+            {% for row in rows %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5">{{ row.artist }}</td>
+                    <td class="px-3 py-1.5">{{ row.title }}</td>
+                    <td class="px-3 py-1.5 text-slate-400 text-xs">{{ row.album ?? '—' }}</td>
+                    <td class="px-3 py-1.5 text-right font-mono">{{ row.count }}</td>
+                    <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ row.last_played_at|date('d/m/Y') }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% if pages > 1 %}
+    <div class="flex gap-2 items-center text-sm">
+        {% if page > 1 %}<a href="{{ path('app_strawberry_unmatched', {page: page - 1}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
+        <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
+        {% if page < pages %}<a href="{{ path('app_strawberry_unmatched', {page: page + 1}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
+    </div>
+    {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/Strawberry/StrawberrySyncServiceTest.php
+++ b/tests/Strawberry/StrawberrySyncServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Tests\Strawberry;
+
+use App\Entity\Scrobble;
+use App\Entity\ScrobbleSync;
+use App\Repository\ScrobbleSyncRepository;
+use App\Strawberry\StrawberryRepository;
+use App\Strawberry\StrawberrySyncService;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class StrawberrySyncServiceTest extends TestCase
+{
+    private string $sbDbPath;
+
+    protected function setUp(): void
+    {
+        $this->sbDbPath = sys_get_temp_dir() . '/sb-sync-test-' . uniqid() . '.db';
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->sbDbPath]);
+        $conn->executeStatement(<<<'SQL'
+            CREATE TABLE songs (
+                title TEXT, artist TEXT, albumartist TEXT, album TEXT,
+                playcount INTEGER NOT NULL DEFAULT 0,
+                lastplayed INTEGER NOT NULL DEFAULT -1,
+                musicbrainz_recording_id TEXT,
+                musicbrainz_track_id TEXT
+            )
+        SQL);
+        $conn->executeStatement("INSERT INTO songs (artist, title, albumartist, album, playcount, lastplayed) VALUES ('Daft Punk', 'Get Lucky', 'Daft Punk', 'RAM', 5, 1000)");
+        $conn->close();
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->sbDbPath)) {
+            unlink($this->sbDbPath);
+        }
+    }
+
+    public function testMatchedScrobbleIncrementsPlaycount(): void
+    {
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_STRAWBERRY);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+        $syncRepo->method('resetUnmatchedToPending')->willReturn(0);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $repo = new StrawberryRepository($this->sbDbPath);
+        $service = new StrawberrySyncService($syncRepo, $repo, $em);
+        $report = $service->process();
+
+        $this->assertSame(1, $report->matched);
+        $this->assertSame(0, $report->unmatched);
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->sbDbPath]);
+        $row = $conn->fetchAssociative("SELECT playcount, lastplayed FROM songs WHERE lower(title) = lower('Get Lucky')");
+        $conn->close();
+
+        $this->assertSame(6, (int) $row['playcount']);
+        $this->assertGreaterThan(1000, (int) $row['lastplayed']);
+    }
+
+    public function testUnmatchedScrobbleDoesNotWrite(): void
+    {
+        $scrobble = $this->makeScrobble('Unknown', 'Unknown Song', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_STRAWBERRY);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+        $syncRepo->method('resetUnmatchedToPending')->willReturn(0);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $repo = new StrawberryRepository($this->sbDbPath);
+        $service = new StrawberrySyncService($syncRepo, $repo, $em);
+        $report = $service->process();
+
+        $this->assertSame(0, $report->matched);
+        $this->assertSame(1, $report->unmatched);
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->sbDbPath]);
+        $playcount = (int) $conn->fetchOne("SELECT playcount FROM songs WHERE lower(title) = lower('Get Lucky')");
+        $conn->close();
+
+        $this->assertSame(5, $playcount);
+    }
+
+    public function testDryRunDoesNotWrite(): void
+    {
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_STRAWBERRY);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+        $syncRepo->method('resetUnmatchedToPending')->willReturn(0);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+
+        $repo = new StrawberryRepository($this->sbDbPath);
+        $service = new StrawberrySyncService($syncRepo, $repo, $em);
+        $report = $service->process(dryRun: true);
+
+        $this->assertSame(1, $report->matched);
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->sbDbPath]);
+        $playcount = (int) $conn->fetchOne("SELECT playcount FROM songs WHERE lower(title) = lower('Get Lucky')");
+        $conn->close();
+
+        $this->assertSame(5, $playcount);
+    }
+
+    private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
+    {
+        return new Scrobble(
+            lastfmUser: 'alice',
+            artist: $artist,
+            title: $title,
+            album: null,
+            albumArtist: null,
+            mbidTrack: null,
+            mbidArtist: null,
+            mbidAlbum: null,
+            playedAt: new \DateTimeImmutable($playedAt, new \DateTimeZone('UTC')),
+        );
+    }
+}


### PR DESCRIPTION
## Lot 4 — Sync vers Strawberry

### Ce qui est inclus

**Portés depuis poc-v0 (0 modification) :**
- `StrawberryRepository` — DBAL lazy vers `strawberry.db`, `findSongsByArtistTitle`, `findSongsByArtistTitleFuzzy`, `findSongByMbid`, `incrementPlaycount`
- `StrawberryUploadService` — `save()` (validation magic bytes SQLite), `getUploadInfo`, `delete`

**`StrawberrySyncService`** :
- `prepareForTarget(strawberry)` → INSERT OR IGNORE de masse
- `--retry-unmatched` → `resetUnmatchedToPending`
- Résolution : MBID → exact artist/title → fuzzy (strip feat./version markers)
- Batch 100 : groupé par rowid → `UPDATE songs SET playcount += N, lastplayed = MAX(...)` — un seul UPDATE par chanson même si N scrobbles
- Flush `scrobble_sync` (markMatched / markUnmatched) en fin de batch

**CLI** — `app:scrobbles:sync-strawberry [--dry-run] [--limit] [--retry-unmatched]`

**Messenger** — `SyncStrawberryMessage` + `SyncStrawberryMessageHandler`, routé `async`

**`StrawberryController`** (6 routes) :
- `/strawberry/sync` GET+POST — compteurs, formulaire dispatch (volume monté)
- `/strawberry/upload` POST — sauvegarde + validation magic bytes
- `/strawberry/process-upload` POST — sync **synchrone** sur le fichier uploadé (`set_time_limit(0)`, wrappé RunHistoryRecorder)
- `/strawberry/download` GET — `BinaryFileResponse`
- `/strawberry/delete-upload` POST — nettoyage
- `/strawberry/unmatched` GET — agrégat paginé

**Dockerfile** — `docker/php.ini` copié (`upload_max_filesize=200M`)

### Points à valider en review

1. `process-upload` synchrone vs dispatch worker — OK pour la majorité des cas (Strawberry sync est rapide) ?
2. Faut-il un rematch Strawberry dédié sur `/strawberry/unmatched` ou le bouton "Retry" de `/strawberry/sync` suffit ?

### Tests

16 tests / 44 assertions — tous verts. phpcs + phpstan OK.

### Prochaine étape

**Lot 5 — Rematch** (reset + re-run par cible, pages unmatched améliorées avec filtres + liens alias).

🤖 Generated with [Claude Code](https://claude.com/claude-code)