### PR TITLE
fix(tests): instancier ORMInvalidArgumentException, pas l'interface ORMException

### DIFF
--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -150,7 +150,7 @@ class NavidromeSyncServiceTest extends TestCase
         });
         $em->method('persist')->willReturnCallback(static function (object $e) use ($detached): void {
             if (isset($detached[$e])) {
-                throw new \Doctrine\ORM\Exception\ORMException('Detached entity cannot be persisted');
+                throw \Doctrine\ORM\ORMInvalidArgumentException::detachedEntityCannot($e, 'persisted');
             }
         });
         $em->method('flush');

--- a/tests/Strawberry/StrawberrySyncServiceTest.php
+++ b/tests/Strawberry/StrawberrySyncServiceTest.php
@@ -119,7 +119,7 @@ class StrawberrySyncServiceTest extends TestCase
         });
         $em->method('persist')->willReturnCallback(static function (object $e) use ($detached): void {
             if (isset($detached[$e])) {
-                throw new \Doctrine\ORM\Exception\ORMException('Detached entity cannot be persisted');
+                throw \Doctrine\ORM\ORMInvalidArgumentException::detachedEntityCannot($e, 'persisted');
             }
         });
         $em->method('flush');


### PR DESCRIPTION
## Symptôme

CI phpstan échoue sur develop depuis la merge de #157 :

```
Cannot instantiate interface Doctrine\ORM\Exception\ORMException.
 ------ -------------------------------------------------------------------
  Line   tests/Navidrome/NavidromeSyncServiceTest.php
 ------ -------------------------------------------------------------------
  153    Cannot instantiate interface Doctrine\ORM\Exception\ORMException.
         🪪  new.interface
 ------ -------------------------------------------------------------------
  Line   tests/Strawberry/StrawberrySyncServiceTest.php
 ------ -------------------------------------------------------------------
  122    Cannot instantiate interface Doctrine\ORM\Exception\ORMException.
         🪪  new.interface
 ------ -------------------------------------------------------------------
```

## Cause

Dans le test de régression du fix précédent, j'utilisais `new \Doctrine\ORM\Exception\ORMException(...)` pour simuler l'erreur que Doctrine lève quand on persiste une entité détachée. Sauf que `ORMException` est une **interface** dans Doctrine ORM 3 — pas instanciable.

## Fix

Remplacé par `ORMInvalidArgumentException::detachedEntityCannot($entity, 'persisted')`, qui est exactement la factory statique utilisée par `UnitOfWork::doPersist()` ligne 1838 quand il rejette le persist sur une entité détachée. Le test reproduit donc littéralement la condition d'erreur réelle.

## Tests

- `composer ci` : phpcs ✓, phpstan ✓, 23 tests / 55 assertions ✓ (en local avec composer install propre)
- Les deux tests de régression continuent de fail si on remet le `detach()` avant le `persist()` dans les services.

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_