### PR TITLE
feat(lastfm): défaut à 48h sur le premier fetch au lieu de full history

### DIFF
--- a/src/Command/FetchLastFmCommand.php
+++ b/src/Command/FetchLastFmCommand.php
@@ -18,8 +18,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Fetch scrobbles from Last.fm and store them in the local `scrobbles` table.
  *
- * Smart date mode (no --date-min): reads setting[lastfm_last_fetch_{user}]
- * and fetches from that date - 1h to now. On success, updates the setting.
+ * Smart date mode (no --date-min): on subsequent runs reads
+ * setting[lastfm_last_fetch_{user}] and fetches from that date - 1h to now.
+ * On the first run (no previous fetch recorded) defaults to the last 48h —
+ * a full-history bootstrap is opt-in via --date-min=1970-01-01.
  * With --date-min: explicit window, does NOT update the last_fetch setting.
  */
 #[AsCommand(
@@ -30,6 +32,7 @@ class FetchLastFmCommand extends Command
 {
     private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
     private const OVERLAP_HOURS = 1;
+    private const DEFAULT_WINDOW_HOURS = 48;
 
     public function __construct(
         private readonly LastFmFetcher $fetcher,
@@ -158,7 +161,16 @@ class FetchLastFmCommand extends Command
             return [$dateMin, $dateMax];
         }
 
-        $io->note('No previous fetch found. Fetching full history (this may take a while).');
-        return [null, $dateMax];
+        // No previous fetch — default to the last DEFAULT_WINDOW_HOURS. A full
+        // bootstrap is opt-in via --date-min=1970-01-01 so a fresh install
+        // doesn't accidentally pull years of history on a cron tick.
+        $dateMin = (new \DateTimeImmutable())->modify(sprintf('-%d hours', self::DEFAULT_WINDOW_HOURS));
+        $io->note(sprintf(
+            'No previous fetch found — defaulting to the last %dh (from %s). '
+            . 'Pass --date-min for a different window.',
+            self::DEFAULT_WINDOW_HOURS,
+            $dateMin->format('Y-m-d H:i:s'),
+        ));
+        return [$dateMin, $dateMax];
     }
 }

--- a/tests/Command/FetchLastFmCommandTest.php
+++ b/tests/Command/FetchLastFmCommandTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Command;
+
+use App\Command\FetchLastFmCommand;
+use App\Entity\RunHistory;
+use App\LastFm\FetchReport;
+use App\LastFm\LastFmFetcher;
+use App\Repository\SettingRepository;
+use App\Service\RunHistoryRecorder;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class FetchLastFmCommandTest extends TestCase
+{
+    public function testDefaultWindowIsLast48HoursOnFirstRun(): void
+    {
+        // Capture the window the fetcher is called with — that's what we
+        // are actually asserting (the printed note is just for the user).
+        $captured = null;
+        $fetcher = $this->createMock(LastFmFetcher::class);
+        $fetcher->expects($this->once())
+            ->method('fetch')
+            ->willReturnCallback(function (string $apiKey, string $user, ?\DateTimeInterface $dateMin, ?\DateTimeInterface $dateMax) use (&$captured): FetchReport {
+                $captured = ['dateMin' => $dateMin, 'dateMax' => $dateMax];
+                return new FetchReport();
+            });
+
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->willReturn(''); // no previous fetch
+        $settings->expects($this->never())->method('set');
+
+        $tester = $this->makeTester($fetcher, $settings);
+        $tester->execute(['user' => 'alice', '--api-key' => 'k']);
+
+        $this->assertNotNull($captured['dateMin']);
+        $this->assertNull($captured['dateMax']);
+        // Default window is 48h — accept a 5s drift to account for test latency.
+        $expected = (new \DateTimeImmutable())->modify('-48 hours')->getTimestamp();
+        $this->assertLessThanOrEqual(5, abs($captured['dateMin']->getTimestamp() - $expected));
+    }
+
+    public function testSmartDateOverrides48hDefaultWhenLastFetchExists(): void
+    {
+        $captured = null;
+        $fetcher = $this->createMock(LastFmFetcher::class);
+        $fetcher->method('fetch')->willReturnCallback(
+            function (string $apiKey, string $user, ?\DateTimeInterface $dateMin) use (&$captured): FetchReport {
+                $captured = $dateMin;
+                return new FetchReport();
+            }
+        );
+
+        // Last fetch 7 days ago — smart date should use that minus 1h overlap,
+        // NOT the 48h default.
+        $lastFetch = (new \DateTimeImmutable('-7 days'))->format('Y-m-d H:i:s');
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->willReturn($lastFetch);
+
+        $tester = $this->makeTester($fetcher, $settings);
+        $tester->execute(['user' => 'alice', '--api-key' => 'k']);
+
+        $this->assertNotNull($captured);
+        $expected = (new \DateTimeImmutable($lastFetch))->modify('-1 hours')->getTimestamp();
+        $this->assertSame($expected, $captured->getTimestamp());
+    }
+
+    public function testExplicitDateMinOverridesDefault(): void
+    {
+        $captured = null;
+        $fetcher = $this->createMock(LastFmFetcher::class);
+        $fetcher->method('fetch')->willReturnCallback(
+            function (string $apiKey, string $user, ?\DateTimeInterface $dateMin) use (&$captured): FetchReport {
+                $captured = $dateMin;
+                return new FetchReport();
+            }
+        );
+
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->willReturn('');
+
+        $tester = $this->makeTester($fetcher, $settings);
+        $tester->execute(['user' => 'alice', '--api-key' => 'k', '--date-min' => '2024-01-01']);
+
+        $this->assertSame('2024-01-01', $captured->format('Y-m-d'));
+    }
+
+    private function makeTester(LastFmFetcher $fetcher, SettingRepository $settings): CommandTester
+    {
+        // Recorder that just invokes the action — no DB writes in tests.
+        $recorder = $this->createMock(RunHistoryRecorder::class);
+        $recorder->method('record')->willReturnCallback(
+            static fn (string $type, string $ref, string $label, callable $action) => $action(new RunHistory($type, $ref, $label)),
+        );
+
+        $command = new FetchLastFmCommand($fetcher, $recorder, $settings, 'default-key', 'default-user');
+        $app = new Application();
+        $app->add($command);
+
+        return new CommandTester($app->find('app:lastfm:fetch'));
+    }
+}


### PR DESCRIPTION
## Problème

Sans `--date-min`/`--date-max` et sans `last_fetch` enregistré (premier run, conteneur neuf, ou wipe DB), `app:lastfm:fetch` tirait **tout** l'historique Last.fm. Sur un compte actif ça représente plusieurs centaines de milliers de scrobbles (363 699 dans le cas que tu m'as remonté) — pas le bon défaut pour une commande planifiée en cron qui tourne sans surveillance.

## Fix

Le fallback "no previous fetch" passe de "full history" à "now - 48h".

| Cas | Avant | Après |
|---|---|---|
| `--date-min=2024-01-01` | window explicite | inchangé |
| `last_fetch` en settings | smart date: `last_fetch - 1h` | inchangé |
| Premier run, pas de settings | full history (∞ → now) | **48h → now** |

Le bootstrap complet reste accessible explicitement via `--date-min=1970-01-01`, c'est juste plus opt-in.

## Tests

- `FetchLastFmCommandTest::testDefaultWindowIsLast48HoursOnFirstRun` — capture la `$dateMin` passée au fetcher et vérifie qu'elle est ~48h en arrière (tolérance 5s pour la latence de test).
- `testSmartDateOverrides48hDefaultWhenLastFetchExists` — quand `last_fetch` existe (ex: 7 jours), c'est lui qui prime, pas le défaut 48h.
- `testExplicitDateMinOverridesDefault` — `--date-min` reste prioritaire.

`composer ci` : phpcs ✓, phpstan ✓, 26 tests / 64 assertions ✓

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_