### PR TITLE
fix(sync): détacher aussi les Scrobble post-flush pour éviter l'OOM

### DIFF
--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -226,9 +226,18 @@ class NavidromeSyncService
         // ORMInvalidArgumentException ("detached entity cannot be persisted")
         // in Doctrine ORM 3, which closes the EM. Doing it here bounds the
         // identity map to one batch worth of entities at most.
+        //
+        // We also detach the joined Scrobble, otherwise `toIterable()` keeps
+        // loading them into the identity map forever (one per yielded row)
+        // and a `--limit=50000` run OOMs at ~30k rows on a 128M heap.
         foreach ($batch as $row) {
-            if ($this->em->contains($row['sync'])) {
-                $this->em->detach($row['sync']);
+            $sync = $row['sync'];
+            $scrobble = $sync->getScrobble();
+            if ($this->em->contains($sync)) {
+                $this->em->detach($sync);
+            }
+            if ($this->em->contains($scrobble)) {
+                $this->em->detach($scrobble);
             }
         }
     }

--- a/src/Strawberry/StrawberrySyncService.php
+++ b/src/Strawberry/StrawberrySyncService.php
@@ -158,9 +158,18 @@ class StrawberrySyncService
         // ORMInvalidArgumentException ("detached entity cannot be persisted")
         // in Doctrine ORM 3, which closes the EM. Doing it here bounds the
         // identity map to one batch worth of entities at most.
+        //
+        // We also detach the joined Scrobble, otherwise `toIterable()` keeps
+        // loading them into the identity map forever (one per yielded row)
+        // and a `--limit=50000` run OOMs at ~30k rows on a 128M heap.
         foreach ($batch as $row) {
-            if ($this->em->contains($row['sync'])) {
-                $this->em->detach($row['sync']);
+            $sync = $row['sync'];
+            $scrobble = $sync->getScrobble();
+            if ($this->em->contains($sync)) {
+                $this->em->detach($sync);
+            }
+            if ($this->em->contains($scrobble)) {
+                $this->em->detach($scrobble);
             }
         }
     }

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -161,6 +161,42 @@ class NavidromeSyncServiceTest extends TestCase
         $this->assertSame(1, $report->matched);
     }
 
+    public function testBatchFlushDetachesBothSyncAndScrobble(): void
+    {
+        // Regression for the OOM on --limit=50000 : the old code detached
+        // ScrobbleSync but left the joined Scrobble entity in the identity
+        // map, so the map grew unbounded across iterations.
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturn(null);
+
+        $detached = new \SplObjectStorage();
+        $em = $this->createMock(EntityManagerInterface::class);
+        // contains() returns true until detach() is called for that entity.
+        $em->method('contains')->willReturnCallback(static fn (object $e): bool => !isset($detached[$e]));
+        $em->method('detach')->willReturnCallback(static function (object $e) use ($detached): void {
+            $detached[$e] = true;
+        });
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $service->process();
+
+        $this->assertTrue(isset($detached[$sync]), 'ScrobbleSync must be detached');
+        $this->assertTrue(isset($detached[$scrobble]), 'Scrobble must be detached (otherwise toIterable() leaks them on long runs)');
+    }
+
     private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
     {
         return new Scrobble(

--- a/tests/Strawberry/StrawberrySyncServiceTest.php
+++ b/tests/Strawberry/StrawberrySyncServiceTest.php
@@ -159,6 +159,36 @@ class StrawberrySyncServiceTest extends TestCase
         $this->assertSame(5, $playcount);
     }
 
+    public function testBatchFlushDetachesBothSyncAndScrobble(): void
+    {
+        // Regression for the OOM on --limit=50000 : the old code detached
+        // ScrobbleSync but left the joined Scrobble entity in the identity
+        // map, so the map grew unbounded across iterations.
+        $scrobble = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $sync = new ScrobbleSync($scrobble, ScrobbleSync::TARGET_STRAWBERRY);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(1);
+        $syncRepo->method('streamPending')->willReturnCallback(fn () => yield $sync);
+        $syncRepo->method('resetUnmatchedToPending')->willReturn(0);
+
+        $detached = new \SplObjectStorage();
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturnCallback(static fn (object $e): bool => !isset($detached[$e]));
+        $em->method('detach')->willReturnCallback(static function (object $e) use ($detached): void {
+            $detached[$e] = true;
+        });
+        $em->method('persist');
+        $em->method('flush');
+
+        $repo = new StrawberryRepository($this->sbDbPath);
+        $service = new StrawberrySyncService($syncRepo, $repo, $em);
+        $service->process();
+
+        $this->assertTrue(isset($detached[$sync]), 'ScrobbleSync must be detached');
+        $this->assertTrue(isset($detached[$scrobble]), 'Scrobble must be detached (otherwise toIterable() leaks them on long runs)');
+    }
+
     private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
     {
         return new Scrobble(


### PR DESCRIPTION
## Symptôme

```
$ bin/console app:scrobbles:sync-navidrome --limit=50000
Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 4096 bytes)
in /app/vendor/doctrine/dbal/src/Connection.php on line 899
```

## Cause

`streamPending()` utilise Doctrine's `toIterable()`, qui **ne détache pas** automatiquement les entités yieldées — chaque itération laisse le `ScrobbleSync` *et* le `Scrobble` joint dans l'identity map.

Mon fix précédent (#157) détachait `ScrobbleSync` après le `flush()`, mais le `Scrobble` lui restait collé. Sur 50 000 itérations, ça représente ~25 MB de Scrobble + overhead Doctrine (proxies, metadata, change-tracking), suffisant pour faire péter le heap 128 MB par défaut de PHP. L'OOM tombait au prochain `executeStatement()` côté DBAL — le coupable n'est pas la requête, c'est juste là que la machine n'avait plus d'air.

## Fix

Dans `flushBatch()` des deux services, on capture `$sync->getScrobble()` avant le `detach()` puis on détache les deux. L'identity map reste bornée à `BATCH_SIZE` (100) entités à tout moment, quel que soit `--limit`.

## Tests

`testBatchFlushDetachesBothSyncAndScrobble` ajouté sur les deux services : EM stub qui track les `detach()` via `SplObjectStorage`, on vérifie que **les deux** entités sont retirées post-flush. Si quelqu'un regresse en oubliant le scrobble, ces tests pétent.

`composer ci` : phpcs ✓, phpstan ✓, 31 tests / 137 assertions ✓.

## Test plan

- [ ] Rebuild `:develop`
- [ ] `app:scrobbles:sync-navidrome --limit=50000` → doit aller au bout sans OOM
- [ ] Surveiller `ps -o rss` pendant le run → doit rester stable autour de 30-50 MB au lieu de grimper linéairement

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_