### PR TITLE
fix(sync): compter les scrobbles non préparés dans countPendingForTarget

### DIFF
--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -5,6 +5,7 @@ namespace App\Repository;
 use App\Entity\Scrobble;
 use App\Entity\ScrobbleSync;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ManagerRegistry;
 
@@ -70,9 +71,35 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
             ->getSingleScalarResult();
     }
 
+    /**
+     * Pending = scrobbles awaiting a first sync attempt for $target. This
+     * covers both rows already marked `pending` in scrobble_sync AND
+     * scrobbles that don't have a scrobble_sync row yet for this target
+     * (rows are created lazily by {@see self::prepareForTarget()} on the
+     * first sync run, so the counter must include un-prepared scrobbles
+     * — otherwise it reads 0 right after a fetch and the user thinks
+     * nothing needs to be done).
+     */
     public function countPendingForTarget(string $target): int
     {
-        return $this->countByTargetStatus($target, ScrobbleSync::STATUS_PENDING);
+        return self::queryPendingCount($this->em->getConnection(), $target);
+    }
+
+    /**
+     * Pure-SQL counterpart of {@see self::countPendingForTarget()} — exposed
+     * statically so tests can hit a bare DBAL connection without spinning
+     * up Doctrine's ManagerRegistry just to instantiate the repository.
+     */
+    public static function queryPendingCount(Connection $conn, string $target): int
+    {
+        return (int) $conn->fetchOne(
+            'SELECT COUNT(s.id)
+             FROM scrobbles s
+             LEFT JOIN scrobble_sync ss
+                 ON ss.scrobble_id = s.id AND ss.target = :target
+             WHERE ss.id IS NULL OR ss.status = :pending',
+            ['target' => $target, 'pending' => ScrobbleSync::STATUS_PENDING],
+        );
     }
 
     public function countUnmatchedForTarget(string $target): int

--- a/tests/Repository/ScrobbleSyncRepositoryTest.php
+++ b/tests/Repository/ScrobbleSyncRepositoryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\ScrobbleSync;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\TestCase;
+
+class ScrobbleSyncRepositoryTest extends TestCase
+{
+    private string $dbPath;
+    private Connection $conn;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/scrobble-sync-test-' . uniqid() . '.db';
+        $this->conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $this->conn->executeStatement(<<<'SQL'
+            CREATE TABLE scrobbles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                lastfm_user VARCHAR(255) NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                played_at DATETIME NOT NULL
+            )
+        SQL);
+        $this->conn->executeStatement(<<<'SQL'
+            CREATE TABLE scrobble_sync (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scrobble_id INTEGER NOT NULL,
+                target VARCHAR(32) NOT NULL,
+                status VARCHAR(16) NOT NULL DEFAULT 'pending'
+            )
+        SQL);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->conn->close();
+        if (file_exists($this->dbPath)) {
+            unlink($this->dbPath);
+        }
+    }
+
+    public function testPendingCountIncludesScrobblesWithoutSyncRow(): void
+    {
+        // 3 scrobbles fetched, none prepared yet — pending count must
+        // reflect the un-prepared rows, otherwise the user sees "0 pending"
+        // right after a fetch and assumes nothing needs syncing.
+        $this->insertScrobble(1, '2024-01-01 12:00:00');
+        $this->insertScrobble(2, '2024-01-02 12:00:00');
+        $this->insertScrobble(3, '2024-01-03 12:00:00');
+
+        $count = ScrobbleSyncRepository::queryPendingCount($this->conn, ScrobbleSync::TARGET_NAVIDROME);
+
+        $this->assertSame(3, $count);
+    }
+
+    public function testPendingCountSumsUnpreparedAndPendingRows(): void
+    {
+        $this->insertScrobble(1, '2024-01-01 12:00:00');
+        $this->insertScrobble(2, '2024-01-02 12:00:00');
+        $this->insertScrobble(3, '2024-01-03 12:00:00');
+
+        // Row 1 prepared and still pending, row 2 unprepared, row 3
+        // already matched — expect 1 + 1 = 2 pending.
+        $this->insertSync(1, ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_PENDING);
+        $this->insertSync(3, ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::STATUS_MATCHED);
+
+        $count = ScrobbleSyncRepository::queryPendingCount($this->conn, ScrobbleSync::TARGET_NAVIDROME);
+
+        $this->assertSame(2, $count);
+    }
+
+    public function testPendingCountIsTargetScoped(): void
+    {
+        // A scrobble already synced to strawberry must still count as
+        // pending for navidrome (each target has its own sync state).
+        $this->insertScrobble(1, '2024-01-01 12:00:00');
+        $this->insertSync(1, ScrobbleSync::TARGET_STRAWBERRY, ScrobbleSync::STATUS_MATCHED);
+
+        $count = ScrobbleSyncRepository::queryPendingCount($this->conn, ScrobbleSync::TARGET_NAVIDROME);
+
+        $this->assertSame(1, $count);
+    }
+
+    private function insertScrobble(int $id, string $playedAt): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO scrobbles (id, lastfm_user, artist, title, played_at) VALUES (?, ?, ?, ?, ?)',
+            [$id, 'alice', 'Artist ' . $id, 'Title ' . $id, $playedAt],
+        );
+    }
+
+    private function insertSync(int $scrobbleId, string $target, string $status): void
+    {
+        $this->conn->executeStatement(
+            'INSERT INTO scrobble_sync (scrobble_id, target, status) VALUES (?, ?, ?)',
+            [$scrobbleId, $target, $status],
+        );
+    }
+}


### PR DESCRIPTION
## Symptôme

Après un `app:lastfm:fetch` qui rapporte des milliers de scrobbles fetchés, la card « En attente → Navidrome » de `/navidrome/sync` (et la card équivalente du dashboard) affichait **0**. L'utilisateur croit que rien n'est à synchroniser alors que le backlog complet attend.

## Cause

Les rows `scrobble_sync` sont créées paresseusement par `ScrobbleSyncRepository::prepareForTarget()`, lui-même appelé seulement quand `NavidromeSyncService::process()` tourne. Entre le fetch et le premier sync, **aucune** row `scrobble_sync` n'existe pour `target=navidrome` → l'ancien `countPendingForTarget()` (qui ne comptait que les rows en `status=pending`) retournait 0.

## Fix

`countPendingForTarget()` fait maintenant un `LEFT JOIN scrobbles → scrobble_sync` et compte aussi les scrobbles **sans** row pour le target (= pas encore préparés), en plus de ceux déjà en `status=pending`. Les compteurs `/navidrome/sync`, `/strawberry/sync` et le dashboard reflètent désormais le vrai backlog dès la fin du fetch.

La logique SQL est extraite dans `queryPendingCount(Connection, target)` (helper statique) pour qu'elle soit testable sans passer par `ManagerRegistry`.

## Tests

- 3 tests d'intégration sur SQLite en mémoire (`tests/Repository/ScrobbleSyncRepositoryTest.php`) :
  - scrobbles sans aucune row `scrobble_sync` → comptés
  - mix unprepared + pending + matched → seuls les deux premiers sont comptés
  - cloisonnement par target (pas de fuite navidrome ↔ strawberry)
- `composer ci` : phpcs ✓, phpstan ✓ sur les fichiers touchés, 21 tests / 53 assertions ✓

## Test plan

- [ ] Lancer `app:lastfm:fetch` sur un buffer vide
- [ ] Vérifier que `/navidrome/sync` affiche bien `fetched` au lieu de `0`
- [ ] Cliquer « Lancer la sync » → le compteur baisse au fur et à mesure (matched / unmatched / duplicates augmentent)

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_