### PR TITLE
feat(navidrome): reset complet des statuts sync vers pending

### DIFF
--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -43,6 +43,19 @@ class NavidromeSyncController extends AbstractController
         return $this->redirectToRoute('app_history');
     }
 
+    #[Route('/navidrome/sync/reset', name: 'app_navidrome_sync_reset', methods: ['POST'])]
+    public function reset(Request $request, ScrobbleSyncRepository $syncRepo): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_sync_reset', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $reset = $syncRepo->resetAllToPending(ScrobbleSync::TARGET_NAVIDROME);
+        $this->addFlash('success', sprintf('Reset Navidrome : %d ligne(s) remises en pending.', $reset));
+
+        return $this->redirectToRoute('app_navidrome_sync');
+    }
+
     #[Route('/navidrome/rematch', name: 'app_navidrome_rematch', methods: ['POST'])]
     public function rematch(Request $request, MessageBusInterface $bus): Response
     {

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -124,6 +124,29 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
     }
 
     /**
+     * Reset every non-pending row for $target back to pending. Wipes
+     * target_id and strategy too so the next sync starts from a clean
+     * slate (they will be re-resolved by the matching cascade anyway).
+     */
+    public function resetAllToPending(string $target): int
+    {
+        return (int) $this->em->getConnection()->executeStatement(
+            'UPDATE scrobble_sync
+                SET status = :pending,
+                    target_id = NULL,
+                    strategy = NULL,
+                    attempted_at = NULL,
+                    synced_at = NULL,
+                    run_id = NULL
+              WHERE target = :target AND status <> :pending',
+            [
+                'pending' => ScrobbleSync::STATUS_PENDING,
+                'target' => $target,
+            ],
+        );
+    }
+
+    /**
      * Aggregate unmatched rows grouped by (artist, title, album) for display.
      *
      * @return list<array{artist: string, title: string, album: string|null, count: int, last_played_at: string}>

--- a/templates/navidrome/sync.html.twig
+++ b/templates/navidrome/sync.html.twig
@@ -70,4 +70,22 @@
             <code>php bin/console app:scrobbles:sync-navidrome [--auto-stop] [--dry-run] [--limit=N]</code>
         </div>
     </div>
+
+    {# Reset #}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl border-l-4 border-rose-400">
+        <h2 class="text-lg font-semibold mb-2">Zone dangereuse — Reset</h2>
+        <p class="text-sm text-slate-600 mb-4">
+            Remet <strong>tous</strong> les morceaux (matchés, doublons, non matchés, skipped)
+            en <em>pending</em> pour retenter la synchronisation à zéro. Les playcounts déjà
+            écrits dans Navidrome ne sont pas modifiés.
+        </p>
+        <form method="post" action="{{ path('app_navidrome_sync_reset') }}"
+              onsubmit="return confirm('Confirmer le reset de tous les statuts Navidrome en pending ?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_sync_reset') }}">
+            <button type="submit"
+                    class="bg-rose-600 hover:bg-rose-700 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                ⟲ Reset → pending
+            </button>
+        </form>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Ajoute un bouton « ⟲ Reset → pending » sur `/navidrome/sync` pour remettre tous les morceaux (matched + duplicate + unmatched + skipped) en `pending` et relancer la sync depuis zéro
- `ScrobbleSyncRepository::resetAllToPending()` vide aussi `target_id` et `strategy` (réécrits au prochain run)
- Route `POST /navidrome/sync/reset` avec CSRF + confirm JS dans une zone « dangereuse »

## Test plan

- [ ] Visiter `/navidrome/sync`, cliquer « Reset → pending », confirmer la modal
- [ ] Vérifier le flash : « Reset Navidrome : N ligne(s) remises en pending. »
- [ ] Vérifier que les compteurs (matched/duplicate/unmatched) tombent à 0 et que `pending` reflète le total
- [ ] Relancer une sync : les morceaux sont retraités normalement

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_