### PR TITLE
feat(lot-5): rematch, pages unmatched améliorées, CRUD alias, dashboard

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -15,3 +15,4 @@ framework:
             'App\Message\FetchLastFmMessage': async
             'App\Message\SyncNavidromeMessage': async
             'App\Message\SyncStrawberryMessage': async
+            'App\Message\RematchMessage': async

--- a/src/Command/RematchCommand.php
+++ b/src/Command/RematchCommand.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Command;
+
+use App\Docker\NavidromeContainerException;
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Navidrome\NavidromeSyncReport;
+use App\Navidrome\NavidromeSyncService;
+use App\Repository\ScrobbleSyncRepository;
+use App\Service\RunHistoryRecorder;
+use App\Strawberry\StrawberrySyncReport;
+use App\Strawberry\StrawberrySyncService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Re-attempt matching for unmatched scrobbles of a given target.
+ * Resets unmatched → pending then runs the sync service.
+ * Useful after adding tracks to the library, creating aliases, or
+ * deploying improved matching heuristics.
+ */
+#[AsCommand(
+    name: 'app:scrobbles:rematch',
+    description: 'Re-attempt matching for unmatched scrobbles (navidrome or strawberry).',
+)]
+class RematchCommand extends Command
+{
+    public function __construct(
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly NavidromeSyncService $navidromeSync,
+        private readonly StrawberrySyncService $strawberrySync,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly NavidromeContainerManager $container,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('target', 't', InputOption::VALUE_REQUIRED, 'Target: navidrome or strawberry.', 'navidrome')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Reset and match without writing.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Max rows to process (0 = no limit).', '0')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Bypass Navidrome container pre-flight.')
+            ->addOption('auto-stop', null, InputOption::VALUE_NONE, 'Auto-stop Navidrome (only relevant for navidrome target).');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $target = (string) $input->getOption('target');
+        $dryRun = (bool) $input->getOption('dry-run');
+        $limit = max(0, (int) $input->getOption('limit'));
+        $force = (bool) $input->getOption('force');
+        $autoStop = (bool) $input->getOption('auto-stop');
+
+        if (!in_array($target, [ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::TARGET_STRAWBERRY], true)) {
+            $io->error(sprintf('Invalid target "%s". Use "navidrome" or "strawberry".', $target));
+            return Command::FAILURE;
+        }
+
+        if ($target === ScrobbleSync::TARGET_NAVIDROME && !$dryRun && !$autoStop) {
+            try {
+                $this->container->assertSafeToWrite($force);
+            } catch (NavidromeContainerException $e) {
+                $io->error($e->getMessage());
+                return Command::FAILURE;
+            }
+        }
+
+        $label = sprintf('%s rematch%s', $target, $dryRun ? ' [dry-run]' : '');
+        $type = $target === ScrobbleSync::TARGET_NAVIDROME
+            ? RunHistory::TYPE_NAVIDROME_REMATCH
+            : RunHistory::TYPE_STRAWBERRY_REMATCH;
+
+        try {
+            $runProcess = fn () => $this->recorder->record(
+                type: $type,
+                reference: 'unmatched',
+                label: $label,
+                action: function (RunHistory $entry) use ($target, $limit, $dryRun): NavidromeSyncReport|StrawberrySyncReport {
+                    $reset = $this->syncRepo->resetUnmatchedToPending($target);
+                    $io = null; // logger only available in progress callback
+                    if ($target === ScrobbleSync::TARGET_NAVIDROME) {
+                        return $this->navidromeSync->process(limit: $limit, dryRun: $dryRun, run: $entry);
+                    }
+                    return $this->strawberrySync->process(limit: $limit, dryRun: $dryRun, run: $entry);
+                },
+                extractMetrics: static function (NavidromeSyncReport|StrawberrySyncReport $r): array {
+                    if ($r instanceof NavidromeSyncReport) {
+                        return [
+                            'considered' => $r->considered,
+                            'matched' => $r->matched,
+                            'duplicates' => $r->duplicates,
+                            'unmatched' => $r->unmatched,
+                        ];
+                    }
+                    return [
+                        'considered' => $r->considered,
+                        'matched' => $r->matched,
+                        'unmatched' => $r->unmatched,
+                    ];
+                },
+            );
+
+            $report = ($target === ScrobbleSync::TARGET_NAVIDROME && $autoStop && !$dryRun)
+                ? $this->container->runWithNavidromeStopped($runProcess)
+                : $runProcess();
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $matched = $report instanceof NavidromeSyncReport ? $report->matched : $report->matched;
+        $unmatched = $report instanceof NavidromeSyncReport ? $report->unmatched : $report->unmatched;
+
+        $io->success(sprintf(
+            '%s rematch done. matched=%d unmatched=%d',
+            ucfirst($target),
+            $matched,
+            $unmatched,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -2,7 +2,12 @@
 
 namespace App\Controller;
 
+use App\Entity\ScrobbleSync;
 use App\Repository\RunHistoryRepository;
+use App\Repository\ScrobbleRepository;
+use App\Repository\ScrobbleSyncRepository;
+use App\Strawberry\StrawberryRepository;
+use App\Strawberry\StrawberryUploadService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
@@ -10,12 +15,32 @@ use Symfony\Component\Routing\Attribute\Route;
 class DashboardController extends AbstractController
 {
     #[Route('/', name: 'app_dashboard')]
-    public function index(RunHistoryRepository $runHistory): Response
-    {
+    public function index(
+        RunHistoryRepository $runHistory,
+        ScrobbleRepository $scrobbleRepo,
+        ScrobbleSyncRepository $syncRepo,
+        StrawberryRepository $strawberry,
+        StrawberryUploadService $uploadService,
+    ): Response {
         $recentRuns = $runHistory->findFilteredPaginated([], 1, 10)['items'];
+
+        $navidromePending = $syncRepo->countPendingForTarget(ScrobbleSync::TARGET_NAVIDROME);
+        $navidromeUnmatched = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
+        $navidromeMatched = $syncRepo->countByTargetStatus(ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_MATCHED);
+
+        $strawberryActive = $strawberry->isAvailable() || $uploadService->hasUpload();
+        $strawberryPending = $strawberryActive ? $syncRepo->countPendingForTarget(ScrobbleSync::TARGET_STRAWBERRY) : null;
+        $strawberryUnmatched = $strawberryActive ? $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_STRAWBERRY) : null;
 
         return $this->render('dashboard/index.html.twig', [
             'recent_runs' => $recentRuns,
+            'total_scrobbles' => $scrobbleRepo->countAll(),
+            'navidrome_pending' => $navidromePending,
+            'navidrome_unmatched' => $navidromeUnmatched,
+            'navidrome_matched' => $navidromeMatched,
+            'strawberry_active' => $strawberryActive,
+            'strawberry_pending' => $strawberryPending,
+            'strawberry_unmatched' => $strawberryUnmatched,
         ]);
     }
 }

--- a/src/Controller/LastFmAliasController.php
+++ b/src/Controller/LastFmAliasController.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\LastFmAlias;
+use App\Form\LastFmAliasType;
+use App\Repository\LastFmAliasRepository;
+use App\Repository\LastFmMatchCacheRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmAliasController extends AbstractController
+{
+    private const PER_PAGE = 25;
+
+    #[Route('/lastfm/aliases', name: 'app_lastfm_alias_index', methods: ['GET'])]
+    public function index(Request $request, LastFmAliasRepository $repo): Response
+    {
+        $query = trim((string) $request->query->get('q', ''));
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $aliases = $repo->search($query, $page, self::PER_PAGE);
+        $total = $repo->countSearch($query);
+        $totalPages = (int) max(1, ceil($total / self::PER_PAGE));
+
+        return $this->render('lastfm/aliases/index.html.twig', [
+            'aliases' => $aliases,
+            'total' => $total,
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => ['q' => $query],
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/new', name: 'app_lastfm_alias_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+        LastFmAliasRepository $repo,
+        EntityManagerInterface $em,
+        LastFmMatchCacheRepository $cacheRepo,
+    ): Response {
+        // Pre-fill from query string (« Mapper » button on /history/{id}
+        // and /lastfm/unmatched). Passed as FormType options because the
+        // field's `data` option in the builder takes precedence over
+        // post-creation `setData()` calls.
+        $prefillArtist = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_artist', ''))
+            : '';
+        $prefillTitle = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_title', ''))
+            : '';
+
+        $form = $this->createForm(LastFmAliasType::class, null, [
+            'alias' => null,
+            'prefill_source_artist' => $prefillArtist,
+            'prefill_source_title' => $prefillTitle,
+        ]);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $sourceTitle = (string) $form->get('source_title')->getData();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = $skip ? null : trim((string) $form->get('target_media_file_id')->getData());
+
+            $existing = $repo->findByScrobble($sourceArtist, $sourceTitle);
+            if ($existing !== null) {
+                $this->addFlash('error', sprintf(
+                    'Un alias existe déjà pour « %s — %s ». Modifiez-le au lieu d\'en créer un nouveau.',
+                    $sourceArtist,
+                    $sourceTitle,
+                ));
+
+                return $this->redirectToRoute('app_lastfm_alias_edit', ['id' => $existing->getId()]);
+            }
+
+            $alias = new LastFmAlias($sourceArtist, $sourceTitle, $target);
+            try {
+                $em->persist($alias);
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un alias normalisé identique existe déjà — modifiez-le.');
+
+                return $this->redirectToRoute('app_lastfm_alias_index', ['q' => $sourceArtist]);
+            }
+
+            // Drop any stale match cache row for this couple — the alias
+            // is the source of truth from now on, so the cache must
+            // either be re-cascaded or simply re-bypassed (the alias
+            // check happens first in the matcher).
+            $cacheRepo->purgeByCouple($sourceArtist, $sourceTitle);
+            $em->flush();
+
+            $this->addFlash('success', sprintf(
+                'Alias créé : « %s — %s » → %s.',
+                $sourceArtist,
+                $sourceTitle,
+                $skip ? 'IGNORÉ' : ($target ?? ''),
+            ));
+
+            return $this->redirectToRoute('app_lastfm_alias_index');
+        }
+
+        return $this->render('lastfm/aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => null,
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/{id}/edit', name: 'app_lastfm_alias_edit', methods: ['GET', 'POST'])]
+    public function edit(
+        int $id,
+        Request $request,
+        LastFmAliasRepository $repo,
+        EntityManagerInterface $em,
+        LastFmMatchCacheRepository $cacheRepo,
+    ): Response {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        $form = $this->createForm(LastFmAliasType::class, null, [
+            'alias' => $alias,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $sourceTitle = (string) $form->get('source_title')->getData();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = $skip ? null : trim((string) $form->get('target_media_file_id')->getData());
+
+            // Capture pre-edit source so we purge cache rows under both
+            // the old AND new couples — the user may have renamed the
+            // alias's source, leaving cache rows under either key.
+            $oldSourceArtist = $alias->getSourceArtist();
+            $oldSourceTitle = $alias->getSourceTitle();
+
+            $alias->setSource($sourceArtist, $sourceTitle);
+            $alias->setTargetMediaFileId($target);
+
+            try {
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un autre alias couvre déjà cette paire normalisée.');
+
+                return $this->redirectToRoute('app_lastfm_alias_index');
+            }
+
+            $cacheRepo->purgeByCouple($oldSourceArtist, $oldSourceTitle);
+            if ($oldSourceArtist !== $sourceArtist || $oldSourceTitle !== $sourceTitle) {
+                $cacheRepo->purgeByCouple($sourceArtist, $sourceTitle);
+            }
+            $em->flush();
+
+            $this->addFlash('success', sprintf('Alias « %s — %s » mis à jour.', $sourceArtist, $sourceTitle));
+
+            return $this->redirectToRoute('app_lastfm_alias_index');
+        }
+
+        return $this->render('lastfm/aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/lastfm/aliases/{id}/delete', name: 'app_lastfm_alias_delete', methods: ['POST'])]
+    public function delete(
+        int $id,
+        Request $request,
+        LastFmAliasRepository $repo,
+        EntityManagerInterface $em,
+        LastFmMatchCacheRepository $cacheRepo,
+    ): Response {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        if (!$this->isCsrfTokenValid('delete-alias-' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $label = sprintf('%s — %s', $alias->getSourceArtist(), $alias->getSourceTitle());
+        $sourceArtist = $alias->getSourceArtist();
+        $sourceTitle = $alias->getSourceTitle();
+        $em->remove($alias);
+        $em->flush();
+        // Drop the cache row for this couple. Without the alias, the
+        // cascade now decides — and any stale resolution cached from
+        // before the alias was created might be wrong.
+        $cacheRepo->purgeByCouple($sourceArtist, $sourceTitle);
+        $em->flush();
+        $this->addFlash('success', sprintf('Alias « %s » supprimé.', $label));
+
+        return $this->redirectToRoute('app_lastfm_alias_index');
+    }
+}

--- a/src/Controller/LastFmArtistAliasController.php
+++ b/src/Controller/LastFmArtistAliasController.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\LastFmArtistAlias;
+use App\Form\LastFmArtistAliasType;
+use App\Repository\LastFmArtistAliasRepository;
+use App\Repository\LastFmMatchCacheRepository;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmArtistAliasController extends AbstractController
+{
+    private const PER_PAGE = 25;
+
+    #[Route('/lastfm/artist-aliases', name: 'app_lastfm_artist_alias_index', methods: ['GET'])]
+    public function index(Request $request, LastFmArtistAliasRepository $repo): Response
+    {
+        $query = trim((string) $request->query->get('q', ''));
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $aliases = $repo->search($query, $page, self::PER_PAGE);
+        $total = $repo->countSearch($query);
+        $totalPages = (int) max(1, ceil($total / self::PER_PAGE));
+
+        return $this->render('lastfm/artist_aliases/index.html.twig', [
+            'aliases' => $aliases,
+            'total' => $total,
+            'page' => $page,
+            'total_pages' => $totalPages,
+            'filters' => ['q' => $query],
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/new', name: 'app_lastfm_artist_alias_new', methods: ['GET', 'POST'])]
+    public function new(
+        Request $request,
+        LastFmArtistAliasRepository $repo,
+        EntityManagerInterface $em,
+        LastFmMatchCacheRepository $cacheRepo,
+    ): Response {
+        // Pre-fill from query string when coming from the « Aliaser l'artiste »
+        // button — passed as a FormType option so it wires into the field's
+        // initial `data`. Setting `data` via the form builder takes precedence
+        // over post-creation `setData()` calls, hence this route.
+        $prefillSource = $request->isMethod('GET')
+            ? trim((string) $request->query->get('source_artist', ''))
+            : '';
+
+        $form = $this->createForm(LastFmArtistAliasType::class, null, [
+            'alias' => null,
+            'prefill_source_artist' => $prefillSource,
+        ]);
+
+        $form->handleRequest($request);
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $targetArtist = (string) $form->get('target_artist')->getData();
+
+            $existing = $repo->findBySourceArtist($sourceArtist);
+            if ($existing !== null) {
+                $this->addFlash('error', sprintf(
+                    'Un alias existe déjà pour « %s » → « %s ». Modifiez-le au lieu d\'en créer un nouveau.',
+                    $existing->getSourceArtist(),
+                    $existing->getTargetArtist(),
+                ));
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_edit', ['id' => $existing->getId()]);
+            }
+
+            $alias = new LastFmArtistAlias($sourceArtist, $targetArtist);
+            try {
+                $em->persist($alias);
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un alias normalisé identique existe déjà — modifiez-le.');
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_index', ['q' => $sourceArtist]);
+            }
+
+            // Drop every cache row keyed under the alias source — the
+            // matcher now rewrites those scrobbles to `$targetArtist`
+            // before the cache lookup, so the old rows are unreachable
+            // dead weight (and might mislead a future delete-alias
+            // resurrection if we kept them).
+            $cacheRepo->purgeByArtist($sourceArtist);
+            $em->flush();
+
+            $this->addFlash('success', sprintf(
+                'Alias artiste créé : « %s » → « %s ». Lancez « Re-tenter le matching » pour ré-essayer les unmatched.',
+                $sourceArtist,
+                $targetArtist,
+            ));
+
+            return $this->redirectToRoute('app_lastfm_artist_alias_index');
+        }
+
+        return $this->render('lastfm/artist_aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => null,
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/{id}/edit', name: 'app_lastfm_artist_alias_edit', methods: ['GET', 'POST'])]
+    public function edit(
+        int $id,
+        Request $request,
+        LastFmArtistAliasRepository $repo,
+        EntityManagerInterface $em,
+        LastFmMatchCacheRepository $cacheRepo,
+    ): Response {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        $form = $this->createForm(LastFmArtistAliasType::class, null, [
+            'alias' => $alias,
+        ]);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $sourceArtist = (string) $form->get('source_artist')->getData();
+            $targetArtist = (string) $form->get('target_artist')->getData();
+
+            $oldSourceArtist = $alias->getSourceArtist();
+
+            $alias->setSource($sourceArtist);
+            $alias->setTargetArtist($targetArtist);
+
+            try {
+                $em->flush();
+            } catch (UniqueConstraintViolationException) {
+                $this->addFlash('error', 'Un autre alias couvre déjà cet artiste source normalisé.');
+
+                return $this->redirectToRoute('app_lastfm_artist_alias_index');
+            }
+
+            $cacheRepo->purgeByArtist($oldSourceArtist);
+            if ($oldSourceArtist !== $sourceArtist) {
+                $cacheRepo->purgeByArtist($sourceArtist);
+            }
+            $em->flush();
+
+            $this->addFlash('success', sprintf('Alias artiste « %s » → « %s » mis à jour.', $sourceArtist, $targetArtist));
+
+            return $this->redirectToRoute('app_lastfm_artist_alias_index');
+        }
+
+        return $this->render('lastfm/artist_aliases/form.html.twig', [
+            'form' => $form,
+            'alias' => $alias,
+        ]);
+    }
+
+    #[Route('/lastfm/artist-aliases/{id}/delete', name: 'app_lastfm_artist_alias_delete', methods: ['POST'])]
+    public function delete(int $id, Request $request, LastFmArtistAliasRepository $repo, EntityManagerInterface $em): Response
+    {
+        $alias = $repo->find($id);
+        if ($alias === null) {
+            throw $this->createNotFoundException('Alias introuvable.');
+        }
+
+        if (!$this->isCsrfTokenValid('delete-artist-alias-' . $id, (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Jeton CSRF invalide.');
+        }
+
+        $label = sprintf('%s → %s', $alias->getSourceArtist(), $alias->getTargetArtist());
+        $em->remove($alias);
+        $em->flush();
+        // Intentional no-op on the match cache. Rows keyed under the
+        // alias *target* artist (e.g. « la ruda ») were created by
+        // legitimate scrobbles whose original artist was already that
+        // name — they remain correct after the alias is gone. Rows
+        // under the alias *source* never existed once the alias started
+        // rewriting them. Negative TTL handles any future drift.
+        $this->addFlash('success', sprintf('Alias artiste « %s » supprimé.', $label));
+
+        return $this->redirectToRoute('app_lastfm_artist_alias_index');
+    }
+}

--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Entity\ScrobbleSync;
+use App\Message\RematchMessage;
 use App\Message\SyncNavidromeMessage;
 use App\Repository\ScrobbleSyncRepository;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -31,20 +32,32 @@ class NavidromeSyncController extends AbstractController
             throw $this->createAccessDeniedException();
         }
 
-        $dryRun = (bool) $request->request->get('dry_run');
-        $autoStop = (bool) $request->request->get('auto_stop');
-        $limit = max(0, (int) $request->request->get('limit', 0));
-        $tolerance = max(0, (int) $request->request->get('tolerance', 60));
-
         $bus->dispatch(new SyncNavidromeMessage(
-            limit: $limit,
-            dryRun: $dryRun,
-            toleranceSeconds: $tolerance,
-            autoStop: $autoStop,
+            limit: max(0, (int) $request->request->get('limit', 0)),
+            dryRun: (bool) $request->request->get('dry_run'),
+            toleranceSeconds: max(0, (int) $request->request->get('tolerance', 60)),
+            autoStop: (bool) $request->request->get('auto_stop'),
         ));
 
-        $this->addFlash('success', 'Sync Navidrome lancé en arrière-plan. Suivez la progression dans l\'historique.');
+        $this->addFlash('success', 'Sync Navidrome lancé en arrière-plan.');
+        return $this->redirectToRoute('app_history');
+    }
 
+    #[Route('/navidrome/rematch', name: 'app_navidrome_rematch', methods: ['POST'])]
+    public function rematch(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_rematch', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $bus->dispatch(new RematchMessage(
+            target: ScrobbleSync::TARGET_NAVIDROME,
+            limit: max(0, (int) $request->request->get('limit', 0)),
+            dryRun: (bool) $request->request->get('dry_run'),
+            autoStop: (bool) $request->request->get('auto_stop'),
+        ));
+
+        $this->addFlash('success', 'Rematch Navidrome lancé en arrière-plan.');
         return $this->redirectToRoute('app_history');
     }
 
@@ -53,8 +66,16 @@ class NavidromeSyncController extends AbstractController
     {
         $page = max(1, (int) $request->query->get('page', 1));
         $perPage = 50;
+        $filterArtist = trim((string) $request->query->get('artist', ''));
+        $filterTitle = trim((string) $request->query->get('title', ''));
 
-        $rows = $syncRepo->aggregateUnmatched(ScrobbleSync::TARGET_NAVIDROME, $perPage, ($page - 1) * $perPage);
+        $rows = $syncRepo->aggregateUnmatched(
+            target: ScrobbleSync::TARGET_NAVIDROME,
+            limit: $perPage,
+            offset: ($page - 1) * $perPage,
+            filterArtist: $filterArtist !== '' ? $filterArtist : null,
+            filterTitle: $filterTitle !== '' ? $filterTitle : null,
+        );
         $total = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
 
         return $this->render('navidrome/unmatched.html.twig', [
@@ -62,6 +83,8 @@ class NavidromeSyncController extends AbstractController
             'total' => $total,
             'page' => $page,
             'pages' => max(1, (int) ceil($total / $perPage)),
+            'filter_artist' => $filterArtist,
+            'filter_title' => $filterTitle,
         ]);
     }
 }

--- a/src/Controller/StrawberryController.php
+++ b/src/Controller/StrawberryController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\RunHistory;
 use App\Entity\ScrobbleSync;
+use App\Message\RematchMessage;
 use App\Message\SyncStrawberryMessage;
 use App\Repository\ScrobbleSyncRepository;
 use App\Service\RunHistoryRecorder;
@@ -159,13 +160,39 @@ class StrawberryController extends AbstractController
         return $this->redirectToRoute('app_strawberry_sync');
     }
 
+    #[Route('/strawberry/rematch', name: 'app_strawberry_rematch', methods: ['POST'])]
+    public function rematch(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_rematch', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $bus->dispatch(new RematchMessage(
+            target: ScrobbleSync::TARGET_STRAWBERRY,
+            limit: max(0, (int) $request->request->get('limit', 0)),
+            dryRun: (bool) $request->request->get('dry_run'),
+            autoStop: false,
+        ));
+
+        $this->addFlash('success', 'Rematch Strawberry lancé en arrière-plan.');
+        return $this->redirectToRoute('app_history');
+    }
+
     #[Route('/strawberry/unmatched', name: 'app_strawberry_unmatched', methods: ['GET'])]
     public function unmatched(Request $request): Response
     {
         $page = max(1, (int) $request->query->get('page', 1));
         $perPage = 50;
+        $filterArtist = trim((string) $request->query->get('artist', ''));
+        $filterTitle = trim((string) $request->query->get('title', ''));
 
-        $rows = $this->syncRepo->aggregateUnmatched(ScrobbleSync::TARGET_STRAWBERRY, $perPage, ($page - 1) * $perPage);
+        $rows = $this->syncRepo->aggregateUnmatched(
+            target: ScrobbleSync::TARGET_STRAWBERRY,
+            limit: $perPage,
+            offset: ($page - 1) * $perPage,
+            filterArtist: $filterArtist !== '' ? $filterArtist : null,
+            filterTitle: $filterTitle !== '' ? $filterTitle : null,
+        );
         $total = $this->syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_STRAWBERRY);
 
         return $this->render('strawberry/unmatched.html.twig', [
@@ -173,6 +200,8 @@ class StrawberryController extends AbstractController
             'total' => $total,
             'page' => $page,
             'pages' => max(1, (int) ceil($total / $perPage)),
+            'filter_artist' => $filterArtist,
+            'filter_title' => $filterTitle,
         ]);
     }
 

--- a/src/Form/LastFmAliasType.php
+++ b/src/Form/LastFmAliasType.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\LastFmAlias;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @extends AbstractType<LastFmAlias|null>
+ */
+class LastFmAliasType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var LastFmAlias|null $alias */
+        $alias = $options['alias'];
+        $isSkip = $alias !== null && $alias->isSkip();
+        $prefillArtist = $options['prefill_source_artist'] !== ''
+            ? $options['prefill_source_artist']
+            : ($alias?->getSourceArtist() ?? '');
+        $prefillTitle = $options['prefill_source_title'] !== ''
+            ? $options['prefill_source_title']
+            : ($alias?->getSourceTitle() ?? '');
+
+        $builder
+            ->add('source_artist', TextType::class, [
+                'label' => 'Artiste (Last.fm)',
+                'help' => 'Tel qu\'écrit par Last.fm. Comparé sans accents / casse / ponctuation.',
+                'data' => $prefillArtist,
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('source_title', TextType::class, [
+                'label' => 'Titre (Last.fm)',
+                'data' => $prefillTitle,
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('skip', CheckboxType::class, [
+                'label' => 'Ignorer ce scrobble (au lieu de le mapper)',
+                'help' => 'Cochez pour que ces scrobbles soient comptés en « Ignorés » plutôt qu\'écrits dans la lib (utile pour les podcasts ou le bruit).',
+                'required' => false,
+                'data' => $isSkip,
+            ])
+            ->add('target_media_file_id', TextType::class, [
+                'label' => 'ID du media_file Navidrome',
+                'help' => 'Cherchez le morceau dans Navidrome ; l\'ID figure dans l\'URL (ex. /app/#/track/abc-123-def → abc-123-def). Laissez vide si vous cochez « Ignorer ».',
+                'data' => $alias !== null && !$alias->isSkip() ? $alias->getTargetMediaFileId() : '',
+                'required' => false,
+            ]);
+
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $form = $event->getForm();
+            $skip = (bool) $form->get('skip')->getData();
+            $target = trim((string) $form->get('target_media_file_id')->getData());
+            if (!$skip && $target === '') {
+                $form->get('target_media_file_id')->addError(
+                    new FormError('Renseignez un ID de media_file ou cochez « Ignorer ce scrobble ».'),
+                );
+            }
+            if ($skip && $target !== '') {
+                $form->get('target_media_file_id')->addError(
+                    new FormError('Décochez « Ignorer » pour mapper vers un media_file.'),
+                );
+            }
+        });
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'alias' => null,
+            'prefill_source_artist' => '',
+            'prefill_source_title' => '',
+        ]);
+        $resolver->setAllowedTypes('alias', [LastFmAlias::class, 'null']);
+        $resolver->setAllowedTypes('prefill_source_artist', 'string');
+        $resolver->setAllowedTypes('prefill_source_title', 'string');
+    }
+}

--- a/src/Form/LastFmArtistAliasType.php
+++ b/src/Form/LastFmArtistAliasType.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Form;
+
+use App\Entity\LastFmArtistAlias;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\NotBlank;
+
+/**
+ * @extends AbstractType<LastFmArtistAlias|null>
+ */
+class LastFmArtistAliasType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        /** @var LastFmArtistAlias|null $alias */
+        $alias = $options['alias'];
+        $prefillSource = $options['prefill_source_artist'] !== ''
+            ? $options['prefill_source_artist']
+            : ($alias?->getSourceArtist() ?? '');
+
+        $builder
+            ->add('source_artist', TextType::class, [
+                'label' => 'Artiste source (Last.fm)',
+                'help' => 'Le nom tel qu\'envoyé par Last.fm (ex. « La Ruda Salska »). Comparé sans accents / casse / ponctuation.',
+                'data' => $prefillSource,
+                'constraints' => [new NotBlank()],
+            ])
+            ->add('target_artist', TextType::class, [
+                'label' => 'Artiste cible (canonique côté Navidrome)',
+                'help' => 'Le nom tel qu\'il apparaît dans votre lib Navidrome (ex. « La Ruda »). Une fois la cascade relancée, tous les scrobbles de l\'artiste source seront ré-essayés avec ce nom.',
+                'data' => $alias?->getTargetArtist() ?? '',
+                'constraints' => [new NotBlank()],
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'alias' => null,
+            'prefill_source_artist' => '',
+        ]);
+        $resolver->setAllowedTypes('alias', [LastFmArtistAlias::class, 'null']);
+        $resolver->setAllowedTypes('prefill_source_artist', 'string');
+    }
+}

--- a/src/Message/RematchMessage.php
+++ b/src/Message/RematchMessage.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Message;
+
+final class RematchMessage
+{
+    public function __construct(
+        public readonly string $target,
+        public readonly int $limit,
+        public readonly bool $dryRun,
+        public readonly bool $autoStop,
+    ) {
+    }
+}

--- a/src/MessageHandler/RematchMessageHandler.php
+++ b/src/MessageHandler/RematchMessageHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Docker\NavidromeContainerManager;
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Message\RematchMessage;
+use App\Navidrome\NavidromeSyncReport;
+use App\Navidrome\NavidromeSyncService;
+use App\Repository\ScrobbleSyncRepository;
+use App\Service\RunHistoryRecorder;
+use App\Strawberry\StrawberrySyncReport;
+use App\Strawberry\StrawberrySyncService;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class RematchMessageHandler
+{
+    public function __construct(
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly NavidromeSyncService $navidromeSync,
+        private readonly StrawberrySyncService $strawberrySync,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly NavidromeContainerManager $container,
+    ) {
+    }
+
+    public function __invoke(RematchMessage $message): void
+    {
+        $type = $message->target === ScrobbleSync::TARGET_NAVIDROME
+            ? RunHistory::TYPE_NAVIDROME_REMATCH
+            : RunHistory::TYPE_STRAWBERRY_REMATCH;
+
+        $runProcess = fn () => $this->recorder->record(
+            type: $type,
+            reference: 'unmatched',
+            label: sprintf('%s rematch%s', $message->target, $message->dryRun ? ' [dry-run]' : ''),
+            action: function (RunHistory $entry) use ($message): NavidromeSyncReport|StrawberrySyncReport {
+                $this->syncRepo->resetUnmatchedToPending($message->target);
+                if ($message->target === ScrobbleSync::TARGET_NAVIDROME) {
+                    return $this->navidromeSync->process(limit: $message->limit, dryRun: $message->dryRun, run: $entry);
+                }
+                return $this->strawberrySync->process(limit: $message->limit, dryRun: $message->dryRun, run: $entry);
+            },
+            extractMetrics: static fn (NavidromeSyncReport|StrawberrySyncReport $r): array => [
+                'considered' => $r->considered,
+                'matched' => $r->matched,
+                'unmatched' => $r->unmatched,
+            ],
+        );
+
+        if ($message->target === ScrobbleSync::TARGET_NAVIDROME && $message->autoStop && !$message->dryRun) {
+            $this->container->runWithNavidromeStopped($runProcess);
+        } else {
+            $runProcess();
+        }
+    }
+}

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -101,23 +101,38 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
      *
      * @return list<array{artist: string, title: string, album: string|null, count: int, last_played_at: string}>
      */
-    public function aggregateUnmatched(string $target, int $limit = 50, int $offset = 0): array
-    {
+    public function aggregateUnmatched(
+        string $target,
+        int $limit = 50,
+        int $offset = 0,
+        ?string $filterArtist = null,
+        ?string $filterTitle = null,
+    ): array {
+        $where = ['ss.target = :target', 'ss.status = :status'];
+        $params = ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED];
+
+        if ($filterArtist !== null) {
+            $where[] = 'LOWER(s.artist) LIKE LOWER(:artist)';
+            $params['artist'] = '%' . $filterArtist . '%';
+        }
+        if ($filterTitle !== null) {
+            $where[] = 'LOWER(s.title) LIKE LOWER(:title)';
+            $params['title'] = '%' . $filterTitle . '%';
+        }
+
+        $params['lim'] = $limit;
+        $params['off'] = $offset;
+
         /** @var list<array{artist: string, title: string, album: string|null, count: int, last_played_at: string}> */
         return $this->em->getConnection()->fetchAllAssociative(
             'SELECT s.artist, s.title, s.album, COUNT(*) AS count, MAX(s.played_at) AS last_played_at
              FROM scrobble_sync ss
              JOIN scrobbles s ON s.id = ss.scrobble_id
-             WHERE ss.target = :target AND ss.status = :status
+             WHERE ' . implode(' AND ', $where) . '
              GROUP BY s.artist, s.title, s.album
              ORDER BY count DESC, last_played_at DESC
              LIMIT :lim OFFSET :off',
-            [
-                'target' => $target,
-                'status' => ScrobbleSync::STATUS_UNMATCHED,
-                'lim' => $limit,
-                'off' => $offset,
-            ],
+            $params,
         );
     }
 }

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -3,11 +3,53 @@
 {% block body %}
     <h1 class="text-2xl font-semibold mb-6">Dashboard</h1>
 
-    <div class="bg-amber-50 border border-amber-300 rounded-sm p-4 mb-6 text-sm text-amber-900">
-        🚧 <strong>Navidrome Tools v2</strong> — développement en cours (Lot 2 : import Last.fm à venir).
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Scrobbles locaux</div>
+            <div class="text-3xl font-semibold">{{ total_scrobbles|number_format(0, '.', ' ') }}</div>
+            <div class="text-xs text-slate-400 mt-1"><a href="{{ path('app_lastfm_import') }}" class="hover:underline">Import Last.fm →</a></div>
+        </div>
+
+        <div class="bg-white shadow-sm rounded-sm p-4 {{ navidrome_unmatched > 0 ? 'border border-amber-200' : '' }}">
+            <div class="text-xs uppercase text-slate-500">Navidrome</div>
+            <div class="text-lg font-semibold">{{ navidrome_matched|number_format(0, '.', ' ') }} matchés</div>
+            <div class="text-xs mt-1 space-y-0.5">
+                {% if navidrome_pending > 0 %}
+                <div class="text-amber-700">{{ navidrome_pending }} en attente — <a href="{{ path('app_navidrome_sync') }}" class="underline">sync</a></div>
+                {% endif %}
+                {% if navidrome_unmatched > 0 %}
+                <div class="text-rose-600">{{ navidrome_unmatched }} non matchés — <a href="{{ path('app_navidrome_unmatched') }}" class="underline">voir</a></div>
+                {% elseif navidrome_pending == 0 %}
+                <div class="text-emerald-600">✓ à jour</div>
+                {% endif %}
+            </div>
+        </div>
+
+        {% if strawberry_active %}
+        <div class="bg-white shadow-sm rounded-sm p-4 {{ strawberry_unmatched > 0 ? 'border border-amber-200' : '' }}">
+            <div class="text-xs uppercase text-slate-500">Strawberry</div>
+            <div class="text-xs mt-1 space-y-0.5">
+                {% if strawberry_pending > 0 %}
+                <div class="text-amber-700">{{ strawberry_pending }} en attente — <a href="{{ path('app_strawberry_sync') }}" class="underline">sync</a></div>
+                {% endif %}
+                {% if strawberry_unmatched > 0 %}
+                <div class="text-rose-600">{{ strawberry_unmatched }} non matchés — <a href="{{ path('app_strawberry_unmatched') }}" class="underline">voir</a></div>
+                {% elseif strawberry_pending == 0 %}
+                <div class="text-emerald-600">✓ à jour</div>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
+
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Aliases</div>
+            <div class="text-xs mt-2 space-y-1">
+                <div><a href="{{ path('app_lastfm_aliases') }}" class="text-sky-700 hover:underline">Aliases track →</a></div>
+                <div><a href="{{ path('app_lastfm_artist_aliases') }}" class="text-sky-700 hover:underline">Aliases artiste →</a></div>
+            </div>
+        </div>
     </div>
 
-    {# Derniers runs #}
     <div class="bg-white shadow-sm rounded-sm overflow-hidden">
         <div class="flex items-center justify-between px-3 py-2 bg-slate-100 border-b">
             <h2 class="text-sm font-semibold text-slate-700">Derniers runs</h2>
@@ -30,9 +72,7 @@
                 {% for run in recent_runs %}
                     <tr class="hover:bg-slate-50">
                         <td class="px-3 py-1.5">
-                            <a href="{{ path('app_history_show', {id: run.id}) }}" class="hover:underline">
-                                {{ run.label }}
-                            </a>
+                            <a href="{{ path('app_history_show', {id: run.id}) }}" class="hover:underline">{{ run.label }}</a>
                         </td>
                         <td class="px-3 py-1.5 font-mono text-xs text-slate-500">{{ run.type }}</td>
                         <td class="px-3 py-1.5">
@@ -44,12 +84,10 @@
                                 {{ run.status }}
                             </span>
                         </td>
-                        <td class="px-3 py-1.5 text-right text-xs text-slate-500 font-mono">
+                        <td class="px-3 py-1.5 text-right text-xs font-mono">
                             {% if run.durationMs %}{{ (run.durationMs / 1000)|number_format(1) }}s{% else %}—{% endif %}
                         </td>
-                        <td class="px-3 py-1.5 text-right text-xs text-slate-500">
-                            {{ run.startedAt|date('d/m H:i') }}
-                        </td>
+                        <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ run.startedAt|date('d/m H:i') }}</td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/templates/lastfm/aliases/form.html.twig
+++ b/templates/lastfm/aliases/form.html.twig
@@ -1,0 +1,61 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ alias ? 'Modifier alias' : 'Nouvel alias' }} Last.fm{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-sky-700 hover:underline">
+            ← Retour à la liste des alias
+        </a>
+    </div>
+
+    <h1 class="text-2xl font-semibold mb-2">
+        {{ alias ? 'Modifier l\'alias' : 'Nouvel alias Last.fm → Navidrome' }}
+    </h1>
+    <p class="text-sm text-slate-500 mb-6">
+        Forcez la résolution d'une paire (artiste, titre) Last.fm vers un media_file Navidrome
+        spécifique. Consulté avant toutes les heuristiques de matching.
+    </p>
+
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl">
+        {{ form_start(form) }}
+            <div class="space-y-4">
+                <div>
+                    {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
+                    {{ form_errors(form.source_artist) }}
+                </div>
+                <div>
+                    {{ form_label(form.source_title, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_title, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
+                    {{ form_errors(form.source_title) }}
+                </div>
+
+                <div class="border-t pt-4">
+                    <label class="flex items-center gap-2 text-sm">
+                        {{ form_widget(form.skip, {attr: {class: 'h-4 w-4'}}) }}
+                        <span>{{ form.skip.vars.label }}</span>
+                    </label>
+                    <p class="text-xs text-slate-500 mt-1 ml-6">{{ form_help(form.skip) }}</p>
+                </div>
+
+                <div>
+                    {{ form_label(form.target_media_file_id, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.target_media_file_id, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm font-mono'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_media_file_id) }}</p>
+                    {{ form_errors(form.target_media_file_id) }}
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3 mt-6">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
+                    {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias' }}
+                </button>
+                <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-slate-500 hover:underline">
+                    Annuler
+                </a>
+            </div>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/lastfm/aliases/index.html.twig
+++ b/templates/lastfm/aliases/index.html.twig
@@ -1,0 +1,91 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Alias Last.fm{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Alias Last.fm → Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ total|number_format(0, '.', ' ') }} alias définis. Consultés en priorité avant toutes les heuristiques de matching.
+            </p>
+        </div>
+        <a href="{{ path('app_lastfm_alias_new') }}"
+           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias</a>
+    </div>
+
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[200px]">
+            <label class="block text-xs uppercase text-slate-500">Recherche</label>
+            <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste ou titre source…"
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_lastfm_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
+    </form>
+
+    {% if aliases is empty %}
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
+            {% if filters.q %}
+                Aucun alias ne correspond à « {{ filters.q }} ».
+            {% else %}
+                Aucun alias défini pour l'instant. Cliquez « + Nouvel alias » ou utilisez le bouton « ✏️ Mapper »
+                à côté d'un scrobble non matché dans le détail d'un import Last.fm.
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2">Source (artiste)</th>
+                    <th class="px-3 py-2">Source (titre)</th>
+                    <th class="px-3 py-2">Cible</th>
+                    <th class="px-3 py-2">Créé le</th>
+                    <th class="px-3 py-2"></th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for alias in aliases %}
+                    <tr>
+                        <td class="px-3 py-1.5">{{ alias.sourceArtist }}</td>
+                        <td class="px-3 py-1.5">{{ alias.sourceTitle }}</td>
+                        <td class="px-3 py-1.5 font-mono text-xs">
+                            {% if alias.skip %}
+                                <span class="px-2 py-0.5 rounded-sm bg-amber-100 text-amber-800">IGNORÉ</span>
+                            {% else %}
+                                {{ alias.targetMediaFileId }}
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">{{ alias.createdAt|date('Y-m-d H:i') }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            <a href="{{ path('app_lastfm_alias_edit', {id: alias.id}) }}"
+                               class="text-xs text-sky-700 hover:underline">Modifier</a>
+                            <form method="post" action="{{ path('app_lastfm_alias_delete', {id: alias.id}) }}"
+                                  class="inline-block ml-2"
+                                  onsubmit="return confirm('Supprimer cet alias ?');">
+                                <input type="hidden" name="_token" value="{{ csrf_token('delete-alias-' ~ alias.id) }}">
+                                <button type="submit" class="text-xs text-rose-700 hover:underline">Supprimer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_lastfm_alias_index', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/lastfm/artist_aliases/form.html.twig
+++ b/templates/lastfm/artist_aliases/form.html.twig
@@ -1,0 +1,49 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ alias ? 'Modifier alias artiste' : 'Nouvel alias artiste' }} Last.fm{% endblock %}
+
+{% block body %}
+    <div class="mb-4">
+        <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-sky-700 hover:underline">
+            ← Retour à la liste des alias artistes
+        </a>
+    </div>
+
+    <h1 class="text-2xl font-semibold mb-2">
+        {{ alias ? 'Modifier l\'alias artiste' : 'Nouvel alias artiste' }}
+    </h1>
+    <p class="text-sm text-slate-500 mb-6">
+        Réécrit le nom d'artiste source en nom canonique avant la cascade de matching.
+        Un seul alias couvre tous les morceaux de l'artiste — utile pour les renommages
+        (« La Ruda Salska » → « La Ruda »), les variantes de romanisation, ou les conventions
+        « The X » / « X, The ».
+    </p>
+
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-2xl">
+        {{ form_start(form) }}
+            <div class="space-y-4">
+                <div>
+                    {{ form_label(form.source_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.source_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.source_artist) }}</p>
+                    {{ form_errors(form.source_artist) }}
+                </div>
+                <div>
+                    {{ form_label(form.target_artist, null, {label_attr: {class: 'block text-xs uppercase text-slate-500'}}) }}
+                    {{ form_widget(form.target_artist, {attr: {class: 'w-full border rounded-sm px-2 py-1 text-sm'}}) }}
+                    <p class="text-xs text-slate-500 mt-1">{{ form_help(form.target_artist) }}</p>
+                    {{ form_errors(form.target_artist) }}
+                </div>
+            </div>
+
+            <div class="flex items-center gap-3 mt-6">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
+                    {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias artiste' }}
+                </button>
+                <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-slate-500 hover:underline">
+                    Annuler
+                </a>
+            </div>
+        {{ form_end(form) }}
+    </div>
+{% endblock %}

--- a/templates/lastfm/artist_aliases/index.html.twig
+++ b/templates/lastfm/artist_aliases/index.html.twig
@@ -1,0 +1,86 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Alias artistes Last.fm{% endblock %}
+
+{% block body %}
+    <div class="flex items-start justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Alias artistes Last.fm → Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ total|number_format(0, '.', ' ') }} alias définis. Réécrit le nom d'artiste avant la cascade
+                (utile pour les renommages : « La Ruda Salska » → « La Ruda »). Un seul alias couvre tous les
+                morceaux. Pour mapper un track précis vers un media_file, utilisez les
+                <a href="{{ path('app_lastfm_alias_index') }}" class="underline">alias track-level</a>.
+            </p>
+        </div>
+        <a href="{{ path('app_lastfm_artist_alias_new') }}"
+           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias artiste</a>
+    </div>
+
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
+        <div class="flex-1 min-w-[200px]">
+            <label class="block text-xs uppercase text-slate-500">Recherche</label>
+            <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste source ou cible…"
+                   class="w-full border rounded-sm px-2 py-1 text-sm">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
+    </form>
+
+    {% if aliases is empty %}
+        <div class="bg-white shadow-sm rounded-sm p-6 text-center text-slate-500">
+            {% if filters.q %}
+                Aucun alias artiste ne correspond à « {{ filters.q }} ».
+            {% else %}
+                Aucun alias artiste défini pour l'instant. Cliquez « + Nouvel alias artiste » ou utilisez le bouton
+                « 🎭 Aliaser l'artiste » sur la page <a href="{{ path('app_lastfm_unmatched') }}" class="underline">Unmatched</a>.
+            {% endif %}
+        </div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-slate-600 text-left text-xs">
+                <tr>
+                    <th class="px-3 py-2">Artiste source (Last.fm)</th>
+                    <th class="px-3 py-2">Artiste cible (Navidrome)</th>
+                    <th class="px-3 py-2">Créé le</th>
+                    <th class="px-3 py-2"></th>
+                </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for alias in aliases %}
+                    <tr>
+                        <td class="px-3 py-1.5">{{ alias.sourceArtist }}</td>
+                        <td class="px-3 py-1.5">{{ alias.targetArtist }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500">{{ alias.createdAt|date('Y-m-d H:i') }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            <a href="{{ path('app_lastfm_artist_alias_edit', {id: alias.id}) }}"
+                               class="text-xs text-sky-700 hover:underline">Modifier</a>
+                            <form method="post" action="{{ path('app_lastfm_artist_alias_delete', {id: alias.id}) }}"
+                                  class="inline-block ml-2"
+                                  onsubmit="return confirm('Supprimer cet alias artiste ?');">
+                                <input type="hidden" name="_token" value="{{ csrf_token('delete-artist-alias-' ~ alias.id) }}">
+                                <button type="submit" class="text-xs text-rose-700 hover:underline">Supprimer</button>
+                            </form>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if total_pages > 1 %}
+            <div class="flex items-center justify-center gap-2 mt-4 text-sm">
+                {% if page > 1 %}
+                    <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page - 1})) }}"
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">‹ Précédent</a>
+                {% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ total_pages }}</span>
+                {% if page < total_pages %}
+                    <a href="{{ path('app_lastfm_artist_alias_index', filters|merge({page: page + 1})) }}"
+                       class="px-3 py-1 rounded-sm border hover:bg-slate-100">Suivant ›</a>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -1,19 +1,44 @@
 {% extends 'base.html.twig' %}
 {% block title %}Non matchés — Navidrome{% endblock %}
 {% block body %}
-    <div class="mb-4">
-        <a href="{{ path('app_navidrome_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Navidrome</a>
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <a href="{{ path('app_navidrome_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Navidrome</a>
+            <h1 class="text-2xl font-semibold mt-1">Scrobbles non matchés — Navidrome</h1>
+            <p class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }} (artiste, titre, album)</p>
+        </div>
+        <form method="post" action="{{ path('app_navidrome_rematch') }}" class="flex gap-2 items-center">
+            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_rematch') }}">
+            <label class="flex items-center gap-1 text-xs text-slate-500">
+                <input type="checkbox" name="auto_stop" value="1"> auto-stop
+            </label>
+            <button type="submit"
+                    class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                ↺ Rematcher tous
+            </button>
+        </form>
     </div>
 
-    <div class="flex items-center justify-between mb-4">
-        <h1 class="text-2xl font-semibold">Scrobbles non matchés — Navidrome</h1>
-        <span class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }}</span>
-    </div>
-
-    <p class="text-sm text-slate-500 mb-4">
-        Ces scrobbles n'ont pas trouvé de correspondance dans Navidrome. Créez un alias ou ajoutez les morceaux
-        à votre bibliothèque, puis relancez la sync avec <code>--retry-unmatched</code>.
-    </p>
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Artiste</label>
+            <input type="text" name="artist" value="{{ filter_artist }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Titre</label>
+            <input type="text" name="title" value="{{ filter_title }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_navidrome_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+        <a href="{{ path('app_lastfm_aliases') }}" class="ml-auto text-xs text-sky-700 hover:underline self-center">
+            Gérer les alias track →
+        </a>
+        <a href="{{ path('app_lastfm_artist_aliases') }}" class="text-xs text-sky-700 hover:underline self-center">
+            Alias artiste →
+        </a>
+    </form>
 
     {% if rows is empty %}
         <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun scrobble non matché 🎉</div>
@@ -27,6 +52,7 @@
                     <th class="px-3 py-2 text-left">Album</th>
                     <th class="px-3 py-2 text-right">Scrobbles</th>
                     <th class="px-3 py-2 text-right">Dernier joué</th>
+                    <th class="px-3 py-2 text-right">Actions</th>
                 </tr>
             </thead>
             <tbody class="divide-y">
@@ -37,17 +63,20 @@
                     <td class="px-3 py-1.5 text-slate-400 text-xs">{{ row.album ?? '—' }}</td>
                     <td class="px-3 py-1.5 text-right font-mono">{{ row.count }}</td>
                     <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ row.last_played_at|date('d/m/Y') }}</td>
+                    <td class="px-3 py-1.5 text-right">
+                        <a href="{{ path('app_lastfm_alias_new', {artist: row.artist, title: row.title}) }}"
+                           class="text-xs text-sky-700 hover:underline">✏️ Alias</a>
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>
         </table>
     </div>
-
     {% if pages > 1 %}
     <div class="flex gap-2 items-center text-sm">
-        {% if page > 1 %}<a href="{{ path('app_navidrome_unmatched', {page: page - 1}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
+        {% if page > 1 %}<a href="{{ path('app_navidrome_unmatched', {page: page - 1, artist: filter_artist, title: filter_title}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
         <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
-        {% if page < pages %}<a href="{{ path('app_navidrome_unmatched', {page: page + 1}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
+        {% if page < pages %}<a href="{{ path('app_navidrome_unmatched', {page: page + 1, artist: filter_artist, title: filter_title}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
     </div>
     {% endif %}
     {% endif %}

--- a/templates/strawberry/unmatched.html.twig
+++ b/templates/strawberry/unmatched.html.twig
@@ -1,15 +1,36 @@
 {% extends 'base.html.twig' %}
 {% block title %}Non matchés — Strawberry{% endblock %}
 {% block body %}
-    <div class="mb-4"><a href="{{ path('app_strawberry_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Strawberry</a></div>
-    <div class="flex items-center justify-between mb-4">
-        <h1 class="text-2xl font-semibold">Scrobbles non matchés — Strawberry</h1>
-        <span class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }}</span>
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <a href="{{ path('app_strawberry_sync') }}" class="text-sm text-sky-700 hover:underline">← Sync Strawberry</a>
+            <h1 class="text-2xl font-semibold mt-1">Scrobbles non matchés — Strawberry</h1>
+            <p class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }}</p>
+        </div>
+        <form method="post" action="{{ path('app_strawberry_rematch') }}" class="flex gap-2">
+            <input type="hidden" name="_token" value="{{ csrf_token('strawberry_rematch') }}">
+            <button type="submit"
+                    class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                ↺ Rematcher tous
+            </button>
+        </form>
     </div>
-    <p class="text-sm text-slate-500 mb-4">
-        Ces morceaux n'ont pas été trouvés dans Strawberry. Ajoutez-les à votre bibliothèque
-        puis relancez avec le bouton <em>Retry unmatched</em>.
-    </p>
+
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Artiste</label>
+            <input type="text" name="artist" value="{{ filter_artist }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Titre</label>
+            <input type="text" name="title" value="{{ filter_title }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_strawberry_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+    </form>
+
     {% if rows is empty %}
         <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun non matché 🎉</div>
     {% else %}
@@ -39,9 +60,9 @@
     </div>
     {% if pages > 1 %}
     <div class="flex gap-2 items-center text-sm">
-        {% if page > 1 %}<a href="{{ path('app_strawberry_unmatched', {page: page - 1}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
+        {% if page > 1 %}<a href="{{ path('app_strawberry_unmatched', {page: page - 1, artist: filter_artist, title: filter_title}) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
         <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
-        {% if page < pages %}<a href="{{ path('app_strawberry_unmatched', {page: page + 1}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
+        {% if page < pages %}<a href="{{ path('app_strawberry_unmatched', {page: page + 1, artist: filter_artist, title: filter_title}) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
     </div>
     {% endif %}
     {% endif %}


### PR DESCRIPTION
## Lot 5 — Rematch, Unmatched, Alias CRUD, Dashboard

### Ce qui est inclus

**Commande `app:scrobbles:rematch`** — `--target=navidrome|strawberry [--dry-run] [--limit] [--force] [--auto-stop]`
- Reset `unmatched → pending` via `resetUnmatchedToPending`
- Relance `NavidromeSyncService` ou `StrawberrySyncService`
- `RematchMessage` + `RematchMessageHandler` (Messenger async)
- Routes POST `/navidrome/rematch` + `/strawberry/rematch`

**Pages unmatched améliorées :**
- Filtres GET `artist` / `title` (LIKE case-insensitive) sur les deux cibles
- `ScrobbleSyncRepository::aggregateUnmatched()` accepte les filtres optionnels
- Bouton "↺ Rematcher tous" sur chaque page
- Liens vers CRUD alias depuis `/navidrome/unmatched`

**CRUD Last.fm aliases** (portés poc-v0, 0 modification) :
- `/lastfm/alias` — mapping manuel `(artist, title) → media_file_id` ou NULL (skip)
- `/lastfm/artist-alias` — réécriture nom artiste avant la cascade
- Forms `LastFmAliasType` + `LastFmArtistAliasType`

**Dashboard refait :**
- Card scrobbles totaux
- Card Navidrome (matchés / en attente / non matchés)
- Card Strawberry (si STRAWBERRY_DB_PATH configuré ou upload présent)
- Card Aliases (liens rapides)
- Derniers runs

### Tests

16 tests / 44 assertions — tous verts. phpcs + phpstan OK.

### Bilan lots 1–5

| Lot | Statut |
|-----|--------|
| 1 — Socle technique | ✅ mergé |
| 2 — Import Last.fm → scrobbles | ✅ mergé |
| 3 — Sync Navidrome | ✅ mergé |
| 4 — Sync Strawberry | ✅ mergé |
| 5 — Rematch + Unmatched + Alias | ✅ cette PR |
| 6 — Stats + historique | 🔜 prochaine |

### Prochaine étape

**Lot 6** — Stats + historique enrichi : `/stats` (tops artistes/tracks par période), `/stats/heatmap`, cards supplémentaires sur le dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)