### PR TITLE
feat(navidrome): page de stats lues depuis la DB Navidrome

### DIFF
--- a/src/Controller/NavidromeStatsController.php
+++ b/src/Controller/NavidromeStatsController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Controller;
+
+use App\Navidrome\NavidromeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class NavidromeStatsController extends AbstractController
+{
+    public function __construct(private readonly NavidromeRepository $navidrome)
+    {
+    }
+
+    #[Route('/navidrome/stats', name: 'app_navidrome_stats', methods: ['GET'])]
+    public function index(): Response
+    {
+        if (!$this->navidrome->isAvailable()) {
+            return $this->render('navidrome/stats.html.twig', [
+                'unavailable' => true,
+            ]);
+        }
+
+        try {
+            $library = $this->navidrome->getLibraryCounts();
+            $starred = $this->navidrome->getStarredCounts();
+            $totalPlays = $this->navidrome->getTotalPlays(null, null);
+            $distinctPlayed = $this->navidrome->getDistinctTracksPlayed(null, null);
+            $recentScrobbles = $this->navidrome->getRecentScrobbles(100);
+            $recentStarred = $this->navidrome->getRecentStarredTracks(25);
+            $topArtists = $this->navidrome->getTopArtists(null, null, 15);
+            $topTracks = $this->navidrome->getTopTracksWithDetails(null, null, 15);
+            $topAlbums = $this->navidrome->getTopAlbums(null, null, 15);
+            $playsByMonth = $this->navidrome->getPlaysByMonth(12);
+        } catch (\Throwable $e) {
+            return $this->render('navidrome/stats.html.twig', [
+                'unavailable' => true,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $this->render('navidrome/stats.html.twig', [
+            'unavailable' => false,
+            'has_scrobbles' => $this->navidrome->hasScrobblesTable(),
+            'library' => $library,
+            'starred' => $starred,
+            'total_plays' => $totalPlays,
+            'distinct_played' => $distinctPlayed,
+            'recent_scrobbles' => $recentScrobbles,
+            'recent_starred' => $recentStarred,
+            'top_artists' => $topArtists,
+            'top_tracks' => $topTracks,
+            'top_albums' => $topAlbums,
+            'plays_by_month' => $playsByMonth,
+        ]);
+    }
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -78,6 +78,113 @@ class NavidromeRepository
         return (int) $this->connection()->fetchOne('SELECT COUNT(*) FROM scrobbles');
     }
 
+    /**
+     * Library-wide aggregates from `media_file`. Used by the stats page to
+     * show « combien on a » indépendamment de l'écoute.
+     *
+     * @return array{tracks: int, artists: int, albums: int, duration_seconds: int}
+     */
+    public function getLibraryCounts(): array
+    {
+        $row = $this->connection()->fetchAssociative(
+            "SELECT COUNT(*) AS tracks,
+                    COUNT(DISTINCT CASE WHEN artist != '' THEN artist END) AS artists,
+                    COUNT(DISTINCT CASE WHEN album != '' THEN album END) AS albums,
+                    COALESCE(SUM(duration), 0) AS dur
+             FROM media_file",
+        );
+
+        return [
+            'tracks' => (int) ($row['tracks'] ?? 0),
+            'artists' => (int) ($row['artists'] ?? 0),
+            'albums' => (int) ($row['albums'] ?? 0),
+            'duration_seconds' => (int) ($row['dur'] ?? 0),
+        ];
+    }
+
+    /**
+     * Number of starred items for the configured user, split by type.
+     * `annotation.starred` is a boolean column present since Navidrome
+     * pre-0.50; safe to query unconditionally.
+     *
+     * @return array{tracks: int, albums: int, artists: int}
+     */
+    public function getStarredCounts(): array
+    {
+        $userId = $this->resolveUserId();
+
+        $rows = $this->connection()->fetchAllAssociative(
+            'SELECT item_type, COUNT(*) AS c
+             FROM annotation
+             WHERE user_id = :uid AND starred = 1
+             GROUP BY item_type',
+            ['uid' => $userId],
+        );
+
+        $out = ['tracks' => 0, 'albums' => 0, 'artists' => 0];
+        foreach ($rows as $r) {
+            $count = (int) $r['c'];
+            switch ((string) $r['item_type']) {
+                case 'media_file':
+                    $out['tracks'] = $count;
+                    break;
+                case 'album':
+                    $out['albums'] = $count;
+                    break;
+                case 'artist':
+                    $out['artists'] = $count;
+                    break;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Most recently starred ("loved") tracks for the configured user.
+     * Items whose `starred_at` is null (very old starred rows from before
+     * Navidrome started recording the timestamp) are excluded so the
+     * ordering stays meaningful.
+     *
+     * @return list<array{id: string, title: string, artist: string, album: string, starred_at: \DateTimeImmutable}>
+     */
+    public function getRecentStarredTracks(int $limit): array
+    {
+        $userId = $this->resolveUserId();
+        $tz = new \DateTimeZone(date_default_timezone_get());
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT a.item_id AS id, a.starred_at AS starred_at,
+                    mf.title AS title, mf.artist AS artist, mf.album AS album
+             FROM annotation a
+             JOIN media_file mf ON mf.id = a.item_id
+             WHERE a.user_id = :uid
+               AND a.item_type = 'media_file'
+               AND a.starred = 1
+               AND a.starred_at IS NOT NULL
+             ORDER BY a.starred_at DESC
+             LIMIT :lim",
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static function (array $r) use ($tz): array {
+            try {
+                $starredAt = new \DateTimeImmutable((string) $r['starred_at']);
+            } catch (\Throwable) {
+                $starredAt = new \DateTimeImmutable('@0');
+            }
+
+            return [
+                'id' => (string) $r['id'],
+                'title' => (string) ($r['title'] ?? ''),
+                'artist' => (string) ($r['artist'] ?? ''),
+                'album' => (string) ($r['album'] ?? ''),
+                'starred_at' => $starredAt->setTimezone($tz),
+            ];
+        }, $rows);
+    }
+
     public function hasScrobblesTable(): bool
     {
         if ($this->hasScrobblesCache !== null) {

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -22,6 +22,7 @@
         { heading: null, items: [
             { label: 'Sync', route: 'app_navidrome_sync' },
             { label: 'Unmatched', route: 'app_navidrome_unmatched' },
+            { label: 'Stats', route: 'app_navidrome_stats' },
         ]},
     ]},
     { type: 'dropdown', label: 'Strawberry', width: 'w-56', groups: [

--- a/templates/navidrome/stats.html.twig
+++ b/templates/navidrome/stats.html.twig
@@ -1,0 +1,236 @@
+{% extends 'base.html.twig' %}
+{% block title %}Stats Navidrome{% endblock %}
+
+{% block body %}
+    <h1 class="text-2xl font-semibold mb-4">Stats Navidrome</h1>
+
+    {% if unavailable %}
+        <div class="bg-rose-50 border border-rose-300 text-rose-900 rounded-sm p-4">
+            <strong>Base Navidrome indisponible.</strong>
+            Vérifiez <code>NAVIDROME_DB_PATH</code> et <code>NAVIDROME_USER</code>.
+            {% if error is defined %}<div class="text-xs mt-2 font-mono">{{ error }}</div>{% endif %}
+        </div>
+    {% else %}
+
+    {# Bibliothèque #}
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Morceaux</div>
+            <div class="text-3xl font-semibold">{{ library.tracks|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Artistes</div>
+            <div class="text-3xl font-semibold">{{ library.artists|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Albums</div>
+            <div class="text-3xl font-semibold">{{ library.albums|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Bibliothèque</div>
+            {% set total_h = (library.duration_seconds // 3600) %}
+            {% set total_m = ((library.duration_seconds // 60) % 60) %}
+            <div class="text-lg font-semibold">
+                {% if total_h >= 24 %}
+                    {{ (total_h // 24) }} j {{ (total_h % 24) }} h
+                {% else %}
+                    {{ total_h }} h {{ total_m }} min
+                {% endif %}
+            </div>
+            <div class="text-xs text-slate-500">{{ library.duration_seconds|number_format(0, '.', ' ') }} s</div>
+        </div>
+    </div>
+
+    {# Écoutes & coups de cœur #}
+    <div class="grid grid-cols-2 sm:grid-cols-5 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Lectures totales</div>
+            <div class="text-3xl font-semibold">{{ total_plays|number_format(0, '.', ' ') }}</div>
+            {% if not has_scrobbles %}
+                <div class="text-[10px] text-amber-600">via annotation (Navidrome &lt; 0.55)</div>
+            {% endif %}
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Morceaux joués</div>
+            <div class="text-3xl font-semibold">{{ distinct_played|number_format(0, '.', ' ') }}</div>
+            {% if library.tracks > 0 %}
+                <div class="text-xs text-slate-500">
+                    {{ (distinct_played / library.tracks * 100)|round(1) }} % de la lib
+                </div>
+            {% endif %}
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">♥ Morceaux</div>
+            <div class="text-3xl font-semibold text-rose-600">{{ starred.tracks|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">♥ Albums</div>
+            <div class="text-3xl font-semibold text-rose-600">{{ starred.albums|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">♥ Artistes</div>
+            <div class="text-3xl font-semibold text-rose-600">{{ starred.artists|number_format(0, '.', ' ') }}</div>
+        </div>
+    </div>
+
+    {# Lectures par mois (12 derniers) #}
+    {% if plays_by_month is not empty %}
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
+        <div class="text-sm font-semibold mb-3">Lectures — 12 derniers mois</div>
+        {% set max_month = max(plays_by_month|map(r => r.plays)) %}
+        <div class="flex items-end gap-1 h-24">
+            {% for row in plays_by_month %}
+            <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
+                <div class="w-full bg-sky-400 rounded-t-sm"
+                     style="height: {{ max_month > 0 ? ((row.plays / max_month * 88)|round) : 0 }}px"
+                     title="{{ row.month }} : {{ row.plays }} lectures"></div>
+                <div class="text-xs text-slate-400 truncate" style="font-size:9px">{{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}</div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# Top all-time #}
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        {% if top_artists is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top artistes (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_a = top_artists[0].plays %}
+                {% for i, row in top_artists %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5 font-medium truncate">{{ row.artist }}</td>
+                    <td class="px-3 py-1.5 w-24">
+                        <div class="bg-sky-200 h-2 rounded-full" style="width: {{ (row.plays / max_a * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {% if top_tracks is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top morceaux (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_t = top_tracks[0].plays %}
+                {% for i, row in top_tracks %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5">
+                        <div class="font-medium truncate max-w-40">{{ row.title }}</div>
+                        <div class="text-xs text-slate-500 truncate max-w-40">{{ row.artist }}</div>
+                    </td>
+                    <td class="px-3 py-1.5 w-20">
+                        <div class="bg-emerald-200 h-2 rounded-full" style="width: {{ (row.plays / max_t * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {% if top_albums is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top albums (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_al = top_albums[0].plays %}
+                {% for i, row in top_albums %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5">
+                        <div class="font-medium truncate max-w-40">{{ row.album }}</div>
+                        <div class="text-xs text-slate-500 truncate max-w-40">{{ row.album_artist }}</div>
+                    </td>
+                    <td class="px-3 py-1.5 w-20">
+                        <div class="bg-amber-200 h-2 rounded-full" style="width: {{ (row.plays / max_al * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+    </div>
+
+    {# 100 derniers lus + 25 derniers ♥ #}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {% if recent_scrobbles is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">
+                100 derniers morceaux lus
+            </div>
+            <div class="max-h-[640px] overflow-y-auto">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y">
+                    {% for row in recent_scrobbles %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 w-32 text-xs text-slate-500 whitespace-nowrap">
+                            {{ row.played_at|date('d/m H:i') }}
+                        </td>
+                        <td class="px-3 py-1.5">
+                            <div class="font-medium truncate max-w-xs">{{ row.title ?: '—' }}</div>
+                            <div class="text-xs text-slate-500 truncate max-w-xs">
+                                {{ row.artist ?: '—' }}{% if row.album %} · {{ row.album }}{% endif %}
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="bg-white shadow-sm rounded-sm p-4 text-sm text-slate-500">
+            Aucune écoute trouvée dans Navidrome.
+            {% if not has_scrobbles %}
+                <br><span class="text-xs">La table <code>scrobbles</code> n'existe pas (Navidrome &lt; 0.55) ; les écoutes récentes n'apparaîtront qu'après mise à jour.</span>
+            {% endif %}
+        </div>
+        {% endif %}
+
+        {% if recent_starred is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">
+                25 derniers coups de cœur
+            </div>
+            <div class="max-h-[640px] overflow-y-auto">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y">
+                    {% for row in recent_starred %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 w-12 text-rose-500 text-center">♥</td>
+                        <td class="px-3 py-1.5">
+                            <div class="font-medium truncate max-w-xs">{{ row.title ?: '—' }}</div>
+                            <div class="text-xs text-slate-500 truncate max-w-xs">
+                                {{ row.artist ?: '—' }}{% if row.album %} · {{ row.album }}{% endif %}
+                            </div>
+                        </td>
+                        <td class="px-3 py-1.5 w-24 text-xs text-slate-500 whitespace-nowrap text-right">
+                            {{ row.starred_at|date('d/m/Y') }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="bg-white shadow-sm rounded-sm p-4 text-sm text-slate-500">
+            Aucun coup de cœur enregistré dans Navidrome.
+        </div>
+        {% endif %}
+    </div>
+
+    {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary

Nouvelle page **/navidrome/stats** accessible via le dropdown Navidrome.
Lit directement la DB SQLite Navidrome et agrège plusieurs vues all-time :

- Compteurs bibliothèque : morceaux / artistes / albums / durée totale
- Lectures totales + nombre de morceaux distincts joués (% de la lib)
- Coups de cœur (♥) : morceaux / albums / artistes (`annotation.starred = 1`)
- Lectures par mois sur 12 mois (barres CSS)
- Top 15 artistes / morceaux / albums all-time
- **100 derniers morceaux lus** (depuis `scrobbles`)
- **25 derniers coups de cœur** (depuis `annotation.starred_at DESC`)

3 nouvelles méthodes sur `NavidromeRepository` (`getLibraryCounts`,
`getStarredCounts`, `getRecentStarredTracks`) ; le reste réutilise les
agrégats existants en passant `null/null` sur les bornes temporelles.

Gestion gracieuse :
- DB Navidrome indisponible → bannière d'erreur
- table `scrobbles` absente (Navidrome < 0.55) → fallback `annotation` pour les lectures, bandeau d'info sur les écoutes récentes

## Test plan

- [ ] Visiter `/navidrome/stats` → tous les compteurs s'affichent
- [ ] Cliquer dans le menu Navidrome → Stats : la page est listée
- [ ] Vérifier les 100 derniers morceaux lus et 25 derniers coups de cœur
- [ ] Couper la DB Navidrome (renommer le fichier) → la bannière d'indisponibilité apparaît

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_