### PR TITLE
fix(sync): détacher les ScrobbleSync APRÈS le flush, pas avant le persist

### DIFF
--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -95,10 +95,6 @@ class NavidromeSyncService
                     ];
                 }
 
-                if ($this->em->contains($sync)) {
-                    $this->em->detach($sync);
-                }
-
                 if (!$dryRun && count($batch) >= self::BATCH_SIZE) {
                     if (!$backupTaken) {
                         $report->backupPath = $this->backup->backup();
@@ -225,5 +221,15 @@ class NavidromeSyncService
             $this->em->persist($sync);
         }
         $this->em->flush();
+
+        // Detach AFTER flush — detaching before persist() throws
+        // ORMInvalidArgumentException ("detached entity cannot be persisted")
+        // in Doctrine ORM 3, which closes the EM. Doing it here bounds the
+        // identity map to one batch worth of entities at most.
+        foreach ($batch as $row) {
+            if ($this->em->contains($row['sync'])) {
+                $this->em->detach($row['sync']);
+            }
+        }
     }
 }

--- a/src/Strawberry/StrawberrySyncService.php
+++ b/src/Strawberry/StrawberrySyncService.php
@@ -89,10 +89,6 @@ class StrawberrySyncService
                     ];
                 }
 
-                if ($this->em->contains($sync)) {
-                    $this->em->detach($sync);
-                }
-
                 if (!$dryRun && count($batch) >= self::BATCH_SIZE) {
                     $this->flushBatch($batch, $run);
                     $batch = [];
@@ -157,6 +153,16 @@ class StrawberrySyncService
         }
 
         $this->em->flush();
+
+        // Detach AFTER flush — detaching before persist() throws
+        // ORMInvalidArgumentException ("detached entity cannot be persisted")
+        // in Doctrine ORM 3, which closes the EM. Doing it here bounds the
+        // identity map to one batch worth of entities at most.
+        foreach ($batch as $row) {
+            if ($this->em->contains($row['sync'])) {
+                $this->em->detach($row['sync']);
+            }
+        }
     }
 
     private function findStrawberryRowid(?string $mbid, string $artist, string $title): ?int

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -123,6 +123,44 @@ class NavidromeSyncServiceTest extends TestCase
         $this->assertSame(1, $report->unmatched);
     }
 
+    public function testPersistIsNeverCalledOnDetachedSync(): void
+    {
+        // Regression: detaching a sync before persist() crashes Doctrine ORM 3
+        // with "Detached entity cannot be persisted", closing the EM and
+        // surfacing to the user as "The EntityManager is closed."
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturn(null);
+
+        $detached = new \SplObjectStorage();
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturnCallback(static fn (object $e): bool => !isset($detached[$e]));
+        $em->method('detach')->willReturnCallback(static function (object $e) use ($detached): void {
+            $detached[$e] = true;
+        });
+        $em->method('persist')->willReturnCallback(static function (object $e) use ($detached): void {
+            if (isset($detached[$e])) {
+                throw new \Doctrine\ORM\Exception\ORMException('Detached entity cannot be persisted');
+            }
+        });
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process();
+
+        $this->assertSame(1, $report->matched);
+    }
+
     private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
     {
         return new Scrobble(

--- a/tests/Strawberry/StrawberrySyncServiceTest.php
+++ b/tests/Strawberry/StrawberrySyncServiceTest.php
@@ -98,6 +98,41 @@ class StrawberrySyncServiceTest extends TestCase
         $this->assertSame(5, $playcount);
     }
 
+    public function testPersistIsNeverCalledOnDetachedSync(): void
+    {
+        // Regression: detaching a sync before persist() crashes Doctrine ORM 3
+        // with "Detached entity cannot be persisted", which closes the EM and
+        // surfaces to the user as "The EntityManager is closed."
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_STRAWBERRY);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+        $syncRepo->method('resetUnmatchedToPending')->willReturn(0);
+
+        $detached = new \SplObjectStorage();
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturnCallback(static fn (object $e): bool => !isset($detached[$e]));
+        $em->method('detach')->willReturnCallback(static function (object $e) use ($detached): void {
+            $detached[$e] = true;
+        });
+        $em->method('persist')->willReturnCallback(static function (object $e) use ($detached): void {
+            if (isset($detached[$e])) {
+                throw new \Doctrine\ORM\Exception\ORMException('Detached entity cannot be persisted');
+            }
+        });
+        $em->method('flush');
+
+        $repo = new StrawberryRepository($this->sbDbPath);
+        $service = new StrawberrySyncService($syncRepo, $repo, $em);
+
+        // Must not throw — would mean we detached before persisting.
+        $report = $service->process();
+
+        $this->assertSame(1, $report->matched);
+    }
+
     public function testDryRunDoesNotWrite(): void
     {
         $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');


### PR DESCRIPTION
## Symptôme

Quand l'utilisateur lance la sync Strawberry (ou Navidrome) depuis le bouton `▶ Lancer la sync`, le worker plante rapidement avec :

> Erreur : The EntityManager is closed.

## Cause

Pattern fautif dans `NavidromeSyncService::process()` et `StrawberrySyncService::process()` :

```php
foreach ($this->syncRepo->streamPending(...) as $sync) {
    // ...
    $batch[] = ['sync' => $sync, ...];        // référence stockée
    if ($this->em->contains($sync)) {
        $this->em->detach($sync);              // ← détaché immédiatement
    }
    // ...
}

// Plus tard, dans flushBatch() :
$row['sync']->markMatched(...);
$this->em->persist($row['sync']);              // ← persist sur une entité détachée
$this->em->flush();
```

Doctrine ORM 3 lève `ORMInvalidArgumentException::detachedEntityCannot('persisted')` à l'étape `persist()` ([`UnitOfWork.php:1838`](https://github.com/doctrine/orm/blob/3.6.5/src/UnitOfWork.php#L1838)). L'exception remonte jusqu'au `RunHistoryRecorder::record()`, qui appelle `$this->em->flush()` dans son catch pour écrire le status `error` — cet appel ferme l'EM, et le message qui parvient à l'utilisateur est l'erreur secondaire « The EntityManager is closed. ».

## Fix

Inverser l'ordre : détacher **après** le `flush()`, plus dans la boucle d'itération. Le `flushBatch()` écrit, flush, puis détache les entités qu'il vient de traiter. L'identity map reste bornée à `BATCH_SIZE` entités (la taille d'un batch en cours d'accumulation).

## Tests

- `testPersistIsNeverCalledOnDetachedSync` sur les deux services : EM stub qui throw explicitement quand `persist()` est appelé après `detach()` sur la même entité — reproduit la condition d'erreur réelle de Doctrine 3.
- `composer ci` : phpcs ✓, phpstan ✓ sur les fichiers touchés, 23 tests / 55 assertions ✓

## Test plan

- [ ] Lancer la sync Strawberry sur un backlog non vide → doit aller jusqu'au bout sans « EntityManager is closed »
- [ ] Idem pour la sync Navidrome (Navidrome arrêté ou `--auto-stop`)
- [ ] Vérifier que `/history` montre le run en `success` avec les bonnes métriques (`matched`, `unmatched`)

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_