### PR TITLE
fix(lastfm): appliquer le défaut 48h aussi sur le fetch déclenché depuis l'UI

### DIFF
--- a/src/Command/FetchLastFmCommand.php
+++ b/src/Command/FetchLastFmCommand.php
@@ -4,8 +4,8 @@ namespace App\Command;
 
 use App\Entity\RunHistory;
 use App\LastFm\FetchReport;
+use App\LastFm\FetchWindowResolver;
 use App\LastFm\LastFmFetcher;
-use App\Repository\SettingRepository;
 use App\Service\RunHistoryRecorder;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -18,11 +18,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 /**
  * Fetch scrobbles from Last.fm and store them in the local `scrobbles` table.
  *
- * Smart date mode (no --date-min): on subsequent runs reads
- * setting[lastfm_last_fetch_{user}] and fetches from that date - 1h to now.
- * On the first run (no previous fetch recorded) defaults to the last 48h —
- * a full-history bootstrap is opt-in via --date-min=1970-01-01.
- * With --date-min: explicit window, does NOT update the last_fetch setting.
+ * Window resolution is delegated to {@see FetchWindowResolver} so the CLI
+ * and the web button (FetchLastFmMessageHandler) agree on what "by default"
+ * means — 48h on a fresh install, smart date on subsequent runs.
  */
 #[AsCommand(
     name: 'app:lastfm:fetch',
@@ -30,14 +28,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 class FetchLastFmCommand extends Command
 {
-    private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
-    private const OVERLAP_HOURS = 1;
-    private const DEFAULT_WINDOW_HOURS = 48;
-
     public function __construct(
         private readonly LastFmFetcher $fetcher,
         private readonly RunHistoryRecorder $recorder,
-        private readonly SettingRepository $settings,
+        private readonly FetchWindowResolver $windowResolver,
         private readonly string $defaultApiKey,
         private readonly string $defaultUser,
     ) {
@@ -73,20 +67,25 @@ class FetchLastFmCommand extends Command
             return Command::FAILURE;
         }
 
-        $explicitDateMin = $input->getOption('date-min');
-        $explicitDateMax = $input->getOption('date-max');
-        $smartDate = $explicitDateMin === null;
+        $window = $this->windowResolver->resolve(
+            $user,
+            $input->getOption('date-min'),
+            $input->getOption('date-max'),
+        );
+        $dateMin = $window['dateMin'];
+        $dateMax = $window['dateMax'];
+        $smartDate = $window['source'] !== 'explicit';
 
-        [$dateMin, $dateMax] = $this->resolveDateRange($user, $explicitDateMin, $explicitDateMax, $io);
-
-        if ($dateMin !== null) {
-            $io->note(sprintf(
-                'Fetch window: %s → %s%s',
-                $dateMin->format('Y-m-d H:i:s'),
-                $dateMax?->format('Y-m-d H:i:s') ?? 'now',
-                $smartDate ? ' (smart date)' : ' (explicit)',
-            ));
-        }
+        $io->note(sprintf(
+            'Fetch window: %s → %s (%s)',
+            $dateMin->format('Y-m-d H:i:s'),
+            $dateMax?->format('Y-m-d H:i:s') ?? 'now',
+            match ($window['source']) {
+                'smart' => 'smart date',
+                'default' => sprintf('default %dh — no previous fetch on record', FetchWindowResolver::DEFAULT_WINDOW_HOURS),
+                'explicit' => 'explicit',
+            },
+        ));
 
         $label = sprintf('Last.fm fetch %s%s', $user, $dryRun ? ' [dry-run]' : '');
         $now = new \DateTimeImmutable();
@@ -120,9 +119,9 @@ class FetchLastFmCommand extends Command
             return Command::FAILURE;
         }
 
-        // Update last_fetch setting only on explicit (non-dry-run, non-explicit-date) runs.
+        // Update last_fetch only when the user did not pin an explicit window.
         if ($smartDate && !$dryRun && $report->fetched > 0) {
-            $this->settings->set(self::SETTING_KEY_PREFIX . $user, $now->format('Y-m-d H:i:s'));
+            $this->windowResolver->markFetchedAt($user, $now);
         }
 
         $io->success(sprintf(
@@ -134,43 +133,5 @@ class FetchLastFmCommand extends Command
         ));
 
         return Command::SUCCESS;
-    }
-
-    /**
-     * @return array{0: ?\DateTimeImmutable, 1: ?\DateTimeImmutable}
-     */
-    private function resolveDateRange(string $user, ?string $explicitMin, ?string $explicitMax, SymfonyStyle $io): array
-    {
-        $dateMax = $explicitMax !== null ? new \DateTimeImmutable($explicitMax) : null;
-
-        if ($explicitMin !== null) {
-            return [new \DateTimeImmutable($explicitMin), $dateMax];
-        }
-
-        // Smart date: read last successful fetch from settings.
-        $lastFetch = $this->settings->get(self::SETTING_KEY_PREFIX . $user);
-        if ($lastFetch !== '') {
-            $dateMin = (new \DateTimeImmutable($lastFetch))
-                ->modify(sprintf('-%d hours', self::OVERLAP_HOURS));
-            $io->note(sprintf(
-                'Smart date: last fetch was %s, starting from %s (-%dh overlap).',
-                $lastFetch,
-                $dateMin->format('Y-m-d H:i:s'),
-                self::OVERLAP_HOURS,
-            ));
-            return [$dateMin, $dateMax];
-        }
-
-        // No previous fetch — default to the last DEFAULT_WINDOW_HOURS. A full
-        // bootstrap is opt-in via --date-min=1970-01-01 so a fresh install
-        // doesn't accidentally pull years of history on a cron tick.
-        $dateMin = (new \DateTimeImmutable())->modify(sprintf('-%d hours', self::DEFAULT_WINDOW_HOURS));
-        $io->note(sprintf(
-            'No previous fetch found — defaulting to the last %dh (from %s). '
-            . 'Pass --date-min for a different window.',
-            self::DEFAULT_WINDOW_HOURS,
-            $dateMin->format('Y-m-d H:i:s'),
-        ));
-        return [$dateMin, $dateMax];
     }
 }

--- a/src/LastFm/FetchWindowResolver.php
+++ b/src/LastFm/FetchWindowResolver.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\LastFm;
+
+use App\Repository\SettingRepository;
+
+/**
+ * Single source of truth for resolving the (dateMin, dateMax) window used by
+ * `app:lastfm:fetch` (CLI) and `FetchLastFmMessageHandler` (web UI). Both
+ * paths previously duplicated the smart-date logic and drifted out of sync —
+ * the web button defaulted to "full history" on a fresh install while the
+ * CLI defaulted to 48h. This service is the canonical implementation.
+ *
+ * Resolution order:
+ *  1. explicit --date-min → that wins.
+ *  2. setting[lastfm_last_fetch_{user}] present → `last_fetch - OVERLAP_HOURS`.
+ *  3. nothing recorded yet → `now - DEFAULT_WINDOW_HOURS` (no full bootstrap
+ *     by accident on a cron tick).
+ */
+final class FetchWindowResolver
+{
+    public const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
+    public const OVERLAP_HOURS = 1;
+    public const DEFAULT_WINDOW_HOURS = 48;
+
+    public function __construct(private readonly SettingRepository $settings)
+    {
+    }
+
+    /**
+     * @return array{dateMin: \DateTimeImmutable, dateMax: ?\DateTimeImmutable, source: 'explicit'|'smart'|'default'}
+     */
+    public function resolve(string $user, ?string $explicitDateMin, ?string $explicitDateMax): array
+    {
+        $dateMax = $explicitDateMax !== null ? new \DateTimeImmutable($explicitDateMax) : null;
+
+        if ($explicitDateMin !== null) {
+            return [
+                'dateMin' => new \DateTimeImmutable($explicitDateMin),
+                'dateMax' => $dateMax,
+                'source' => 'explicit',
+            ];
+        }
+
+        $lastFetch = $this->settings->get(self::SETTING_KEY_PREFIX . $user);
+        if ($lastFetch !== '') {
+            return [
+                'dateMin' => (new \DateTimeImmutable($lastFetch))
+                    ->modify(sprintf('-%d hours', self::OVERLAP_HOURS)),
+                'dateMax' => $dateMax,
+                'source' => 'smart',
+            ];
+        }
+
+        return [
+            'dateMin' => (new \DateTimeImmutable())
+                ->modify(sprintf('-%d hours', self::DEFAULT_WINDOW_HOURS)),
+            'dateMax' => $dateMax,
+            'source' => 'default',
+        ];
+    }
+
+    /**
+     * Record a successful fetch so the next smart-date run knows where to
+     * resume. Callers should only invoke this when source !== 'explicit' and
+     * the run actually pulled scrobbles (no point shifting the cursor on a
+     * dry-run or empty window).
+     */
+    public function markFetchedAt(string $user, \DateTimeImmutable $at): void
+    {
+        $this->settings->set(self::SETTING_KEY_PREFIX . $user, $at->format('Y-m-d H:i:s'));
+    }
+}

--- a/src/MessageHandler/FetchLastFmMessageHandler.php
+++ b/src/MessageHandler/FetchLastFmMessageHandler.php
@@ -4,38 +4,27 @@ namespace App\MessageHandler;
 
 use App\Entity\RunHistory;
 use App\LastFm\FetchReport;
+use App\LastFm\FetchWindowResolver;
 use App\LastFm\LastFmFetcher;
 use App\Message\FetchLastFmMessage;
-use App\Repository\SettingRepository;
 use App\Service\RunHistoryRecorder;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 #[AsMessageHandler]
 class FetchLastFmMessageHandler
 {
-    private const SETTING_KEY_PREFIX = 'lastfm_last_fetch_';
-
     public function __construct(
         private readonly LastFmFetcher $fetcher,
         private readonly RunHistoryRecorder $recorder,
-        private readonly SettingRepository $settings,
+        private readonly FetchWindowResolver $windowResolver,
     ) {
     }
 
     public function __invoke(FetchLastFmMessage $message): void
     {
-        $dateMin = $message->dateMin !== null ? new \DateTimeImmutable($message->dateMin) : null;
-        $dateMax = $message->dateMax !== null ? new \DateTimeImmutable($message->dateMax) : null;
-        $smartDate = $message->dateMin === null;
+        $window = $this->windowResolver->resolve($message->user, $message->dateMin, $message->dateMax);
+        $smartDate = $window['source'] !== 'explicit';
         $now = new \DateTimeImmutable();
-
-        // Apply smart date if no explicit date-min.
-        if ($smartDate) {
-            $lastFetch = $this->settings->get(self::SETTING_KEY_PREFIX . $message->user);
-            if ($lastFetch !== '') {
-                $dateMin = (new \DateTimeImmutable($lastFetch))->modify('-1 hours');
-            }
-        }
 
         $report = $this->recorder->record(
             type: RunHistory::TYPE_LASTFM_FETCH,
@@ -44,8 +33,8 @@ class FetchLastFmMessageHandler
             action: fn () => $this->fetcher->fetch(
                 apiKey: $message->apiKey,
                 lastFmUser: $message->user,
-                dateMin: $dateMin,
-                dateMax: $dateMax,
+                dateMin: $window['dateMin'],
+                dateMax: $window['dateMax'],
                 maxScrobbles: $message->maxScrobbles,
                 dryRun: $message->dryRun,
             ),
@@ -59,7 +48,7 @@ class FetchLastFmMessageHandler
         );
 
         if ($smartDate && !$message->dryRun && $report->fetched > 0) {
-            $this->settings->set(self::SETTING_KEY_PREFIX . $message->user, $now->format('Y-m-d H:i:s'));
+            $this->windowResolver->markFetchedAt($message->user, $now);
         }
     }
 }

--- a/tests/Command/FetchLastFmCommandTest.php
+++ b/tests/Command/FetchLastFmCommandTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Command;
 use App\Command\FetchLastFmCommand;
 use App\Entity\RunHistory;
 use App\LastFm\FetchReport;
+use App\LastFm\FetchWindowResolver;
 use App\LastFm\LastFmFetcher;
 use App\Repository\SettingRepository;
 use App\Service\RunHistoryRecorder;
@@ -16,8 +17,6 @@ class FetchLastFmCommandTest extends TestCase
 {
     public function testDefaultWindowIsLast48HoursOnFirstRun(): void
     {
-        // Capture the window the fetcher is called with — that's what we
-        // are actually asserting (the printed note is just for the user).
         $captured = null;
         $fetcher = $this->createMock(LastFmFetcher::class);
         $fetcher->expects($this->once())
@@ -28,7 +27,7 @@ class FetchLastFmCommandTest extends TestCase
             });
 
         $settings = $this->createMock(SettingRepository::class);
-        $settings->method('get')->willReturn(''); // no previous fetch
+        $settings->method('get')->willReturn('');
         $settings->expects($this->never())->method('set');
 
         $tester = $this->makeTester($fetcher, $settings);
@@ -36,7 +35,6 @@ class FetchLastFmCommandTest extends TestCase
 
         $this->assertNotNull($captured['dateMin']);
         $this->assertNull($captured['dateMax']);
-        // Default window is 48h — accept a 5s drift to account for test latency.
         $expected = (new \DateTimeImmutable())->modify('-48 hours')->getTimestamp();
         $this->assertLessThanOrEqual(5, abs($captured['dateMin']->getTimestamp() - $expected));
     }
@@ -52,8 +50,6 @@ class FetchLastFmCommandTest extends TestCase
             }
         );
 
-        // Last fetch 7 days ago — smart date should use that minus 1h overlap,
-        // NOT the 48h default.
         $lastFetch = (new \DateTimeImmutable('-7 days'))->format('Y-m-d H:i:s');
         $settings = $this->createMock(SettingRepository::class);
         $settings->method('get')->willReturn($lastFetch);
@@ -88,13 +84,13 @@ class FetchLastFmCommandTest extends TestCase
 
     private function makeTester(LastFmFetcher $fetcher, SettingRepository $settings): CommandTester
     {
-        // Recorder that just invokes the action — no DB writes in tests.
         $recorder = $this->createMock(RunHistoryRecorder::class);
         $recorder->method('record')->willReturnCallback(
             static fn (string $type, string $ref, string $label, callable $action) => $action(new RunHistory($type, $ref, $label)),
         );
 
-        $command = new FetchLastFmCommand($fetcher, $recorder, $settings, 'default-key', 'default-user');
+        $resolver = new FetchWindowResolver($settings);
+        $command = new FetchLastFmCommand($fetcher, $recorder, $resolver, 'default-key', 'default-user');
         $app = new Application();
         $app->add($command);
 

--- a/tests/MessageHandler/FetchLastFmMessageHandlerTest.php
+++ b/tests/MessageHandler/FetchLastFmMessageHandlerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\LastFm\FetchReport;
+use App\LastFm\FetchWindowResolver;
+use App\LastFm\LastFmFetcher;
+use App\Message\FetchLastFmMessage;
+use App\MessageHandler\FetchLastFmMessageHandler;
+use App\Repository\SettingRepository;
+use App\Service\RunHistoryRecorder;
+use PHPUnit\Framework\TestCase;
+
+class FetchLastFmMessageHandlerTest extends TestCase
+{
+    public function testWebTriggerDefaultsTo48hWhenNoPreviousFetch(): void
+    {
+        // Regression: handler used to fall through to `null` (full history)
+        // when no setting was recorded — clicking the web button on a fresh
+        // install pulled the entire Last.fm history.
+        $captured = null;
+        $fetcher = $this->createMock(LastFmFetcher::class);
+        $fetcher->expects($this->once())
+            ->method('fetch')
+            ->willReturnCallback(function (string $apiKey, string $user, ?\DateTimeInterface $dateMin) use (&$captured): FetchReport {
+                $captured = $dateMin;
+                return new FetchReport();
+            });
+
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->willReturn('');
+
+        $handler = $this->makeHandler($fetcher, $settings);
+        $handler(new FetchLastFmMessage('alice', 'k', null, null, null, false));
+
+        $this->assertNotNull($captured);
+        $expected = (new \DateTimeImmutable())->modify('-48 hours')->getTimestamp();
+        $this->assertLessThanOrEqual(5, abs($captured->getTimestamp() - $expected));
+    }
+
+    private function makeHandler(LastFmFetcher $fetcher, SettingRepository $settings): FetchLastFmMessageHandler
+    {
+        $recorder = $this->createMock(RunHistoryRecorder::class);
+        $recorder->method('record')->willReturnCallback(
+            static fn (string $type, string $ref, string $label, callable $action) => $action(new RunHistory($type, $ref, $label)),
+        );
+
+        return new FetchLastFmMessageHandler($fetcher, $recorder, new FetchWindowResolver($settings));
+    }
+}


### PR DESCRIPTION
## Symptôme

Le défaut 48h ajouté dans #159 ne s'appliquait **qu'au CLI**. Cliquer « Fetch » depuis `/lastfm/import` sur une install fraîche (pas de `last_fetch` en settings) tirait toujours tout l'historique Last.fm, parce que `FetchLastFmMessageHandler` avait sa propre copie dupliquée de la logique smart-date — copie qui ne connaissait pas le fallback 48h.

## Fix

Extraction de la résolution `(dateMin, dateMax)` dans un service partagé `App\LastFm\FetchWindowResolver`. CLI et handler Messenger l'appellent tous les deux, plus de risque de drift entre les deux chemins.

Resolution order (inchangée, mais maintenant centralisée) :

1. `--date-min` explicite → ce window.
2. `setting[lastfm_last_fetch_{user}]` présent → `last_fetch − 1h → now`.
3. Rien en settings → **`now − 48h → now`** (au lieu de `null` = full history).

## Tests

- `FetchLastFmCommandTest` — 3 tests inchangés sur le path CLI (mis à jour pour injecter le resolver).
- `FetchLastFmMessageHandlerTest::testWebTriggerDefaultsTo48hWhenNoPreviousFetch` — regression test sur le path web : un message avec `dateMin=null` et zéro `last_fetch` doit appeler le fetcher avec `now − 48h`, pas `null`.

`composer ci` : phpcs ✓, phpstan ✓, 27 tests / 68 assertions ✓

## Test plan

- [ ] Wipe les settings (`UPDATE setting … DELETE`) ou install neuf
- [ ] Cliquer le bouton « Fetch » depuis `/lastfm/import`
- [ ] Vérifier sur `/history` que le run `lastfm-fetch` a `fetched ~= ce que tu as scrobblé sur 48h`, pas `363 699`

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_