### PR TITLE
feat(ui): nav responsive avec dropdowns groupés et burger mobile

### DIFF
--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -1,0 +1,97 @@
+{#
+    Main navigation tree. Single source of truth shared by the desktop bar
+    and the mobile burger drawer (variant = 'desktop' | 'mobile') so the
+    two cannot drift apart again. Each top-level entry is either a plain
+    `link` or a `dropdown` made of one or more `groups`. A group with a
+    null `heading` renders flat ; a group with a heading renders the
+    label as a small uppercase divider.
+#}
+
+{% set sections = [
+    { type: 'link', label: 'Dashboard', route: 'app_dashboard' },
+    { type: 'dropdown', label: 'Last.fm', width: 'w-56', groups: [
+        { heading: null, items: [
+            { label: 'Import', route: 'app_lastfm_import' },
+        ]},
+        { heading: 'Aliases', items: [
+            { label: 'Tracks', route: 'app_lastfm_alias_index' },
+            { label: 'Artistes', route: 'app_lastfm_artist_alias_index' },
+        ]},
+    ]},
+    { type: 'dropdown', label: 'Navidrome', width: 'w-56', groups: [
+        { heading: null, items: [
+            { label: 'Sync', route: 'app_navidrome_sync' },
+            { label: 'Unmatched', route: 'app_navidrome_unmatched' },
+        ]},
+    ]},
+    { type: 'dropdown', label: 'Strawberry', width: 'w-56', groups: [
+        { heading: null, items: [
+            { label: 'Sync', route: 'app_strawberry_sync' },
+            { label: 'Unmatched', route: 'app_strawberry_unmatched' },
+        ]},
+    ]},
+    { type: 'link', label: 'Stats', route: 'app_stats' },
+    { type: 'link', label: 'Historique', route: 'app_history' },
+] %}
+
+{% if variant == 'desktop' %}
+    <nav class="hidden md:flex flex-1 items-center justify-center gap-5 text-sm">
+        {% for section in sections %}
+            {% if section.type == 'link' %}
+                <a href="{{ path(section.route) }}" class="hover:text-white">{{ section.label }}</a>
+            {% else %}
+                <div class="relative group">
+                    <button type="button"
+                            class="hover:text-white flex items-center gap-1 cursor-pointer"
+                            aria-haspopup="true">
+                        {{ section.label }} <span class="text-xs">▾</span>
+                    </button>
+                    <div class="absolute left-1/2 -translate-x-1/2 top-full mt-1 {{ section.width }} bg-slate-800 text-slate-100 rounded-sm shadow-lg invisible opacity-0 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100 transition py-1 z-30">
+                        {% for group in section.groups %}
+                            {% if group.heading %}
+                                {% if not loop.first %}
+                                    <hr class="border-slate-700 my-1">
+                                {% endif %}
+                                <div class="px-4 pt-2 pb-1 text-xs uppercase tracking-wide text-slate-400">{{ group.heading }}</div>
+                            {% endif %}
+                            {% for item in group.items %}
+                                <a href="{{ path(item.route) }}" class="block px-4 py-2 text-sm hover:bg-slate-700">{{ item.label }}</a>
+                            {% endfor %}
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+        {% endfor %}
+    </nav>
+{% else %}
+    <nav id="mobile-nav" class="md:hidden hidden border-t border-slate-700 bg-slate-800">
+        <div class="max-w-6xl mx-auto px-4 py-2 flex flex-col text-sm">
+            {% for section in sections %}
+                {% if section.type == 'link' %}
+                    <a href="{{ path(section.route) }}" class="block py-2 px-2 rounded-sm hover:bg-slate-700">{{ section.label }}</a>
+                {% else %}
+                    <details class="group">
+                        <summary class="py-2 px-2 rounded-sm hover:bg-slate-700 cursor-pointer flex items-center justify-between list-none">
+                            <span>{{ section.label }}</span>
+                            <span class="text-xs transition group-open:rotate-180">▾</span>
+                        </summary>
+                        <div class="pl-4 flex flex-col">
+                            {% for group in section.groups %}
+                                {% if group.heading %}
+                                    <div class="px-2 pt-2 pb-1 text-xs uppercase tracking-wide text-slate-400">{{ group.heading }}</div>
+                                {% endif %}
+                                {% for item in group.items %}
+                                    <a href="{{ path(item.route) }}" class="block py-2 px-2 rounded-sm hover:bg-slate-700">{{ item.label }}</a>
+                                {% endfor %}
+                            {% endfor %}
+                        </div>
+                    </details>
+                {% endif %}
+            {% endfor %}
+            <div class="border-t border-slate-700 mt-2 pt-2 flex items-center justify-between px-2">
+                <span class="text-slate-400">{{ app.user.userIdentifier }}</span>
+                <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>
+            </div>
+        </div>
+    </nav>
+{% endif %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -7,22 +7,40 @@
     <title>{% block title %}{% endblock %} — Navidrome Tools{% if app_version is defined and app_version != 'dev' %} {{ app_version }}{% endif %}</title>
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
 </head>
-<body class="bg-slate-100 text-slate-900 min-h-screen">
+<body class="bg-slate-100 text-slate-900 min-h-screen flex flex-col">
 
 {% if app.user %}
-<nav class="bg-slate-800 text-slate-100 px-4 py-2 flex items-center gap-4 text-sm">
-    <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white">Navidrome Tools</a>
-    <a href="{{ path('app_lastfm_import') }}" class="hover:text-slate-300">Import Last.fm</a>
-    <a href="{{ path('app_navidrome_sync') }}" class="hover:text-slate-300">Sync Navidrome</a>
-    <a href="{{ path('app_strawberry_sync') }}" class="hover:text-slate-300">Sync Strawberry</a>
-    <a href="{{ path('app_stats') }}" class="hover:text-slate-300">Stats</a>
-    <a href="{{ path('app_history') }}" class="hover:text-slate-300">Historique</a>
-    <span class="flex-1"></span>
-    <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>
-</nav>
+<header class="bg-slate-800 text-slate-100">
+    <div class="max-w-6xl mx-auto px-4 py-2 flex items-center gap-4">
+        <a href="{{ path('app_dashboard') }}" class="font-semibold hover:text-white whitespace-nowrap">Navidrome Tools</a>
+
+        {% include '_navbar.html.twig' with { variant: 'desktop' } only %}
+
+        <div class="hidden md:flex items-center gap-3 text-sm whitespace-nowrap">
+            <span class="text-slate-400">{{ app.user.userIdentifier }}</span>
+            <a href="{{ path('app_logout') }}" class="hover:text-white">Déconnexion</a>
+        </div>
+
+        <button type="button"
+                id="burger-toggle"
+                class="md:hidden ml-auto inline-flex items-center justify-center w-10 h-10 rounded-sm hover:bg-slate-700"
+                aria-label="Ouvrir le menu"
+                aria-controls="mobile-nav"
+                aria-expanded="false">
+            <svg id="burger-icon-open" class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/>
+            </svg>
+            <svg id="burger-icon-close" class="w-6 h-6 hidden" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/>
+            </svg>
+        </button>
+    </div>
+
+    {% include '_navbar.html.twig' with { variant: 'mobile' } only %}
+</header>
 {% endif %}
 
-<main class="max-w-6xl mx-auto px-4 py-6">
+<main class="flex-1 max-w-6xl w-full mx-auto px-4 py-6">
     {% for type, messages in app.flashes %}
         {% for message in messages %}
             <div class="mb-4 p-3 rounded-sm text-sm
@@ -36,5 +54,24 @@
 
     {% block body %}{% endblock %}
 </main>
+
+{% if app.user %}
+<script>
+    (function () {
+        var btn = document.getElementById('burger-toggle');
+        var nav = document.getElementById('mobile-nav');
+        var iconOpen = document.getElementById('burger-icon-open');
+        var iconClose = document.getElementById('burger-icon-close');
+        if (!btn || !nav) return;
+        btn.addEventListener('click', function () {
+            var willOpen = nav.classList.contains('hidden');
+            nav.classList.toggle('hidden', !willOpen);
+            iconOpen.classList.toggle('hidden', willOpen);
+            iconClose.classList.toggle('hidden', !willOpen);
+            btn.setAttribute('aria-expanded', String(willOpen));
+        });
+    })();
+</script>
+{% endif %}
 </body>
 </html>


### PR DESCRIPTION
## Ce que ça fait

Reprend le pattern du POC pour la nav :

- **Responsive** : burger SVG sur mobile, drawer en `<details>` natif (zéro JS pour les sous-menus, un toggle global pour la nav)
- **Menu centré** sur desktop (brand à gauche, menu `flex-1 justify-center`, user/déconnexion à droite)
- **Dropdowns** avec groupes nommés (sub-headings uppercase + séparateurs)
- **Source unique de vérité** : `_navbar.html.twig` rendu en deux variantes `desktop` / `mobile` à partir du même tableau `sections` Twig — plus de risque de drift entre les deux comme l'ancien menu plat qui pouvait se désynchroniser

## Structure

| Top-level | Sous-entrées |
|---|---|
| Dashboard | (lien direct) |
| Last.fm ▾ | Import / Aliases ▸ Tracks, Artistes |
| Navidrome ▾ | Sync / **Unmatched** ← demandé |
| Strawberry ▾ | Sync / Unmatched |
| Stats | (lien direct) |
| Historique | (lien direct) |

Les groupes nommés sont prêts pour d'autres sous-sections futures (Stats avancées, playlists…) — il suffira d'ajouter un `{ heading: '…', items: [...] }` dans le tableau.

## Tests

- Twig lint : 16/16 ✓
- `composer ci` : phpcs ✓, phpstan ✓, 31 tests / 137 assertions ✓
- Tous les routes référencés vérifiés présents dans les controllers actuels

## Test plan

- [ ] Ouvrir l'app sur desktop → vérifier le centrage du menu et les hover des dropdowns
- [ ] Reduce window < 768px (md breakpoint) → vérifier le burger + le drawer
- [ ] Cliquer chaque entrée → toutes doivent atterrir sur une page existante (en particulier `Navidrome ▾ → Unmatched`)
- [ ] Click sur le burger → drawer s'ouvre, icône passe en croix ; re-click → ferme

https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK2svc4AXqAQSZSaPSHBhA)_