### PR TITLE
feat(lastfm): sync rétro des loved tracks vers scrobbles.loved

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -144,6 +144,12 @@ services:
     App\Controller\LastFmStatsController:
         arguments:
             $defaultUser: '%lastfm.user%'
+            $defaultApiKey: '%lastfm.api_key%'
+
+    App\Command\SyncLastFmLovedCommand:
+        arguments:
+            $defaultApiKey: '%lastfm.api_key%'
+            $defaultUser: '%lastfm.user%'
 
     App\Command\ComputeLastFmStatsCommand:
         arguments:

--- a/src/Command/SyncLastFmLovedCommand.php
+++ b/src/Command/SyncLastFmLovedCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\LastFm\LastFmFetcher;
+use App\LastFm\LovedSyncReport;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Sync the Last.fm loved-tracks list onto the local scrobbles table —
+ * flips `loved=1` retroactively on every scrobble matching a loved
+ * (artist, title) or MBID. Run after each `app:lastfm:fetch` (or in
+ * a crontab) to keep /lastfm/stats heart counts honest.
+ */
+#[AsCommand(
+    name: 'app:lastfm:loved:sync',
+    description: 'Retro-flag scrobbles whose track is in the Last.fm loved list.',
+)]
+class SyncLastFmLovedCommand extends Command
+{
+    public function __construct(
+        private readonly LastFmFetcher $fetcher,
+        private readonly RunHistoryRecorder $recorder,
+        private readonly string $defaultApiKey,
+        private readonly string $defaultUser,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('user', InputArgument::OPTIONAL, 'Last.fm username (defaults to LASTFM_USER env).')
+            ->addOption('api-key', null, InputOption::VALUE_REQUIRED, 'Last.fm API key (defaults to LASTFM_API_KEY env).')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Don\'t update the DB, just report what would change.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $user = (string) ($input->getArgument('user') ?: $this->defaultUser);
+        $apiKey = (string) ($input->getOption('api-key') ?: $this->defaultApiKey);
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if ($user === '') {
+            $io->error('No Last.fm user specified. Pass as argument or set LASTFM_USER env.');
+            return Command::FAILURE;
+        }
+        if ($apiKey === '') {
+            $io->error('No Last.fm API key. Pass --api-key or set LASTFM_API_KEY env.');
+            return Command::FAILURE;
+        }
+
+        $io->writeln(sprintf('Sync des loved tracks pour <info>%s</info>%s…', $user, $dryRun ? ' [dry-run]' : ''));
+
+        try {
+            $report = $this->recorder->record(
+                type: RunHistory::TYPE_LASTFM_LOVED_SYNC,
+                reference: $user,
+                label: sprintf('Last.fm loved sync %s%s', $user, $dryRun ? ' [dry-run]' : ''),
+                action: fn () => $this->fetcher->syncLoved($apiKey, $user, $dryRun),
+                extractMetrics: static fn (LovedSyncReport $r) => [
+                    'fetched' => $r->fetched,
+                    'matched' => $r->matched,
+                    'unmatched' => $r->unmatched,
+                    'updated_rows' => $r->updatedRows,
+                    'dry_run' => $dryRun,
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf(
+            '%d loved tracks fetched ; %d matched, %d unmatched, %d scrobble row(s) flipped.',
+            $report->fetched,
+            $report->matched,
+            $report->unmatched,
+            $report->updatedRows,
+        ));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/LastFmStatsController.php
+++ b/src/Controller/LastFmStatsController.php
@@ -3,11 +3,13 @@
 namespace App\Controller;
 
 use App\Entity\RunHistory;
+use App\Message\SyncLastFmLovedMessage;
 use App\Service\LastFmStatsService;
 use App\Service\RunHistoryRecorder;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 class LastFmStatsController extends AbstractController
@@ -16,6 +18,7 @@ class LastFmStatsController extends AbstractController
         private readonly LastFmStatsService $statsService,
         private readonly RunHistoryRecorder $recorder,
         private readonly string $defaultUser,
+        private readonly string $defaultApiKey,
     ) {
     }
 
@@ -28,6 +31,7 @@ class LastFmStatsController extends AbstractController
         return $this->render('lastfm/stats.html.twig', [
             'data' => $data,
             'user' => $user,
+            'can_sync_loved' => $this->defaultApiKey !== '',
         ]);
     }
 
@@ -51,6 +55,30 @@ class LastFmStatsController extends AbstractController
         } catch (\Throwable $e) {
             $this->addFlash('error', 'Erreur : ' . $e->getMessage());
         }
+
+        return $this->redirectToRoute('app_lastfm_stats');
+    }
+
+    #[Route('/lastfm/stats/sync-loved', name: 'app_lastfm_stats_sync_loved', methods: ['POST'])]
+    public function syncLoved(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('lastfm_stats_sync_loved', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        if ($user === null || $this->defaultApiKey === '') {
+            $this->addFlash('error', 'LASTFM_USER ou LASTFM_API_KEY non configuré.');
+            return $this->redirectToRoute('app_lastfm_stats');
+        }
+
+        $bus->dispatch(new SyncLastFmLovedMessage(
+            user: $user,
+            apiKey: $this->defaultApiKey,
+            dryRun: false,
+        ));
+
+        $this->addFlash('success', 'Sync des loved tracks Last.fm lancé en arrière-plan. Pensez à recalculer le snapshot ensuite.');
 
         return $this->redirectToRoute('app_lastfm_stats');
     }

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -14,6 +14,7 @@ use Doctrine\ORM\Mapping as ORM;
 class RunHistory
 {
     public const TYPE_LASTFM_FETCH = 'lastfm-fetch';
+    public const TYPE_LASTFM_LOVED_SYNC = 'lastfm-loved-sync';
     public const TYPE_NAVIDROME_SYNC = 'navidrome-sync';
     public const TYPE_NAVIDROME_REMATCH = 'navidrome-rematch';
     public const TYPE_STRAWBERRY_SYNC = 'strawberry-sync';

--- a/src/LastFm/LastFmFetcher.php
+++ b/src/LastFm/LastFmFetcher.php
@@ -87,4 +87,51 @@ class LastFmFetcher
 
         return $report;
     }
+
+    /**
+     * Pull the full loved-tracks list from `user.getLovedTracks` and flip
+     * `scrobbles.loved=1` for every (artist, title) — or matching MBID —
+     * that has at least one scrobble in our DB.
+     *
+     * The Last.fm recent-tracks endpoint only reports `loved=1` if the user
+     * had already loved the track BEFORE the scrobble landed, so most
+     * historical scrobbles miss the flag even when the track is currently
+     * loved. This sync closes that gap retroactively.
+     */
+    public function syncLoved(string $apiKey, string $lastFmUser, bool $dryRun = false): LovedSyncReport
+    {
+        $report = new LovedSyncReport();
+
+        foreach ($this->client->iterateLovedTracks($apiKey, $lastFmUser) as $loved) {
+            $report->fetched++;
+
+            if ($dryRun) {
+                if ($this->scrobbles->hasScrobble($lastFmUser, $loved->artist, $loved->title, $loved->mbid)) {
+                    $report->matched++;
+                } else {
+                    $report->unmatched++;
+                }
+                continue;
+            }
+
+            $affected = $this->scrobbles->markLoved(
+                $lastFmUser,
+                $loved->artist,
+                $loved->title,
+                $loved->mbid,
+            );
+            $report->updatedRows += $affected;
+
+            if ($affected > 0) {
+                $report->matched++;
+            } elseif ($this->scrobbles->hasScrobble($lastFmUser, $loved->artist, $loved->title, $loved->mbid)) {
+                // Track is known but every scrobble was already flagged loved.
+                $report->matched++;
+            } else {
+                $report->unmatched++;
+            }
+        }
+
+        return $report;
+    }
 }

--- a/src/LastFm/LovedSyncReport.php
+++ b/src/LastFm/LovedSyncReport.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * Outcome of a `user.getLovedTracks` sync: number of loved tracks pulled
+ * from the API, how many had at least one matching scrobble in the local
+ * DB (the rest are loved-but-never-scrobbled), and the total number of
+ * `scrobbles.loved` rows newly flipped from 0 to 1.
+ */
+final class LovedSyncReport
+{
+    public int $fetched = 0;
+    public int $matched = 0;
+    public int $unmatched = 0;
+    public int $updatedRows = 0;
+}

--- a/src/Message/SyncLastFmLovedMessage.php
+++ b/src/Message/SyncLastFmLovedMessage.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Message;
+
+final class SyncLastFmLovedMessage
+{
+    public function __construct(
+        public readonly string $user,
+        public readonly string $apiKey,
+        public readonly bool $dryRun = false,
+    ) {
+    }
+}

--- a/src/MessageHandler/FetchLastFmMessageHandler.php
+++ b/src/MessageHandler/FetchLastFmMessageHandler.php
@@ -7,8 +7,10 @@ use App\LastFm\FetchReport;
 use App\LastFm\FetchWindowResolver;
 use App\LastFm\LastFmFetcher;
 use App\Message\FetchLastFmMessage;
+use App\Message\SyncLastFmLovedMessage;
 use App\Service\RunHistoryRecorder;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 #[AsMessageHandler]
 class FetchLastFmMessageHandler
@@ -17,6 +19,7 @@ class FetchLastFmMessageHandler
         private readonly LastFmFetcher $fetcher,
         private readonly RunHistoryRecorder $recorder,
         private readonly FetchWindowResolver $windowResolver,
+        private readonly MessageBusInterface $bus,
     ) {
     }
 
@@ -49,6 +52,17 @@ class FetchLastFmMessageHandler
 
         if ($smartDate && !$message->dryRun && $report->fetched > 0) {
             $this->windowResolver->markFetchedAt($message->user, $now);
+        }
+
+        // Chain a loved-sync so /lastfm/stats heart counts stay honest
+        // even when older scrobbles missed the live `loved` flag. Skip on
+        // dry-run (would still hit the API for nothing).
+        if (!$message->dryRun) {
+            $this->bus->dispatch(new SyncLastFmLovedMessage(
+                user: $message->user,
+                apiKey: $message->apiKey,
+                dryRun: false,
+            ));
         }
     }
 }

--- a/src/MessageHandler/SyncLastFmLovedMessageHandler.php
+++ b/src/MessageHandler/SyncLastFmLovedMessageHandler.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\LastFm\LastFmFetcher;
+use App\LastFm\LovedSyncReport;
+use App\Message\SyncLastFmLovedMessage;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+#[AsMessageHandler]
+class SyncLastFmLovedMessageHandler
+{
+    public function __construct(
+        private readonly LastFmFetcher $fetcher,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function __invoke(SyncLastFmLovedMessage $message): void
+    {
+        $this->recorder->record(
+            type: RunHistory::TYPE_LASTFM_LOVED_SYNC,
+            reference: $message->user,
+            label: sprintf('Last.fm loved sync %s%s', $message->user, $message->dryRun ? ' [dry-run]' : ''),
+            action: fn () => $this->fetcher->syncLoved($message->apiKey, $message->user, $message->dryRun),
+            extractMetrics: static fn (LovedSyncReport $r) => [
+                'fetched' => $r->fetched,
+                'matched' => $r->matched,
+                'unmatched' => $r->unmatched,
+                'updated_rows' => $r->updatedRows,
+                'dry_run' => $message->dryRun,
+            ],
+        );
+    }
+}

--- a/src/Repository/ScrobbleRepository.php
+++ b/src/Repository/ScrobbleRepository.php
@@ -98,4 +98,64 @@ class ScrobbleRepository extends ServiceEntityRepository
 
         return $affected === 1;
     }
+
+    /**
+     * Flip `loved=1` on every scrobble of (user, track). MBID match wins
+     * when present (Last.fm and Navidrome agree on MusicBrainz ids when
+     * tagged), case-insensitive (artist, title) otherwise. Returns the
+     * number of rows actually flipped — 0 when the track has no matching
+     * scrobble (loved-but-never-scrobbled), or when every matching row
+     * was already loved.
+     */
+    public function markLoved(string $user, string $artist, string $title, ?string $mbidTrack): int
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        if ($mbidTrack !== null && $mbidTrack !== '') {
+            $affected = (int) $conn->executeStatement(
+                'UPDATE scrobbles SET loved = 1
+                 WHERE lastfm_user = :u AND loved = 0 AND mbid_track = :mbid',
+                ['u' => $user, 'mbid' => $mbidTrack],
+            );
+            if ($affected > 0) {
+                return $affected;
+            }
+        }
+
+        return (int) $conn->executeStatement(
+            'UPDATE scrobbles SET loved = 1
+             WHERE lastfm_user = :u AND loved = 0
+               AND LOWER(artist) = LOWER(:a) AND LOWER(title) = LOWER(:t)',
+            ['u' => $user, 'a' => $artist, 't' => $title],
+        );
+    }
+
+    /**
+     * True if (user, artist, title) has at least one scrobble in the DB,
+     * regardless of its current loved state. Lets the loved-sync count
+     * « known by Navidrome-tools » as matched even when every existing
+     * scrobble was already flagged.
+     */
+    public function hasScrobble(string $user, string $artist, string $title, ?string $mbidTrack): bool
+    {
+        $conn = $this->getEntityManager()->getConnection();
+
+        if ($mbidTrack !== null && $mbidTrack !== '') {
+            $found = $conn->fetchOne(
+                'SELECT 1 FROM scrobbles WHERE lastfm_user = :u AND mbid_track = :mbid LIMIT 1',
+                ['u' => $user, 'mbid' => $mbidTrack],
+            );
+            if ($found !== false) {
+                return true;
+            }
+        }
+
+        $found = $conn->fetchOne(
+            'SELECT 1 FROM scrobbles WHERE lastfm_user = :u
+              AND LOWER(artist) = LOWER(:a) AND LOWER(title) = LOWER(:t) LIMIT 1',
+            ['u' => $user, 'a' => $artist, 't' => $title],
+        );
+
+        return $found !== false;
+    }
 }

--- a/templates/lastfm/stats.html.twig
+++ b/templates/lastfm/stats.html.twig
@@ -8,9 +8,18 @@
             {% set displayed_user = data and data.user ? data.user : user %}
             {% if displayed_user %}<span class="text-sm font-normal text-slate-500">— {{ displayed_user }}</span>{% endif %}
         </h1>
-        <div class="flex items-center gap-3">
+        <div class="flex items-center gap-3 flex-wrap">
             {% if data %}
                 <span class="text-xs text-slate-400">Calculé {{ data.computed_at|date('d/m/Y H:i') }}</span>
+            {% endif %}
+            {% if can_sync_loved %}
+            <form method="post" action="{{ path('app_lastfm_stats_sync_loved') }}" class="inline"
+                  onsubmit="return confirm('Récupérer la liste des loved tracks depuis Last.fm et marquer les scrobbles correspondants ?');">
+                <input type="hidden" name="_token" value="{{ csrf_token('lastfm_stats_sync_loved') }}">
+                <button type="submit" class="text-xs bg-rose-100 hover:bg-rose-200 text-rose-700 px-3 py-1.5 rounded-sm" title="Récupère la liste des coups de cœur depuis Last.fm et flag les scrobbles correspondants">
+                    ♥ Sync loved
+                </button>
+            </form>
             {% endif %}
             <form method="post" action="{{ path('app_lastfm_stats_refresh') }}" class="inline">
                 <input type="hidden" name="_token" value="{{ csrf_token('lastfm_stats_refresh') }}">

--- a/tests/MessageHandler/FetchLastFmMessageHandlerTest.php
+++ b/tests/MessageHandler/FetchLastFmMessageHandlerTest.php
@@ -11,6 +11,8 @@ use App\MessageHandler\FetchLastFmMessageHandler;
 use App\Repository\SettingRepository;
 use App\Service\RunHistoryRecorder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
 
 class FetchLastFmMessageHandlerTest extends TestCase
 {
@@ -46,6 +48,9 @@ class FetchLastFmMessageHandlerTest extends TestCase
             static fn (string $type, string $ref, string $label, callable $action) => $action(new RunHistory($type, $ref, $label)),
         );
 
-        return new FetchLastFmMessageHandler($fetcher, $recorder, new FetchWindowResolver($settings));
+        $bus = $this->createMock(MessageBusInterface::class);
+        $bus->method('dispatch')->willReturnCallback(static fn (object $msg): Envelope => new Envelope($msg));
+
+        return new FetchLastFmMessageHandler($fetcher, $recorder, new FetchWindowResolver($settings), $bus);
     }
 }


### PR DESCRIPTION
## Summary

La colonne `scrobbles.loved` n'est mise à jour qu'à l'instant T du fetch recent-tracks de Last.fm. Conséquence : tous les morceaux qu'on a aimés **après** les avoir scrobblés affichent `loved=0` → `/lastfm/stats` voit zéro coup de cœur.

**`LastFmFetcher::syncLoved()`** tire la liste complète de `user.getLovedTracks` (générateur déjà présent dans `LastFmClient`) et flippe `scrobbles.loved=1` pour chaque (artist, title) — MBID en priorité, fallback case-insensitive sur le couple — possédant au moins un scrobble local.

**Trois déclencheurs** :
- Commande **`app:lastfm:loved:sync`** (argument `user`, options `--api-key` et `--dry-run`) pour crontab.
- Bouton **♥ Sync loved** sur `/lastfm/stats` (dispatch async via Messenger, visible seulement si `LASTFM_API_KEY` est configurée).
- Chaîné automatiquement dans `FetchLastFmMessageHandler` : après chaque fetch (hors dry-run), un `SyncLastFmLovedMessage` est dispatché.

Nouveau `RunHistory::TYPE_LASTFM_LOVED_SYNC` pour le suivi indépendant dans `/history`.

Pas de migration : on reste sur `scrobbles.loved` comme convenu (les loved jamais scrobblés ne sont pas trackés, c'est le compromis assumé).

## Test plan

- [ ] Lancer `php bin/console app:lastfm:loved:sync` → flag les scrobbles, entry dans `/history`
- [ ] Recalculer `/lastfm/stats` → le compteur ♥ et les « 25 derniers coups de cœur » se remplissent
- [ ] Cliquer **♥ Sync loved** sur `/lastfm/stats` → flash de succès, RunHistory créé
- [ ] Lancer un fetch normal (CLI ou bouton import) → un sync loved est dispatché automatiquement à la suite
- [ ] `--dry-run` ne flippe aucune ligne (vérifier `updated_rows = 0` dans les metrics du run)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_