### PR TITLE
feat(strawberry): reset complet des statuts sync vers pending

### DIFF
--- a/src/Controller/StrawberryController.php
+++ b/src/Controller/StrawberryController.php
@@ -178,6 +178,19 @@ class StrawberryController extends AbstractController
         return $this->redirectToRoute('app_history');
     }
 
+    #[Route('/strawberry/sync/reset', name: 'app_strawberry_sync_reset', methods: ['POST'])]
+    public function reset(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('strawberry_sync_reset', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $reset = $this->syncRepo->resetAllToPending(ScrobbleSync::TARGET_STRAWBERRY);
+        $this->addFlash('success', sprintf('Reset Strawberry : %d ligne(s) remises en pending.', $reset));
+
+        return $this->redirectToRoute('app_strawberry_sync');
+    }
+
     #[Route('/strawberry/unmatched', name: 'app_strawberry_unmatched', methods: ['GET'])]
     public function unmatched(Request $request): Response
     {

--- a/templates/strawberry/sync.html.twig
+++ b/templates/strawberry/sync.html.twig
@@ -90,4 +90,22 @@
             Fichier SQLite Strawberry (~/.local/share/strawberry/strawberry/strawberry.db). Max 200 Mo.
         </p>
     </div>
+
+    {# Reset #}
+    <div class="bg-white shadow-sm rounded-sm p-6 max-w-xl mt-6 border-l-4 border-rose-400">
+        <h2 class="text-lg font-semibold mb-2">Zone dangereuse — Reset</h2>
+        <p class="text-sm text-slate-600 mb-4">
+            Remet <strong>tous</strong> les morceaux (matchés, doublons, non matchés, skipped)
+            en <em>pending</em> pour retenter la synchronisation à zéro. Les playcounts déjà
+            écrits dans Strawberry ne sont pas modifiés.
+        </p>
+        <form method="post" action="{{ path('app_strawberry_sync_reset') }}"
+              onsubmit="return confirm('Confirmer le reset de tous les statuts Strawberry en pending ?');">
+            <input type="hidden" name="_token" value="{{ csrf_token('strawberry_sync_reset') }}">
+            <button type="submit"
+                    class="bg-rose-600 hover:bg-rose-700 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                ⟲ Reset → pending
+            </button>
+        </form>
+    </div>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Pendant de #164 côté Strawberry : bouton « ⟲ Reset → pending » sur `/strawberry/sync`
- Réutilise `ScrobbleSyncRepository::resetAllToPending()` avec `TARGET_STRAWBERRY`
- Route `POST /strawberry/sync/reset` avec CSRF + confirm JS

## Test plan

- [ ] Visiter `/strawberry/sync`, cliquer « Reset → pending », confirmer la modal
- [ ] Vérifier le flash : « Reset Strawberry : N ligne(s) remises en pending. »
- [ ] Vérifier que matched/unmatched tombent à 0 et que `pending` reflète le total
- [ ] Relancer une sync : les morceaux sont retraités normalement

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_