### PR TITLE
feat(lot-6): statistiques d'écoute, container dashboard, page /stats

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -131,3 +131,15 @@ services:
     App\Strawberry\StrawberryUploadService:
         arguments:
             $varDir: '%kernel.project_dir%/var'
+
+    App\Command\ComputeStatsCommand:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
+    App\Controller\StatsController:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
+    App\Controller\DashboardController:
+        arguments:
+            $defaultUser: '%lastfm.user%'

--- a/migrations/Version20260515000000.php
+++ b/migrations/Version20260515000000.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260515000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add stats_snapshot table: cached listening statistics per period.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE stats_snapshot (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                period VARCHAR(32) NOT NULL UNIQUE,
+                data CLOB NOT NULL,
+                computed_at DATETIME NOT NULL
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE stats_snapshot');
+    }
+}

--- a/src/Command/ComputeStatsCommand.php
+++ b/src/Command/ComputeStatsCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Service\LocalStatsService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:stats:compute',
+    description: 'Compute and cache listening statistics from the local scrobbles table.',
+)]
+class ComputeStatsCommand extends Command
+{
+    public function __construct(
+        private readonly LocalStatsService $statsService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $defaultUser,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('period', 'p', InputOption::VALUE_REQUIRED, 'Single period to compute (default: all).', null)
+            ->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'Filter by Last.fm username.', null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $user = $input->getOption('user') ?? ($this->defaultUser !== '' ? $this->defaultUser : null);
+        $periodOpt = $input->getOption('period');
+        $periods = $periodOpt !== null ? [$periodOpt] : array_keys(LocalStatsService::PERIODS);
+
+        try {
+            $this->recorder->record(
+                type: RunHistory::TYPE_STATS,
+                reference: 'local',
+                label: 'Stats compute',
+                action: function () use ($periods, $user, $io): void {
+                    foreach ($periods as $period) {
+                        $data = $this->statsService->compute($period, $user);
+                        $io->writeln(sprintf(
+                            '  %s : %d plays, %d top artists, %d top tracks',
+                            $period,
+                            $data['total_plays'],
+                            count($data['top_artists']),
+                            count($data['top_tracks']),
+                        ));
+                    }
+                },
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('Stats computed for %d period(s).', count($periods)));
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -2,10 +2,12 @@
 
 namespace App\Controller;
 
+use App\Docker\NavidromeContainerManager;
 use App\Entity\ScrobbleSync;
 use App\Repository\RunHistoryRepository;
 use App\Repository\ScrobbleRepository;
 use App\Repository\ScrobbleSyncRepository;
+use App\Repository\SettingRepository;
 use App\Strawberry\StrawberryRepository;
 use App\Strawberry\StrawberryUploadService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,6 +16,10 @@ use Symfony\Component\Routing\Attribute\Route;
 
 class DashboardController extends AbstractController
 {
+    public function __construct(private readonly string $defaultUser)
+    {
+    }
+
     #[Route('/', name: 'app_dashboard')]
     public function index(
         RunHistoryRepository $runHistory,
@@ -21,8 +27,15 @@ class DashboardController extends AbstractController
         ScrobbleSyncRepository $syncRepo,
         StrawberryRepository $strawberry,
         StrawberryUploadService $uploadService,
+        NavidromeContainerManager $container,
+        SettingRepository $settings,
     ): Response {
         $recentRuns = $runHistory->findFilteredPaginated([], 1, 10)['items'];
+
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        $lastFetch = $user !== null ? $settings->get('lastfm_last_fetch_' . $user) : '';
+
+        $containerStatus = $container->getStatus();
 
         $navidromePending = $syncRepo->countPendingForTarget(ScrobbleSync::TARGET_NAVIDROME);
         $navidromeUnmatched = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
@@ -35,6 +48,10 @@ class DashboardController extends AbstractController
         return $this->render('dashboard/index.html.twig', [
             'recent_runs' => $recentRuns,
             'total_scrobbles' => $scrobbleRepo->countAll(),
+            'last_fetch' => $lastFetch !== '' ? new \DateTimeImmutable($lastFetch) : null,
+            'container_configured' => $container->isConfigured(),
+            'container_status' => $containerStatus->value,
+            'container_label' => $containerStatus->label(),
             'navidrome_pending' => $navidromePending,
             'navidrome_unmatched' => $navidromeUnmatched,
             'navidrome_matched' => $navidromeMatched,

--- a/src/Controller/NavidromeContainerController.php
+++ b/src/Controller/NavidromeContainerController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Controller;
+
+use App\Docker\NavidromeContainerException;
+use App\Docker\NavidromeContainerManager;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class NavidromeContainerController extends AbstractController
+{
+    public function __construct(
+        private readonly NavidromeContainerManager $manager,
+    ) {
+    }
+
+    #[Route('/navidrome/container/start', name: 'app_navidrome_container_start', methods: ['POST'])]
+    public function start(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_container', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (!$this->manager->isConfigured()) {
+            $this->addFlash('error', 'NAVIDROME_CONTAINER_NAME n\'est pas renseignée.');
+
+            return $this->backTo($request);
+        }
+
+        try {
+            $this->manager->start();
+            $this->addFlash('success', 'Conteneur Navidrome démarré.');
+        } catch (NavidromeContainerException $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->backTo($request);
+    }
+
+    #[Route('/navidrome/container/stop', name: 'app_navidrome_container_stop', methods: ['POST'])]
+    public function stop(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_container', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        if (!$this->manager->isConfigured()) {
+            $this->addFlash('error', 'NAVIDROME_CONTAINER_NAME n\'est pas renseignée.');
+
+            return $this->backTo($request);
+        }
+
+        try {
+            $this->manager->stop();
+            $this->addFlash('success', 'Conteneur Navidrome arrêté.');
+        } catch (NavidromeContainerException $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->backTo($request);
+    }
+
+    private function backTo(Request $request): Response
+    {
+        $back = (string) $request->request->get('_back', '');
+        if ($back !== '' && str_starts_with($back, '/')) {
+            return $this->redirect($back);
+        }
+
+        return $this->redirectToRoute('app_dashboard');
+    }
+}

--- a/src/Controller/StatsController.php
+++ b/src/Controller/StatsController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\RunHistory;
+use App\Repository\ScrobbleRepository;
+use App\Service\LocalStatsService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class StatsController extends AbstractController
+{
+    public function __construct(
+        private readonly LocalStatsService $statsService,
+        private readonly ScrobbleRepository $scrobbleRepo,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $defaultUser,
+    ) {
+    }
+
+    #[Route('/stats', name: 'app_stats', methods: ['GET'])]
+    public function index(Request $request): Response
+    {
+        $period = $request->query->get('period', LocalStatsService::PERIOD_30D);
+        if (!array_key_exists($period, LocalStatsService::PERIODS)) {
+            $period = LocalStatsService::PERIOD_30D;
+        }
+
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        $data = $this->statsService->get($period, $user);
+
+        return $this->render('stats/index.html.twig', [
+            'data' => $data,
+            'period' => $period,
+            'periods' => LocalStatsService::PERIODS,
+            'total_scrobbles' => $this->scrobbleRepo->countAll(),
+        ]);
+    }
+
+    #[Route('/stats/refresh', name: 'app_stats_refresh', methods: ['POST'])]
+    public function refresh(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('stats_refresh', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $period = $request->request->get('period', LocalStatsService::PERIOD_30D);
+        if (!array_key_exists($period, LocalStatsService::PERIODS)) {
+            $period = LocalStatsService::PERIOD_30D;
+        }
+
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+
+        try {
+            $this->recorder->record(
+                type: RunHistory::TYPE_STATS,
+                reference: 'local',
+                label: sprintf('Stats compute (%s)', $period),
+                action: fn () => $this->statsService->compute($period, $user),
+            );
+            $this->addFlash('success', sprintf('Statistiques rechargées pour « %s ».', LocalStatsService::PERIODS[$period]));
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_stats', ['period' => $period]);
+    }
+}

--- a/src/Entity/StatsSnapshot.php
+++ b/src/Entity/StatsSnapshot.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\StatsSnapshotRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity(repositoryClass: StatsSnapshotRepository::class)]
+#[ORM\Table(name: 'stats_snapshot')]
+class StatsSnapshot
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 32, unique: true)]
+    private string $period;
+
+    /**
+     * Free-form JSON payload. The 'stats' periods carry the keys total_plays,
+     * distinct_tracks, top_artists, top_tracks, window_from, window_to ; the
+     * 'wrapped-<year>' periods add wrapped_* keys (year, total seconds estimate,
+     * new artists list, streak days, most active month).
+     *
+     * @var array<string, mixed>
+     */
+    #[ORM\Column(type: Types::JSON)]
+    private array $data = [
+        'total_plays' => 0,
+        'distinct_tracks' => 0,
+        'top_artists' => [],
+        'top_tracks' => [],
+        'window_from' => null,
+        'window_to' => null,
+    ];
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $computedAt;
+
+    public function __construct(string $period)
+    {
+        $this->period = $period;
+        $this->computedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getPeriod(): string
+    {
+        return $this->period;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getData(): array
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+        $this->computedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+
+    public function getComputedAt(): \DateTimeImmutable
+    {
+        return $this->computedAt;
+    }
+}

--- a/src/Repository/StatsSnapshotRepository.php
+++ b/src/Repository/StatsSnapshotRepository.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\StatsSnapshot;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<StatsSnapshot>
+ */
+class StatsSnapshotRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, StatsSnapshot::class);
+    }
+
+    public function findOneByPeriod(string $period): ?StatsSnapshot
+    {
+        return $this->findOneBy(['period' => $period]);
+    }
+}

--- a/src/Service/LocalStatsService.php
+++ b/src/Service/LocalStatsService.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\StatsSnapshot;
+use App\Repository\StatsSnapshotRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Computes listening statistics from the local `scrobbles` table and
+ * caches the results in `stats_snapshot` (keyed by period string).
+ *
+ * All reads go to our own SQLite DB (not Navidrome's) so the stats
+ * reflect the complete Last.fm history, not just what's been synced
+ * to Navidrome.
+ */
+class LocalStatsService
+{
+    public const PERIOD_7D = '7d';
+    public const PERIOD_30D = '30d';
+    public const PERIOD_90D = '90d';
+    public const PERIOD_LAST_YEAR = 'last-year';
+    public const PERIOD_ALL_TIME = 'all-time';
+
+    public const PERIODS = [
+        self::PERIOD_7D => '7 derniers jours',
+        self::PERIOD_30D => '30 derniers jours',
+        self::PERIOD_90D => '90 derniers jours',
+        self::PERIOD_LAST_YEAR => '12 derniers mois',
+        self::PERIOD_ALL_TIME => 'Tout',
+    ];
+
+    private const TOP_ARTISTS_LIMIT = 25;
+    private const TOP_TRACKS_LIMIT = 50;
+    private const PLAYS_BY_MONTH_LIMIT = 24;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly StatsSnapshotRepository $snapshots,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * Compute stats for a period and persist/update the snapshot.
+     * Returns the computed data array.
+     *
+     * @return array<string, mixed>
+     */
+    public function compute(string $period, ?string $user = null): array
+    {
+        [$from, $to] = $this->periodBounds($period);
+
+        $data = [
+            'period' => $period,
+            'user' => $user,
+            'computed_at' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+            'total_plays' => $this->countPlays($from, $to, $user),
+            'top_artists' => $this->topArtists($from, $to, $user),
+            'top_tracks' => $this->topTracks($from, $to, $user),
+            'plays_by_month' => $this->playsByMonth($from, $to, $user),
+            'plays_by_dow' => $this->playsByDayOfWeek($from, $to, $user),
+        ];
+
+        $key = $this->snapshotKey($period, $user);
+        $snapshot = $this->snapshots->findOneByPeriod($key);
+        if ($snapshot === null) {
+            $snapshot = new StatsSnapshot($key);
+            $this->em->persist($snapshot);
+        }
+        $snapshot->setData($data);
+        $this->em->flush();
+
+        return $data;
+    }
+
+    /**
+     * Return cached data, or compute on the fly if absent.
+     *
+     * @return array<string, mixed>
+     */
+    public function get(string $period, ?string $user = null): array
+    {
+        $snapshot = $this->snapshots->findOneByPeriod($this->snapshotKey($period, $user));
+        if ($snapshot !== null) {
+            /** @var array<string, mixed> */
+            return $snapshot->getData();
+        }
+
+        return $this->compute($period, $user);
+    }
+
+    private function snapshotKey(string $period, ?string $user): string
+    {
+        return $user !== null ? "stats-{$period}-{$user}" : "stats-{$period}";
+    }
+
+    /** @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable} */
+    private function periodBounds(string $period): array
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
+
+        return match ($period) {
+            self::PERIOD_7D => [$now->modify('-7 days'), $now],
+            self::PERIOD_30D => [$now->modify('-30 days'), $now],
+            self::PERIOD_90D => [$now->modify('-90 days'), $now],
+            self::PERIOD_LAST_YEAR => [$now->modify('-365 days'), $now],
+            self::PERIOD_ALL_TIME => [null, null],
+            default => throw new \InvalidArgumentException(sprintf('Unknown period "%s"', $period)),
+        };
+    }
+
+    private function countPlays(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): int
+    {
+        [$sql, $params] = $this->baseQuery('COUNT(*)', $from, $to, $user);
+        return (int) $this->connection->fetchOne($sql, $params);
+    }
+
+    /**
+     * @return list<array{artist: string, plays: int}>
+     */
+    private function topArtists(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($from, $to, $user);
+        $sql = 'SELECT artist, COUNT(*) AS plays FROM scrobbles'
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY artist ORDER BY plays DESC LIMIT ' . self::TOP_ARTISTS_LIMIT;
+
+        /** @var list<array{artist: string, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return list<array{artist: string, title: string, plays: int}>
+     */
+    private function topTracks(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($from, $to, $user);
+        $sql = 'SELECT artist, title, COUNT(*) AS plays FROM scrobbles'
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY artist, title ORDER BY plays DESC LIMIT ' . self::TOP_TRACKS_LIMIT;
+
+        /** @var list<array{artist: string, title: string, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return list<array{month: string, plays: int}>
+     */
+    private function playsByMonth(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($from, $to, $user);
+        $sql = "SELECT strftime('%Y-%m', played_at) AS month, COUNT(*) AS plays FROM scrobbles"
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY month ORDER BY month DESC LIMIT ' . self::PLAYS_BY_MONTH_LIMIT;
+
+        /** @var list<array{month: string, plays: int}> */
+        return array_reverse($this->connection->fetchAllAssociative($sql, $params));
+    }
+
+    /**
+     * @return list<array{dow: int, plays: int}>
+     */
+    private function playsByDayOfWeek(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($from, $to, $user);
+        $sql = "SELECT CAST(strftime('%w', played_at) AS INTEGER) AS dow, COUNT(*) AS plays FROM scrobbles"
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY dow ORDER BY dow';
+
+        /** @var list<array{dow: int, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    private function baseQuery(string $select, ?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($from, $to, $user);
+        $sql = "SELECT {$select} FROM scrobbles" . ($where !== '' ? ' WHERE ' . $where : '');
+        return [$sql, $params];
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private function buildWhere(?\DateTimeImmutable $from, ?\DateTimeImmutable $to, ?string $user): array
+    {
+        $parts = [];
+        $params = [];
+
+        if ($from !== null) {
+            $parts[] = 'played_at >= :from';
+            $params['from'] = $from->format('Y-m-d H:i:s');
+        }
+        if ($to !== null) {
+            $parts[] = 'played_at <= :to';
+            $params['to'] = $to->format('Y-m-d H:i:s');
+        }
+        if ($user !== null && $user !== '') {
+            $parts[] = 'lastfm_user = :user';
+            $params['user'] = $user;
+        }
+
+        return [implode(' AND ', $parts), $params];
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -14,6 +14,7 @@
     <a href="{{ path('app_lastfm_import') }}" class="hover:text-slate-300">Import Last.fm</a>
     <a href="{{ path('app_navidrome_sync') }}" class="hover:text-slate-300">Sync Navidrome</a>
     <a href="{{ path('app_strawberry_sync') }}" class="hover:text-slate-300">Sync Strawberry</a>
+    <a href="{{ path('app_stats') }}" class="hover:text-slate-300">Stats</a>
     <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
     <span class="flex-1"></span>
     <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -7,11 +7,19 @@
         <div class="bg-white shadow-sm rounded-sm p-4">
             <div class="text-xs uppercase text-slate-500">Scrobbles locaux</div>
             <div class="text-3xl font-semibold">{{ total_scrobbles|number_format(0, '.', ' ') }}</div>
-            <div class="text-xs text-slate-400 mt-1"><a href="{{ path('app_lastfm_import') }}" class="hover:underline">Import Last.fm →</a></div>
+            <div class="text-xs text-slate-400 mt-1">
+                {% if last_fetch %}dernière sync {{ last_fetch|date('d/m H:i') }}{% endif %}
+                — <a href="{{ path('app_lastfm_import') }}" class="hover:underline">Import</a>
+            </div>
         </div>
 
         <div class="bg-white shadow-sm rounded-sm p-4 {{ navidrome_unmatched > 0 ? 'border border-amber-200' : '' }}">
-            <div class="text-xs uppercase text-slate-500">Navidrome</div>
+            <div class="text-xs uppercase text-slate-500">
+                Navidrome
+                {% if container_configured %}
+                — <span class="font-mono {{ container_status == 'running' ? 'text-emerald-600' : (container_status == 'stopped' ? 'text-slate-500' : 'text-rose-600') }}">{{ container_label }}</span>
+                {% endif %}
+            </div>
             <div class="text-lg font-semibold">{{ navidrome_matched|number_format(0, '.', ' ') }} matchés</div>
             <div class="text-xs mt-1 space-y-0.5">
                 {% if navidrome_pending > 0 %}
@@ -42,13 +50,32 @@
         {% endif %}
 
         <div class="bg-white shadow-sm rounded-sm p-4">
-            <div class="text-xs uppercase text-slate-500">Aliases</div>
+            <div class="text-xs uppercase text-slate-500">Accès rapide</div>
             <div class="text-xs mt-2 space-y-1">
+                <div><a href="{{ path('app_stats') }}" class="text-sky-700 hover:underline">Statistiques →</a></div>
                 <div><a href="{{ path('app_lastfm_aliases') }}" class="text-sky-700 hover:underline">Aliases track →</a></div>
                 <div><a href="{{ path('app_lastfm_artist_aliases') }}" class="text-sky-700 hover:underline">Aliases artiste →</a></div>
             </div>
         </div>
     </div>
+
+    {# Container start/stop #}
+    {% if container_configured %}
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6 flex items-center gap-4">
+        <span class="text-sm font-medium">Conteneur Navidrome :</span>
+        <span class="text-sm font-mono {{ container_status == 'running' ? 'text-emerald-600' : (container_status == 'stopped' ? 'text-slate-500' : 'text-rose-600') }}">
+            {{ container_label }}
+        </span>
+        <form method="post" action="{{ path('app_navidrome_container_start') }}" class="inline">
+            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">
+            <button type="submit" class="text-xs bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1 rounded-sm">▶ Start</button>
+        </form>
+        <form method="post" action="{{ path('app_navidrome_container_stop') }}" class="inline">
+            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">
+            <button type="submit" class="text-xs bg-rose-600 hover:bg-rose-700 text-white px-3 py-1 rounded-sm">■ Stop</button>
+        </form>
+    </div>
+    {% endif %}
 
     <div class="bg-white shadow-sm rounded-sm overflow-hidden">
         <div class="flex items-center justify-between px-3 py-2 bg-slate-100 border-b">

--- a/templates/stats/index.html.twig
+++ b/templates/stats/index.html.twig
@@ -1,0 +1,140 @@
+{% extends 'base.html.twig' %}
+{% block title %}Statistiques{% endblock %}
+
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold">Statistiques d'écoute</h1>
+        <div class="flex items-center gap-3">
+            {% if data.computed_at is defined %}
+            <span class="text-xs text-slate-400">Calculé {{ data.computed_at|date('d/m H:i') }}</span>
+            {% endif %}
+            <form method="post" action="{{ path('app_stats_refresh') }}" class="inline">
+                <input type="hidden" name="_token" value="{{ csrf_token('stats_refresh') }}">
+                <input type="hidden" name="period" value="{{ period }}">
+                <button type="submit" class="text-xs bg-slate-200 hover:bg-slate-300 px-3 py-1.5 rounded-sm">↻ Recalculer</button>
+            </form>
+        </div>
+    </div>
+
+    {# Sélecteur de période #}
+    <div class="flex gap-2 mb-6 flex-wrap">
+        {% for key, label in periods %}
+        <a href="{{ path('app_stats', {period: key}) }}"
+           class="px-3 py-1.5 rounded-sm text-sm font-medium {{ key == period ? 'bg-slate-800 text-white' : 'bg-white text-slate-700 hover:bg-slate-100' }} shadow-sm">
+            {{ label }}
+        </a>
+        {% endfor %}
+    </div>
+
+    {# KPIs #}
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Lectures (période)</div>
+            <div class="text-3xl font-semibold">{{ data.total_plays|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Total historique</div>
+            <div class="text-3xl font-semibold">{{ total_scrobbles|number_format(0, '.', ' ') }}</div>
+        </div>
+        {% if data.top_artists is not empty %}
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Artiste #1</div>
+            <div class="text-lg font-semibold truncate">{{ data.top_artists[0].artist }}</div>
+            <div class="text-xs text-slate-500">{{ data.top_artists[0].plays }} lectures</div>
+        </div>
+        {% endif %}
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
+        {# Top artistes #}
+        {% if data.top_artists is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top artistes</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_plays = data.top_artists[0].plays %}
+                {% for i, row in data.top_artists %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5 font-medium">{{ row.artist }}</td>
+                    <td class="px-3 py-1.5 w-32">
+                        <div class="flex items-center gap-2">
+                            <div class="bg-sky-200 h-2 rounded-full" style="width: {{ (row.plays / max_plays * 100)|round }}%"></div>
+                        </div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {# Top morceaux #}
+        {% if data.top_tracks is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top morceaux</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_plays_t = data.top_tracks[0].plays %}
+                {% for i, row in data.top_tracks|slice(0, 25) %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5">
+                        <div class="font-medium truncate max-w-40">{{ row.title }}</div>
+                        <div class="text-xs text-slate-500 truncate max-w-40">{{ row.artist }}</div>
+                    </td>
+                    <td class="px-3 py-1.5 w-32">
+                        <div class="flex items-center gap-2">
+                            <div class="bg-emerald-200 h-2 rounded-full" style="width: {{ (row.plays / max_plays_t * 100)|round }}%"></div>
+                        </div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+    </div>
+
+    {# Lectures par mois #}
+    {% if data.plays_by_month is not empty %}
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
+        <div class="text-sm font-semibold mb-3">Lectures par mois</div>
+        {% set max_month = data.plays_by_month|map(r => r.plays)|max %}
+        <div class="flex items-end gap-1 h-24">
+            {% for row in data.plays_by_month %}
+            <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
+                <div class="w-full bg-sky-400 rounded-t-sm"
+                     style="height: {{ max_month > 0 ? ((row.plays / max_month * 88)|round) : 0 }}px"
+                     title="{{ row.month }} : {{ row.plays }} lectures"></div>
+                <div class="text-xs text-slate-400 truncate" style="font-size:9px">{{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}</div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# Lectures par jour de la semaine #}
+    {% if data.plays_by_dow is not empty %}
+    <div class="bg-white shadow-sm rounded-sm p-4">
+        <div class="text-sm font-semibold mb-3">Lectures par jour de la semaine</div>
+        {% set days = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'] %}
+        {% set dow_map = {} %}
+        {% for row in data.plays_by_dow %}{% set dow_map = dow_map|merge({(row.dow): row.plays}) %}{% endfor %}
+        {% set max_dow = data.plays_by_dow|map(r => r.plays)|max %}
+        <div class="flex items-end gap-2 h-20">
+            {% for d in 0..6 %}
+            {% set plays = dow_map[d] is defined ? dow_map[d] : 0 %}
+            <div class="flex-1 flex flex-col items-center gap-1">
+                <div class="w-full bg-emerald-400 rounded-t-sm"
+                     style="height: {{ max_dow > 0 ? ((plays / max_dow * 72)|round) : 0 }}px"
+                     title="{{ days[d] }} : {{ plays }} lectures"></div>
+                <div class="text-xs text-slate-500">{{ days[d] }}</div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Service/LocalStatsServiceTest.php
+++ b/tests/Service/LocalStatsServiceTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Repository\StatsSnapshotRepository;
+use App\Service\LocalStatsService;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class LocalStatsServiceTest extends TestCase
+{
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/stats-test-' . uniqid() . '.db';
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $conn->executeStatement(<<<'SQL'
+            CREATE TABLE scrobbles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                lastfm_user VARCHAR(255) NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                album VARCHAR(255),
+                played_at DATETIME NOT NULL
+            )
+        SQL);
+        // Insert test data.
+        $rows = [
+            ['alice', 'Daft Punk', 'Get Lucky', '2024-01-05 12:00:00'],
+            ['alice', 'Daft Punk', 'Harder Better Faster', '2024-01-06 12:00:00'],
+            ['alice', 'Radiohead', 'Creep', '2024-01-07 12:00:00'],
+            ['alice', 'Daft Punk', 'Get Lucky', '2024-01-08 12:00:00'],
+        ];
+        foreach ($rows as [$user, $artist, $title, $playedAt]) {
+            $conn->executeStatement(
+                'INSERT INTO scrobbles (lastfm_user, artist, title, played_at) VALUES (?, ?, ?, ?)',
+                [$user, $artist, $title, $playedAt],
+            );
+        }
+        $conn->close();
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testComputeAllTimeReturnsCorrectTopArtists(): void
+    {
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $snapshots = $this->createMock(StatsSnapshotRepository::class);
+        $snapshots->method('findOneByPeriod')->willReturn(null);
+        $snapshots->method('findOneBy')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new LocalStatsService($conn, $snapshots, $em);
+        $data = $service->compute(LocalStatsService::PERIOD_ALL_TIME, 'alice');
+
+        $this->assertSame(4, $data['total_plays']);
+        $this->assertSame('Daft Punk', $data['top_artists'][0]['artist']);
+        $this->assertSame(3, (int) $data['top_artists'][0]['plays']);
+        $this->assertSame('Radiohead', $data['top_artists'][1]['artist']);
+
+        $conn->close();
+    }
+
+    public function testTopTracksGroupsByArtistAndTitle(): void
+    {
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $snapshots = $this->createMock(StatsSnapshotRepository::class);
+        $snapshots->method('findOneByPeriod')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new LocalStatsService($conn, $snapshots, $em);
+        $data = $service->compute(LocalStatsService::PERIOD_ALL_TIME, 'alice');
+
+        $topTrack = $data['top_tracks'][0];
+        $this->assertSame('Get Lucky', $topTrack['title']);
+        $this->assertSame(2, (int) $topTrack['plays']);
+
+        $conn->close();
+    }
+}


### PR DESCRIPTION
## Lot 6 — Statistiques + dashboard enrichi

### Ce qui est inclus

**`LocalStatsService`** — lit la table `scrobbles` locale (pas Navidrome) :
- `compute(period, user)` : total_plays, top_artists (25), top_tracks (50), plays_by_month (24 mois), plays_by_dow
- Résultats persistés dans `stats_snapshot` (cache invalidable manuellement)
- Périodes : `7d` / `30d` / `90d` / `last-year` / `all-time`

**Migration `Version20260515000000`** — table `stats_snapshot`

**`app:stats:compute [--period=] [--user=]`** — wrappé RunHistoryRecorder

**Page `/stats`** :
- Sélecteur de période
- KPIs : total plays période, total historique, artiste #1
- Top artistes avec barre relative
- Top morceaux (25 affichés)
- Histogramme plays/mois (24 mois)
- Histogramme plays/jour-semaine
- Bouton "Recalculer" (POST /stats/refresh)

**Dashboard amélioré** :
- Date du dernier fetch Last.fm sur la card scrobbles
- Statut conteneur Navidrome inline (running/stopped) si `NAVIDROME_CONTAINER_NAME` configuré
- Boutons Start/Stop (NavidromeContainerController porté poc-v0)
- Lien "Stats" dans la navbar

### Bilan v2 lots 1–6

| Lot | Contenu |
|-----|---------|
| 1 | Socle, RunHistoryRecorder, Notifier, BackupService |
| 2 | Import Last.fm → table scrobbles locale |
| 3 | Sync Navidrome (ScrobbleMatcher, batch, backup) |
| 4 | Sync Strawberry (playcount, upload/download) |
| 5 | Rematch, pages unmatched, CRUD alias |
| 6 | **Stats, container dashboard** ← cette PR |

L'application est maintenant **fonctionnellement complète** pour le use-case principal : import Last.fm → sync Navidrome + Strawberry → rematch → stats.

### Tests

18 tests / 50 assertions — tous verts. phpcs + phpstan OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)