### PR TITLE
feat(stats): heatmap d'activité 12 mois style GitHub sur /stats

### DIFF
--- a/src/Controller/StatsController.php
+++ b/src/Controller/StatsController.php
@@ -37,6 +37,7 @@ class StatsController extends AbstractController
             'period' => $period,
             'periods' => LocalStatsService::PERIODS,
             'total_scrobbles' => $this->scrobbleRepo->countAll(),
+            'heatmap' => $this->statsService->heatmap($user),
         ]);
     }
 

--- a/src/Service/LocalStatsService.php
+++ b/src/Service/LocalStatsService.php
@@ -34,6 +34,7 @@ class LocalStatsService
     private const TOP_ARTISTS_LIMIT = 25;
     private const TOP_TRACKS_LIMIT = 50;
     private const PLAYS_BY_MONTH_LIMIT = 24;
+    private const HEATMAP_DAYS = 365;
 
     public function __construct(
         private readonly Connection $connection,
@@ -157,6 +158,116 @@ class LocalStatsService
 
         /** @var list<array{month: string, plays: int}> */
         return array_reverse($this->connection->fetchAllAssociative($sql, $params));
+    }
+
+    /**
+     * GitHub-style activity heatmap over the last HEATMAP_DAYS, aligned to
+     * Monday-starting weeks. Independent of the period selector — always
+     * the same rolling window so the visual is stable across nav clicks.
+     *
+     * Levels (0..4) are bucketed by the quartiles of NON-ZERO days so a
+     * single outlier (a 12h playlist marathon) doesn't crush everything
+     * else into level 1.
+     *
+     * @return array{
+     *     weeks: list<list<array{date: string, plays: int, level: int}|null>>,
+     *     start: string,
+     *     end: string,
+     *     total: int,
+     *     max: int,
+     *     thresholds: list<int>,
+     * }
+     */
+    public function heatmap(?string $user = null): array
+    {
+        $tz = new \DateTimeZone('UTC');
+        $today = new \DateTimeImmutable('today', $tz);
+        $start = $today->modify(sprintf('-%d days', self::HEATMAP_DAYS));
+        // Snap start back to Monday. PHP date('w'): 0=Sun..6=Sat → we want 0=Mon..6=Sun.
+        $startDow = ((int) $start->format('w') + 6) % 7;
+        $start = $start->modify(sprintf('-%d days', $startDow));
+
+        [$where, $params] = $this->buildWhere($start, $today->modify('+1 day'), $user);
+        $sql = "SELECT date(played_at) AS d, COUNT(*) AS n FROM scrobbles"
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY d';
+        /** @var array<string, int> $plays */
+        $plays = $this->connection->fetchAllKeyValue($sql, $params);
+        $plays = array_map('intval', $plays);
+
+        $thresholds = $this->quartileThresholds(array_values($plays));
+
+        $weeks = [];
+        $cursor = $start;
+        while ($cursor <= $today) {
+            $week = [];
+            for ($i = 0; $i < 7; $i++) {
+                if ($cursor > $today) {
+                    // Right-pad: days after today within the last column.
+                    $week[] = null;
+                } else {
+                    $date = $cursor->format('Y-m-d');
+                    $n = $plays[$date] ?? 0;
+                    $week[] = [
+                        'date' => $date,
+                        'plays' => $n,
+                        'level' => $this->level($n, $thresholds),
+                    ];
+                }
+                $cursor = $cursor->modify('+1 day');
+            }
+            $weeks[] = $week;
+        }
+
+        return [
+            'weeks' => $weeks,
+            'start' => $start->format('Y-m-d'),
+            'end' => $today->format('Y-m-d'),
+            'total' => array_sum($plays),
+            'max' => $plays === [] ? 0 : max($plays),
+            'thresholds' => $thresholds,
+        ];
+    }
+
+    /**
+     * @param list<int> $values
+     * @return list<int>  [q1, q2, q3] of non-zero values, ascending
+     */
+    private function quartileThresholds(array $values): array
+    {
+        $nonZero = array_values(array_filter($values, static fn (int $v): bool => $v > 0));
+        if ($nonZero === []) {
+            return [0, 0, 0];
+        }
+        sort($nonZero);
+        $n = count($nonZero);
+
+        // Pick the value at each quartile boundary. With <4 distinct values
+        // the thresholds collapse, which is fine — `level()` just falls
+        // through to the next bucket.
+        return [
+            $nonZero[(int) floor(($n - 1) * 0.25)],
+            $nonZero[(int) floor(($n - 1) * 0.50)],
+            $nonZero[(int) floor(($n - 1) * 0.75)],
+        ];
+    }
+
+    /** @param list<int> $thresholds */
+    private function level(int $plays, array $thresholds): int
+    {
+        if ($plays <= 0) {
+            return 0;
+        }
+        if ($plays <= $thresholds[0]) {
+            return 1;
+        }
+        if ($plays <= $thresholds[1]) {
+            return 2;
+        }
+        if ($plays <= $thresholds[2]) {
+            return 3;
+        }
+        return 4;
     }
 
     /**

--- a/templates/stats/index.html.twig
+++ b/templates/stats/index.html.twig
@@ -45,6 +45,54 @@
         {% endif %}
     </div>
 
+    {# Heatmap d'activité — fenêtre fixe sur les 365 derniers jours, indépendante du sélecteur de période. #}
+    {% if heatmap.total > 0 %}
+    {% set day_labels = ['Lun', '', 'Mer', '', 'Ven', '', 'Dim'] %}
+    {% set level_classes = ['bg-slate-100', 'bg-emerald-200', 'bg-emerald-400', 'bg-emerald-600', 'bg-emerald-800'] %}
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6 overflow-x-auto">
+        <div class="flex items-baseline justify-between mb-3 gap-3 flex-wrap">
+            <div>
+                <div class="text-sm font-semibold">Activité — 12 derniers mois</div>
+                <div class="text-xs text-slate-500">
+                    {{ heatmap.total|number_format(0, '.', ' ') }} lectures du
+                    {{ heatmap.start|date('d/m/Y') }} au {{ heatmap.end|date('d/m/Y') }} —
+                    pic à {{ heatmap.max|number_format(0, '.', ' ') }}/jour
+                </div>
+            </div>
+            <div class="flex items-center gap-1.5 text-xs text-slate-500">
+                <span>Moins</span>
+                {% for lvl in 0..4 %}
+                <span class="inline-block w-3 h-3 rounded-sm {{ level_classes[lvl] }}"></span>
+                {% endfor %}
+                <span>Plus</span>
+            </div>
+        </div>
+
+        <div class="flex gap-1 min-w-fit">
+            {# Day-of-week labels column #}
+            <div class="grid grid-rows-7 gap-0.5 text-[10px] text-slate-400 pr-1">
+                {% for label in day_labels %}
+                <div class="h-3 leading-3">{{ label }}</div>
+                {% endfor %}
+            </div>
+
+            {# Heatmap grid: weeks = columns, days = rows (Mon→Sun). #}
+            <div class="grid grid-flow-col grid-rows-7 gap-0.5">
+                {% for week in heatmap.weeks %}
+                    {% for cell in week %}
+                        {% if cell is null %}
+                            <div class="w-3 h-3"></div>
+                        {% else %}
+                            <div class="w-3 h-3 rounded-sm {{ level_classes[cell.level] }}"
+                                 title="{{ cell.date|date('d/m/Y') }} — {{ cell.plays }} lecture{{ cell.plays > 1 ? 's' : '' }}"></div>
+                        {% endif %}
+                    {% endfor %}
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
         {# Top artistes #}
         {% if data.top_artists is not empty %}

--- a/tests/Service/LocalStatsServiceTest.php
+++ b/tests/Service/LocalStatsServiceTest.php
@@ -71,6 +71,89 @@ class LocalStatsServiceTest extends TestCase
         $conn->close();
     }
 
+    public function testHeatmapCoversFullYearAlignedToMonday(): void
+    {
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        $service = $this->makeService($conn);
+
+        $heatmap = $service->heatmap('alice');
+
+        // Start must be a Monday — that's what the day-of-week labels rely on.
+        $startDow = (int) (new \DateTimeImmutable($heatmap['start']))->format('w');
+        $this->assertSame(1, $startDow, 'heatmap start day must be Monday');
+
+        // Window spans ~366 days (365 + back-to-Monday snap).
+        $start = new \DateTimeImmutable($heatmap['start']);
+        $end = new \DateTimeImmutable($heatmap['end']);
+        $days = $start->diff($end)->days + 1;
+        $this->assertGreaterThanOrEqual(365, $days);
+        $this->assertLessThanOrEqual(371, $days);
+
+        // Each week is exactly 7 cells (Monday..Sunday), null-padded after today.
+        foreach ($heatmap['weeks'] as $week) {
+            $this->assertCount(7, $week);
+        }
+
+        $conn->close();
+    }
+
+    public function testHeatmapLevelsUseQuartileBucketsOfNonZeroDays(): void
+    {
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);
+        // Wipe the setUp fixtures (old 2024 dates fall outside the rolling
+        // 365d window so they're irrelevant — but make it explicit).
+        $conn->executeStatement('DELETE FROM scrobbles');
+
+        // 4 distinct non-zero counts: 1, 5, 10, 50 — quartiles at 1, 5, 10.
+        $today = new \DateTimeImmutable('today');
+        $this->insertN($conn, $today->modify('-1 day'), 1);
+        $this->insertN($conn, $today->modify('-2 days'), 5);
+        $this->insertN($conn, $today->modify('-3 days'), 10);
+        $this->insertN($conn, $today->modify('-4 days'), 50);
+
+        $service = $this->makeService($conn);
+        $heatmap = $service->heatmap('alice');
+
+        $this->assertSame([1, 5, 10], $heatmap['thresholds']);
+        $this->assertSame(50, $heatmap['max']);
+        $this->assertSame(66, $heatmap['total']);
+
+        // Flatten and check each level assignment.
+        $byDate = [];
+        foreach ($heatmap['weeks'] as $week) {
+            foreach ($week as $cell) {
+                if ($cell !== null) {
+                    $byDate[$cell['date']] = $cell['level'];
+                }
+            }
+        }
+        $this->assertSame(1, $byDate[$today->modify('-1 day')->format('Y-m-d')]); // 1 plays → q1
+        $this->assertSame(2, $byDate[$today->modify('-2 days')->format('Y-m-d')]); // 5 plays → q2
+        $this->assertSame(3, $byDate[$today->modify('-3 days')->format('Y-m-d')]); // 10 plays → q3
+        $this->assertSame(4, $byDate[$today->modify('-4 days')->format('Y-m-d')]); // 50 plays → >q3
+
+        $conn->close();
+    }
+
+    private function makeService(\Doctrine\DBAL\Connection $conn): LocalStatsService
+    {
+        $snapshots = $this->createMock(StatsSnapshotRepository::class);
+        $snapshots->method('findOneByPeriod')->willReturn(null);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        return new LocalStatsService($conn, $snapshots, $em);
+    }
+
+    private function insertN(\Doctrine\DBAL\Connection $conn, \DateTimeImmutable $day, int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $conn->executeStatement(
+                'INSERT INTO scrobbles (lastfm_user, artist, title, played_at) VALUES (?, ?, ?, ?)',
+                ['alice', 'A', 'T' . $i, $day->modify(sprintf('+%d minutes', $i))->format('Y-m-d H:i:s')],
+            );
+        }
+    }
+
     public function testTopTracksGroupsByArtistAndTitle(): void
     {
         $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->dbPath]);


### PR DESCRIPTION
## Ce que ça fait

Ajoute une heatmap d'activité **12 derniers mois** sur `/stats`, dans le style des contributions GitHub : 53 colonnes (semaines, lundi-démarrage) × 7 lignes (jours), couleur graduée en 5 niveaux selon le nombre de lectures.

Indépendante du sélecteur de période : reste stable quand tu navigues entre 7d / 30d / 90d / etc.

## Choix de design

- **Quartiles** plutôt que ratio linéaire vs max pour la bucketisation. Avec un ratio linéaire, un seul jour à 1000 lectures (playlist marathon, soirée) tasse tous les autres jours en level 1 et la heatmap devient illisible. Quartiles des jours **non-zéro** → distribution équilibrée même avec une long-tail. Les seuils sont exposés dans le retour (`thresholds`) pour debug.
- **Semaines alignées lundi** (vs Sunday-start de GitHub) pour rester cohérent avec le contexte FR.
- **CSS grid pur** (`grid-flow-col grid-rows-7`) — pas de JS, pas de SVG, tooltip via `title=""` natif.
- **Pas de snapshot cache** : la requête est `SELECT date(played_at), COUNT(*) … GROUP BY` avec index sur `played_at`, très bon marché. Pas besoin de stocker dans `stats_snapshot`.

## Tests

- `testHeatmapCoversFullYearAlignedToMonday` — vérifie que le start est bien un lundi, span 365-371 jours, exactement 7 cellules par semaine.
- `testHeatmapLevelsUseQuartileBucketsOfNonZeroDays` — fixture avec 1/5/10/50 plays sur 4 jours consécutifs, on vérifie thresholds=[1,5,10] et niveaux assignés 1/2/3/4.
- `composer ci` : phpcs ✓, phpstan ✓, 29 tests / 133 assertions ✓, twig lint ✓.

## Test plan

- [ ] Aller sur `/stats` avec une DB qui contient un peu d'historique
- [ ] Heatmap visible juste sous les KPIs, en pleine largeur scrollable horizontalement sur mobile
- [ ] Survoler une case → tooltip "DD/MM/YYYY — N lectures"
- [ ] Cliquer sur `7 derniers jours` / `Tout` → la heatmap ne change pas (c'est voulu)

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_