### PR TITLE
fix(stats): remplacer |max par max() sur /stats

### DIFF
--- a/templates/stats/index.html.twig
+++ b/templates/stats/index.html.twig
@@ -102,7 +102,7 @@
     {% if data.plays_by_month is not empty %}
     <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
         <div class="text-sm font-semibold mb-3">Lectures par mois</div>
-        {% set max_month = data.plays_by_month|map(r => r.plays)|max %}
+        {% set max_month = max(data.plays_by_month|map(r => r.plays)) %}
         <div class="flex items-end gap-1 h-24">
             {% for row in data.plays_by_month %}
             <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
@@ -123,7 +123,7 @@
         {% set days = ['Dim', 'Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam'] %}
         {% set dow_map = {} %}
         {% for row in data.plays_by_dow %}{% set dow_map = dow_map|merge({(row.dow): row.plays}) %}{% endfor %}
-        {% set max_dow = data.plays_by_dow|map(r => r.plays)|max %}
+        {% set max_dow = max(data.plays_by_dow|map(r => r.plays)) %}
         <div class="flex items-end gap-2 h-20">
             {% for d in 0..6 %}
             {% set plays = dow_map[d] is defined ? dow_map[d] : 0 %}


### PR DESCRIPTION
## Problème

La page `/stats` renvoie une erreur 500 dès que le snapshot contient des données :

```
Twig\Error\SyntaxError: Unknown "max" filter. Did you mean "map"
  in "stats/index.html.twig" at line 105
```

## Cause

Twig 3 expose `max` comme **fonction** (`max(...)`) mais pas comme **filtre** (`|max`). Les lignes 105 et 126 de `templates/stats/index.html.twig` utilisent `…|map(r => r.plays)|max`, ce qui plante à la compilation Twig. Le bug ne se déclenche que quand `plays_by_month` / `plays_by_dow` sont non vides — d'où l'absence en dev tant que la table `stats_snapshot` est vierge.

## Fix

Bascule sur la fonction `max(...)` :

```twig
{% set max_month = max(data.plays_by_month|map(r => r.plays)) %}
{% set max_dow   = max(data.plays_by_dow|map(r => r.plays)) %}
```

`|map` renvoie un array, donc le `max()` natif PHP wrappé par Twig consomme directement.

## Test plan

- [x] `php bin/console lint:twig templates/` → 15/15 OK
- [ ] Recharger `/stats` avec un snapshot non vide en prod et vérifier que la page rend les histogrammes "Lectures par mois" et "Lectures par jour de la semaine"

---
_Generated by [Claude Code](https://claude.ai/code/session_011jHUDYQQBEWjWGGLKMLy1F)_