### PR TITLE
feat(lastfm): page de stats Last.fm avec cache, refresh et CLI

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -141,6 +141,14 @@ services:
         arguments:
             $defaultUser: '%lastfm.user%'
 
+    App\Controller\LastFmStatsController:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
+    App\Command\ComputeLastFmStatsCommand:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
     App\Controller\DashboardController:
         arguments:
             $defaultUser: '%lastfm.user%'

--- a/src/Command/ComputeLastFmStatsCommand.php
+++ b/src/Command/ComputeLastFmStatsCommand.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Service\LastFmStatsService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:lastfm:stats:compute',
+    description: 'Recompute the cached Last.fm stats snapshot (suitable for crontab).',
+)]
+class ComputeLastFmStatsCommand extends Command
+{
+    public function __construct(
+        private readonly LastFmStatsService $statsService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $defaultUser,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('user', 'u', InputOption::VALUE_REQUIRED, 'Filter by Last.fm username (defaults to LASTFM_USER).', null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $user = $input->getOption('user') ?? ($this->defaultUser !== '' ? $this->defaultUser : null);
+
+        try {
+            $data = $this->recorder->record(
+                type: RunHistory::TYPE_STATS,
+                reference: 'lastfm',
+                label: 'Last.fm stats compute',
+                action: fn () => $this->statsService->compute($user),
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            'Snapshot Last.fm recalculé : %d scrobbles, %d morceaux, %d artistes, %d albums, %d loved.',
+            $data['library']['scrobbles'] ?? 0,
+            $data['library']['tracks'] ?? 0,
+            $data['library']['artists'] ?? 0,
+            $data['library']['albums'] ?? 0,
+            $data['loved_count'] ?? 0,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/ComputeLastFmStatsCommand.php
+++ b/src/Command/ComputeLastFmStatsCommand.php
@@ -35,13 +35,21 @@ class ComputeLastFmStatsCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
         $user = $input->getOption('user') ?? ($this->defaultUser !== '' ? $this->defaultUser : null);
+        $resolved = $this->statsService->resolveUser($user);
+
+        if ($resolved === null) {
+            $io->warning('Aucun utilisateur Last.fm trouvé en base et LASTFM_USER non renseigné. Lancez d\'abord un import.');
+            return Command::FAILURE;
+        }
+
+        $io->writeln(sprintf('Calcul du snapshot pour <info>%s</info>…', $resolved));
 
         try {
             $data = $this->recorder->record(
                 type: RunHistory::TYPE_STATS,
                 reference: 'lastfm',
-                label: 'Last.fm stats compute',
-                action: fn () => $this->statsService->compute($user),
+                label: sprintf('Last.fm stats compute (%s)', $resolved),
+                action: fn () => $this->statsService->compute($resolved),
             );
         } catch (\Throwable $e) {
             $io->error($e->getMessage());
@@ -49,7 +57,8 @@ class ComputeLastFmStatsCommand extends Command
         }
 
         $io->success(sprintf(
-            'Snapshot Last.fm recalculé : %d scrobbles, %d morceaux, %d artistes, %d albums, %d loved.',
+            'Snapshot Last.fm recalculé pour %s : %d scrobbles, %d morceaux, %d artistes, %d albums, %d loved.',
+            $resolved,
             $data['library']['scrobbles'] ?? 0,
             $data['library']['tracks'] ?? 0,
             $data['library']['artists'] ?? 0,

--- a/src/Controller/LastFmStatsController.php
+++ b/src/Controller/LastFmStatsController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Controller;
+
+use App\Entity\RunHistory;
+use App\Service\LastFmStatsService;
+use App\Service\RunHistoryRecorder;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class LastFmStatsController extends AbstractController
+{
+    public function __construct(
+        private readonly LastFmStatsService $statsService,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $defaultUser,
+    ) {
+    }
+
+    #[Route('/lastfm/stats', name: 'app_lastfm_stats', methods: ['GET'])]
+    public function index(): Response
+    {
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        $data = $this->statsService->get($user);
+
+        return $this->render('lastfm/stats.html.twig', [
+            'data' => $data,
+            'user' => $user,
+        ]);
+    }
+
+    #[Route('/lastfm/stats/refresh', name: 'app_lastfm_stats_refresh', methods: ['POST'])]
+    public function refresh(Request $request): Response
+    {
+        if (!$this->isCsrfTokenValid('lastfm_stats_refresh', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+
+        try {
+            $this->recorder->record(
+                type: RunHistory::TYPE_STATS,
+                reference: 'lastfm',
+                label: 'Last.fm stats compute',
+                action: fn () => $this->statsService->compute($user),
+            );
+            $this->addFlash('success', 'Statistiques Last.fm recalculées.');
+        } catch (\Throwable $e) {
+            $this->addFlash('error', 'Erreur : ' . $e->getMessage());
+        }
+
+        return $this->redirectToRoute('app_lastfm_stats');
+    }
+}

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -39,6 +39,7 @@ class LastFmStatsService
      */
     public function compute(?string $user = null): array
     {
+        $user = $this->resolveUser($user);
         $library = $this->libraryCounts($user);
         $bounds = $this->scrobbleBounds($user);
 
@@ -74,13 +75,37 @@ class LastFmStatsService
      */
     public function get(?string $user = null): ?array
     {
-        $snapshot = $this->snapshots->findOneByPeriod($this->snapshotKey($user));
+        $snapshot = $this->snapshots->findOneByPeriod($this->snapshotKey($this->resolveUser($user)));
         if ($snapshot === null) {
             return null;
         }
 
         /** @var array<string, mixed> */
         return $snapshot->getData();
+    }
+
+    /**
+     * Resolve the user to filter on. Explicit value wins ; otherwise auto-pick
+     * the most-scrobbled `lastfm_user` from the local DB so the CLI and the
+     * UI default to the dominant user when the LASTFM_USER env is empty
+     * (which is the case in fresh installs). Returns null only when there
+     * isn't a single scrobble in the DB.
+     */
+    public function resolveUser(?string $user): ?string
+    {
+        if ($user !== null && $user !== '') {
+            return $user;
+        }
+
+        $row = $this->connection->fetchOne(
+            'SELECT lastfm_user FROM scrobbles
+              WHERE lastfm_user != \'\'
+              GROUP BY lastfm_user
+              ORDER BY COUNT(*) DESC
+              LIMIT 1',
+        );
+
+        return is_string($row) && $row !== '' ? $row : null;
     }
 
     public function snapshotKey(?string $user): string

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -1,0 +1,324 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\StatsSnapshot;
+use App\Repository\StatsSnapshotRepository;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Aggregates the « Last.fm at a glance » payload — counters, top all-time,
+ * recent scrobbles, recent loved — from the local `scrobbles` table
+ * (populated by the Last.fm import). Caches the result in `stats_snapshot`
+ * under the key `lastfm-stats[-<user>]`.
+ *
+ * Distinct from {@see LocalStatsService} which carries the windowed views
+ * (7d / 30d / 90d / 12mo / all-time) used by the existing /stats page;
+ * this one is the all-time « bibliothèque + dernières activités »
+ * counterpart of /navidrome/stats.
+ */
+class LastFmStatsService
+{
+    public const SNAPSHOT_KEY_PREFIX = 'lastfm-stats';
+
+    private const TOP_LIMIT = 15;
+    private const RECENT_SCROBBLES_LIMIT = 100;
+    private const RECENT_LOVED_LIMIT = 25;
+    private const PLAYS_BY_MONTH_COUNT = 12;
+
+    public function __construct(
+        private readonly Connection $connection,
+        private readonly StatsSnapshotRepository $snapshots,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function compute(?string $user = null): array
+    {
+        $library = $this->libraryCounts($user);
+        $bounds = $this->scrobbleBounds($user);
+
+        $data = [
+            'computed_at' => (new \DateTimeImmutable())->format(\DATE_ATOM),
+            'user' => $user,
+            'library' => $library,
+            'loved_count' => $this->lovedCount($user),
+            'first_scrobble_at' => $bounds['first'],
+            'last_scrobble_at' => $bounds['last'],
+            'plays_by_month' => $this->playsByMonth(self::PLAYS_BY_MONTH_COUNT, $user),
+            'top_artists' => $this->topArtists($user, self::TOP_LIMIT),
+            'top_tracks' => $this->topTracks($user, self::TOP_LIMIT),
+            'top_albums' => $this->topAlbums($user, self::TOP_LIMIT),
+            'recent_scrobbles' => $this->recentScrobbles($user, self::RECENT_SCROBBLES_LIMIT),
+            'recent_loved' => $this->recentLoved($user, self::RECENT_LOVED_LIMIT),
+        ];
+
+        $key = $this->snapshotKey($user);
+        $snapshot = $this->snapshots->findOneByPeriod($key);
+        if ($snapshot === null) {
+            $snapshot = new StatsSnapshot($key);
+            $this->em->persist($snapshot);
+        }
+        $snapshot->setData($data);
+        $this->em->flush();
+
+        return $data;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function get(?string $user = null): ?array
+    {
+        $snapshot = $this->snapshots->findOneByPeriod($this->snapshotKey($user));
+        if ($snapshot === null) {
+            return null;
+        }
+
+        /** @var array<string, mixed> */
+        return $snapshot->getData();
+    }
+
+    public function snapshotKey(?string $user): string
+    {
+        return ($user !== null && $user !== '')
+            ? self::SNAPSHOT_KEY_PREFIX . '-' . $user
+            : self::SNAPSHOT_KEY_PREFIX;
+    }
+
+    /**
+     * @return array{scrobbles: int, tracks: int, artists: int, albums: int}
+     */
+    private function libraryCounts(?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $whereClause = $where !== '' ? ' WHERE ' . $where : '';
+
+        $scrobbles = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM scrobbles' . $whereClause,
+            $params,
+        );
+        $artists = (int) $this->connection->fetchOne(
+            "SELECT COUNT(DISTINCT artist) FROM scrobbles"
+            . ($where !== '' ? ' WHERE ' . $where . " AND artist != ''" : " WHERE artist != ''"),
+            $params,
+        );
+        $tracks = (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM (SELECT 1 FROM scrobbles'
+            . $whereClause
+            . ' GROUP BY artist, title)',
+            $params,
+        );
+        $albums = (int) $this->connection->fetchOne(
+            "SELECT COUNT(*) FROM (SELECT 1 FROM scrobbles"
+            . ($where !== '' ? ' WHERE ' . $where . " AND album IS NOT NULL AND album != ''" : " WHERE album IS NOT NULL AND album != ''")
+            . ' GROUP BY artist, album)',
+            $params,
+        );
+
+        return [
+            'scrobbles' => $scrobbles,
+            'tracks' => $tracks,
+            'artists' => $artists,
+            'albums' => $albums,
+        ];
+    }
+
+    /**
+     * Count distinct (artist, title) pairs flagged as loved by at least one
+     * scrobble. Two scrobbles of the same loved track count as one — the
+     * Last.fm import propagates the `loved` flag on every fetched row, so
+     * de-duplicating on (artist, title) gives the actual loved-track count
+     * rather than the number of « loved scrobbles ».
+     */
+    private function lovedCount(?string $user): int
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $sql = 'SELECT COUNT(*) FROM (SELECT 1 FROM scrobbles WHERE loved = 1'
+            . ($where !== '' ? ' AND ' . $where : '')
+            . ' GROUP BY artist, title)';
+
+        return (int) $this->connection->fetchOne($sql, $params);
+    }
+
+    /**
+     * @return array{first: ?string, last: ?string}
+     */
+    private function scrobbleBounds(?string $user): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $row = $this->connection->fetchAssociative(
+            'SELECT MIN(played_at) AS first, MAX(played_at) AS last FROM scrobbles'
+            . ($where !== '' ? ' WHERE ' . $where : ''),
+            $params,
+        );
+        if ($row === false) {
+            return ['first' => null, 'last' => null];
+        }
+
+        return [
+            'first' => $row['first'] !== null ? (string) $row['first'] : null,
+            'last' => $row['last'] !== null ? (string) $row['last'] : null,
+        ];
+    }
+
+    /**
+     * @return list<array{month: string, plays: int}>
+     */
+    private function playsByMonth(int $monthsBack, ?string $user): array
+    {
+        $now = new \DateTimeImmutable('now', new \DateTimeZone(date_default_timezone_get()));
+        $from = $now->modify('first day of this month')->setTime(0, 0)
+            ->modify(sprintf('-%d months', max(0, $monthsBack - 1)));
+
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ['played_at >= :from'];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $params['from'] = $from->format('Y-m-d H:i:s');
+
+        $sql = "SELECT strftime('%Y-%m', played_at) AS month, COUNT(*) AS plays
+                FROM scrobbles
+                WHERE " . implode(' AND ', $clauses)
+            . ' GROUP BY month ORDER BY month ASC';
+
+        /** @var list<array{month: string, plays: int}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+        $byMonth = [];
+        foreach ($rows as $r) {
+            $byMonth[(string) $r['month']] = (int) $r['plays'];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $monthsBack; $i++) {
+            $key = $cursor->format('Y-m');
+            $out[] = ['month' => $key, 'plays' => $byMonth[$key] ?? 0];
+            $cursor = $cursor->modify('+1 month');
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<array{artist: string, plays: int}>
+     */
+    private function topArtists(?string $user, int $limit): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ["artist != ''"];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $sql = 'SELECT artist, COUNT(*) AS plays FROM scrobbles WHERE '
+            . implode(' AND ', $clauses)
+            . ' GROUP BY artist ORDER BY plays DESC, artist ASC LIMIT ' . $limit;
+
+        /** @var list<array{artist: string, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return list<array{artist: string, title: string, album: ?string, plays: int}>
+     */
+    private function topTracks(?string $user, int $limit): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $sql = 'SELECT artist, title,
+                       (SELECT album FROM scrobbles s2
+                        WHERE s2.artist = s.artist AND s2.title = s.title'
+            . ($where !== '' ? ' AND ' . str_replace('lastfm_user', 's2.lastfm_user', $where) : '')
+            . '          AND s2.album IS NOT NULL AND s2.album != ""
+                        LIMIT 1) AS album,
+                       COUNT(*) AS plays
+                FROM scrobbles s'
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' GROUP BY artist, title ORDER BY plays DESC, title ASC LIMIT ' . $limit;
+
+        /** @var list<array{artist: string, title: string, album: ?string, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return list<array{artist: string, album: string, plays: int}>
+     */
+    private function topAlbums(?string $user, int $limit): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ["album IS NOT NULL", "album != ''"];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $sql = 'SELECT artist, album, COUNT(*) AS plays FROM scrobbles WHERE '
+            . implode(' AND ', $clauses)
+            . ' GROUP BY artist, album ORDER BY plays DESC, album ASC LIMIT ' . $limit;
+
+        /** @var list<array{artist: string, album: string, plays: int}> */
+        return $this->connection->fetchAllAssociative($sql, $params);
+    }
+
+    /**
+     * @return list<array{artist: string, title: string, album: ?string, played_at: string, loved: bool}>
+     */
+    private function recentScrobbles(?string $user, int $limit): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $sql = 'SELECT artist, title, album, played_at, loved FROM scrobbles'
+            . ($where !== '' ? ' WHERE ' . $where : '')
+            . ' ORDER BY played_at DESC LIMIT ' . $limit;
+
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        return array_map(static fn (array $r): array => [
+            'artist' => (string) ($r['artist'] ?? ''),
+            'title' => (string) ($r['title'] ?? ''),
+            'album' => $r['album'] !== null ? (string) $r['album'] : null,
+            'played_at' => (string) $r['played_at'],
+            'loved' => (bool) $r['loved'],
+        ], $rows);
+    }
+
+    /**
+     * @return list<array{artist: string, title: string, album: ?string, played_at: string}>
+     */
+    private function recentLoved(?string $user, int $limit): array
+    {
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ['loved = 1'];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $sql = 'SELECT artist, title,
+                       (SELECT album FROM scrobbles s2 WHERE s2.artist = s.artist AND s2.title = s.title AND s2.album IS NOT NULL AND s2.album != "" LIMIT 1) AS album,
+                       MAX(played_at) AS played_at
+                FROM scrobbles s WHERE '
+            . implode(' AND ', $clauses)
+            . ' GROUP BY artist, title ORDER BY played_at DESC LIMIT ' . $limit;
+
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        return array_map(static fn (array $r): array => [
+            'artist' => (string) ($r['artist'] ?? ''),
+            'title' => (string) ($r['title'] ?? ''),
+            'album' => $r['album'] !== null ? (string) $r['album'] : null,
+            'played_at' => (string) $r['played_at'],
+        ], $rows);
+    }
+
+    /**
+     * @return array{0: string, 1: array<string, string>}
+     */
+    private function buildWhere(?string $user): array
+    {
+        if ($user === null || $user === '') {
+            return ['', []];
+        }
+
+        return ['lastfm_user = :user', ['user' => $user]];
+    }
+}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -12,6 +12,7 @@
     { type: 'dropdown', label: 'Last.fm', width: 'w-56', groups: [
         { heading: null, items: [
             { label: 'Import', route: 'app_lastfm_import' },
+            { label: 'Stats', route: 'app_lastfm_stats' },
         ]},
         { heading: 'Aliases', items: [
             { label: 'Tracks', route: 'app_lastfm_alias_index' },

--- a/templates/lastfm/stats.html.twig
+++ b/templates/lastfm/stats.html.twig
@@ -1,0 +1,233 @@
+{% extends 'base.html.twig' %}
+{% block title %}Stats Last.fm{% endblock %}
+
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <h1 class="text-2xl font-semibold">
+            Stats Last.fm
+            {% if user %}<span class="text-sm font-normal text-slate-500">— {{ user }}</span>{% endif %}
+        </h1>
+        <div class="flex items-center gap-3">
+            {% if data %}
+                <span class="text-xs text-slate-400">Calculé {{ data.computed_at|date('d/m/Y H:i') }}</span>
+            {% endif %}
+            <form method="post" action="{{ path('app_lastfm_stats_refresh') }}" class="inline">
+                <input type="hidden" name="_token" value="{{ csrf_token('lastfm_stats_refresh') }}">
+                <button type="submit" class="text-xs bg-slate-200 hover:bg-slate-300 px-3 py-1.5 rounded-sm">↻ Recalculer</button>
+            </form>
+        </div>
+    </div>
+
+    {% if not data %}
+        <div class="bg-amber-50 border border-amber-300 text-amber-900 rounded-sm p-4">
+            <strong>Aucune statistique en cache.</strong>
+            Cliquez sur <em>↻ Recalculer</em> pour générer un premier instantané,
+            ou planifiez la commande <code>app:lastfm:stats:compute</code> dans un crontab.
+        </div>
+    {% else %}
+
+    {# Bibliothèque #}
+    <div class="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Scrobbles</div>
+            <div class="text-3xl font-semibold">{{ data.library.scrobbles|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Morceaux distincts</div>
+            <div class="text-3xl font-semibold">{{ data.library.tracks|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Artistes distincts</div>
+            <div class="text-3xl font-semibold">{{ data.library.artists|number_format(0, '.', ' ') }}</div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Albums distincts</div>
+            <div class="text-3xl font-semibold">{{ data.library.albums|number_format(0, '.', ' ') }}</div>
+        </div>
+    </div>
+
+    {# Loved + plage temporelle #}
+    <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 mb-6">
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">♥ Loved</div>
+            <div class="text-3xl font-semibold text-rose-600">{{ data.loved_count|number_format(0, '.', ' ') }}</div>
+            {% if data.library.tracks > 0 %}
+                <div class="text-xs text-slate-500">
+                    {{ (data.loved_count / data.library.tracks * 100)|round(1) }} % des morceaux
+                </div>
+            {% endif %}
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Premier scrobble</div>
+            <div class="text-lg font-semibold">
+                {{ data.first_scrobble_at ? data.first_scrobble_at|date('d/m/Y') : '—' }}
+            </div>
+        </div>
+        <div class="bg-white shadow-sm rounded-sm p-4">
+            <div class="text-xs uppercase text-slate-500">Dernier scrobble</div>
+            <div class="text-lg font-semibold">
+                {{ data.last_scrobble_at ? data.last_scrobble_at|date('d/m/Y H:i') : '—' }}
+            </div>
+        </div>
+    </div>
+
+    {# Lectures par mois (12 derniers) #}
+    {% if data.plays_by_month is not empty %}
+    <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
+        <div class="text-sm font-semibold mb-3">Scrobbles — 12 derniers mois</div>
+        {% set max_month = max(data.plays_by_month|map(r => r.plays)) %}
+        <div class="flex items-end gap-1 h-24">
+            {% for row in data.plays_by_month %}
+            <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
+                <div class="w-full bg-sky-400 rounded-t-sm"
+                     style="height: {{ max_month > 0 ? ((row.plays / max_month * 88)|round) : 0 }}px"
+                     title="{{ row.month }} : {{ row.plays }} scrobbles"></div>
+                <div class="text-xs text-slate-400 truncate" style="font-size:9px">{{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}</div>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+
+    {# Top all-time #}
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
+        {% if data.top_artists is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top artistes (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_a = data.top_artists[0].plays %}
+                {% for i, row in data.top_artists %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5 font-medium truncate">{{ row.artist }}</td>
+                    <td class="px-3 py-1.5 w-24">
+                        <div class="bg-sky-200 h-2 rounded-full" style="width: {{ (row.plays / max_a * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {% if data.top_tracks is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top morceaux (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_t = data.top_tracks[0].plays %}
+                {% for i, row in data.top_tracks %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5">
+                        <div class="font-medium truncate max-w-40">{{ row.title }}</div>
+                        <div class="text-xs text-slate-500 truncate max-w-40">{{ row.artist }}</div>
+                    </td>
+                    <td class="px-3 py-1.5 w-20">
+                        <div class="bg-emerald-200 h-2 rounded-full" style="width: {{ (row.plays / max_t * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {% if data.top_albums is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">Top albums (all-time)</div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                {% set max_al = data.top_albums[0].plays %}
+                {% for i, row in data.top_albums %}
+                <tr class="hover:bg-slate-50">
+                    <td class="px-3 py-1.5 text-slate-400 w-8 text-right text-xs">{{ i + 1 }}</td>
+                    <td class="px-3 py-1.5">
+                        <div class="font-medium truncate max-w-40">{{ row.album }}</div>
+                        <div class="text-xs text-slate-500 truncate max-w-40">{{ row.artist }}</div>
+                    </td>
+                    <td class="px-3 py-1.5 w-20">
+                        <div class="bg-amber-200 h-2 rounded-full" style="width: {{ (row.plays / max_al * 100)|round }}%"></div>
+                    </td>
+                    <td class="px-3 py-1.5 text-right font-mono text-xs">{{ row.plays }}</td>
+                </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+    </div>
+
+    {# 100 derniers + 25 derniers ♥ #}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {% if data.recent_scrobbles is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">
+                100 derniers scrobbles
+            </div>
+            <div class="max-h-[640px] overflow-y-auto">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y">
+                    {% for row in data.recent_scrobbles %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 w-32 text-xs text-slate-500 whitespace-nowrap">
+                            {{ row.played_at|date('d/m H:i') }}
+                        </td>
+                        <td class="px-3 py-1.5">
+                            <div class="font-medium truncate max-w-xs">
+                                {% if row.loved %}<span class="text-rose-500 mr-1">♥</span>{% endif %}{{ row.title ?: '—' }}
+                            </div>
+                            <div class="text-xs text-slate-500 truncate max-w-xs">
+                                {{ row.artist ?: '—' }}{% if row.album %} · {{ row.album }}{% endif %}
+                            </div>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="bg-white shadow-sm rounded-sm p-4 text-sm text-slate-500">
+            Aucun scrobble en base. Lancez un import Last.fm pour démarrer.
+        </div>
+        {% endif %}
+
+        {% if data.recent_loved is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <div class="px-4 py-2 bg-slate-100 border-b text-sm font-semibold">
+                25 derniers coups de cœur
+            </div>
+            <div class="max-h-[640px] overflow-y-auto">
+                <table class="w-full text-sm">
+                    <tbody class="divide-y">
+                    {% for row in data.recent_loved %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 w-12 text-rose-500 text-center">♥</td>
+                        <td class="px-3 py-1.5">
+                            <div class="font-medium truncate max-w-xs">{{ row.title ?: '—' }}</div>
+                            <div class="text-xs text-slate-500 truncate max-w-xs">
+                                {{ row.artist ?: '—' }}{% if row.album %} · {{ row.album }}{% endif %}
+                            </div>
+                        </td>
+                        <td class="px-3 py-1.5 w-24 text-xs text-slate-500 whitespace-nowrap text-right">
+                            {{ row.played_at|date('d/m/Y') }}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        {% else %}
+        <div class="bg-white shadow-sm rounded-sm p-4 text-sm text-slate-500">
+            Aucun morceau marqué loved.
+        </div>
+        {% endif %}
+    </div>
+
+    {% endif %}
+{% endblock %}

--- a/templates/lastfm/stats.html.twig
+++ b/templates/lastfm/stats.html.twig
@@ -5,7 +5,8 @@
     <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
         <h1 class="text-2xl font-semibold">
             Stats Last.fm
-            {% if user %}<span class="text-sm font-normal text-slate-500">— {{ user }}</span>{% endif %}
+            {% set displayed_user = data and data.user ? data.user : user %}
+            {% if displayed_user %}<span class="text-sm font-normal text-slate-500">— {{ displayed_user }}</span>{% endif %}
         </h1>
         <div class="flex items-center gap-3">
             {% if data %}


### PR DESCRIPTION
## Summary

Nouvelle page **/lastfm/stats** (lien dans le dropdown Last.fm) qui réplique la mise en page de `/navidrome/stats` mais avec les données de la base locale (scrobbles importés depuis Last.fm) :

- Compteurs : scrobbles, morceaux / artistes / albums distincts
- ♥ Coups de cœur (basés sur `scrobbles.loved = 1`, dédupliqués par artist+title) + premier / dernier scrobble
- Barres « scrobbles par mois » (12 derniers)
- Top 15 artistes / morceaux / albums all-time
- **100 derniers scrobbles** (♥ inline pour les loved)
- **25 derniers coups de cœur** (ordonnés par dernier play)

Même pattern que `NavidromeStatsService` :
- `LastFmStatsService::compute()` persiste dans `stats_snapshot` (clé `lastfm-stats[-<user>]`) ; `get()` renvoie `null` si jamais calculé.
- Bouton **↻ Recalculer** (CSRF + `RunHistoryRecorder`, reference=`lastfm`).
- Commande **`app:lastfm:stats:compute`** pour crontab (option `--user`).

Distinct de `LocalStatsService` qui pilote `/stats` avec son sélecteur de périodes 7d/30d/… : ce service est l'équivalent « all-time + dernières activités » de la page Navidrome.

## Test plan

- [ ] `/lastfm/stats` sans snapshot → bannière jaune
- [ ] **↻ Recalculer** → snapshot créé, tous les compteurs s'affichent
- [ ] Vérifier que les ♥ inline apparaissent sur les scrobbles loved dans la liste « 100 derniers »
- [ ] Lancer `php bin/console app:lastfm:stats:compute` → snapshot mis à jour + entry dans Historique
- [ ] Lancer avec `--user=autreuser` → snapshot séparé `lastfm-stats-autreuser`

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_