### PR TITLE
feat(stats): histogrammes scrobbles par semaine et par jour

### DIFF
--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -812,6 +812,92 @@ class NavidromeRepository
     }
 
     /**
+     * Plays per ISO week over the last $weeksBack weeks (current week
+     * included). Weeks without scrobbles are returned with plays=0. The
+     * `week` key is the Monday date (Y-m-d) of each bucket so the chart
+     * has a stable, sortable label.
+     *
+     * @return list<array{week: string, plays: int}>
+     */
+    public function getPlaysByWeek(int $weeksBack): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        // Monday of the current week, then walk back $weeksBack-1 weeks.
+        $monday = (new \DateTimeImmutable('monday this week'))->setTime(0, 0);
+        $from = $monday->modify(sprintf('-%d weeks', max(0, $weeksBack - 1)));
+
+        // SQLite: weekday 0=Sunday..6=Saturday. Shift to Monday-based week
+        // start by subtracting ((weekday+6) % 7) days from each play date.
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT date(s.submission_time, 'unixepoch',
+                         '-' || ((strftime('%w', s.submission_time, 'unixepoch') + 6) % 7) || ' days') AS week,
+                    COUNT(*) AS plays
+             FROM scrobbles s
+             WHERE s.user_id = :uid AND s.submission_time >= :from
+             GROUP BY week ORDER BY week ASC",
+            ['uid' => $userId, 'from' => $from->getTimestamp()],
+            ['from' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+        $byWeek = [];
+        foreach ($rows as $r) {
+            $byWeek[(string) $r['week']] = (int) $r['plays'];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $weeksBack; $i++) {
+            $key = $cursor->format('Y-m-d');
+            $out[] = ['week' => $key, 'plays' => $byWeek[$key] ?? 0];
+            $cursor = $cursor->modify('+1 week');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Plays per day over the last $daysBack days (today included). Days
+     * without scrobbles are returned with plays=0.
+     *
+     * @return list<array{day: string, plays: int}>
+     */
+    public function getPlaysByDay(int $daysBack): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $from = (new \DateTimeImmutable('today'))->modify(sprintf('-%d days', max(0, $daysBack - 1)));
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT date(s.submission_time, 'unixepoch') AS day, COUNT(*) AS plays
+             FROM scrobbles s
+             WHERE s.user_id = :uid AND s.submission_time >= :from
+             GROUP BY day ORDER BY day ASC",
+            ['uid' => $userId, 'from' => $from->getTimestamp()],
+            ['from' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+        $byDay = [];
+        foreach ($rows as $r) {
+            $byDay[(string) $r['day']] = (int) $r['plays'];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $daysBack; $i++) {
+            $key = $cursor->format('Y-m-d');
+            $out[] = ['day' => $key, 'plays' => $byDay[$key] ?? 0];
+            $cursor = $cursor->modify('+1 day');
+        }
+
+        return $out;
+    }
+
+    /**
      * Set of normalized artist names already present in `media_file`.
      * Returned as `[normalized => true]` for O(1) « do we already own X? »
      * lookups (used by the discover suggestions). Uses the same

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -26,6 +26,8 @@ class LastFmStatsService
     private const RECENT_SCROBBLES_LIMIT = 100;
     private const RECENT_LOVED_LIMIT = 25;
     private const PLAYS_BY_MONTH_COUNT = 12;
+    private const PLAYS_BY_WEEK_COUNT = 15;
+    private const PLAYS_BY_DAY_COUNT = 15;
 
     public function __construct(
         private readonly Connection $connection,
@@ -64,6 +66,8 @@ class LastFmStatsService
                 'period_months' => 12,
             ],
             'plays_by_month' => $this->playsByMonth(self::PLAYS_BY_MONTH_COUNT, $user),
+            'plays_by_week' => $this->playsByWeek(self::PLAYS_BY_WEEK_COUNT, $user),
+            'plays_by_day' => $this->playsByDay(self::PLAYS_BY_DAY_COUNT, $user),
             'top_artists' => $this->topArtists($user, self::TOP_LIMIT),
             'top_tracks' => $this->topTracks($user, self::TOP_LIMIT),
             'top_albums' => $this->topAlbums($user, self::TOP_LIMIT),
@@ -238,6 +242,88 @@ class LastFmStatsService
             $key = $cursor->format('Y-m');
             $out[] = ['month' => $key, 'plays' => $byMonth[$key] ?? 0];
             $cursor = $cursor->modify('+1 month');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Plays per Monday-started week over the last $weeksBack weeks. The
+     * `week` key is the Monday date (Y-m-d) of each bucket.
+     *
+     * @return list<array{week: string, plays: int}>
+     */
+    private function playsByWeek(int $weeksBack, ?string $user): array
+    {
+        $monday = (new \DateTimeImmutable('monday this week'))->setTime(0, 0);
+        $from = $monday->modify(sprintf('-%d weeks', max(0, $weeksBack - 1)));
+
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ['played_at >= :from'];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $params['from'] = $from->format('Y-m-d H:i:s');
+
+        // SQLite weekday: 0=Sunday..6=Saturday → shift back to Monday.
+        $sql = "SELECT date(played_at, '-' || ((strftime('%w', played_at) + 6) % 7) || ' days') AS week,
+                       COUNT(*) AS plays
+                FROM scrobbles
+                WHERE " . implode(' AND ', $clauses)
+            . ' GROUP BY week ORDER BY week ASC';
+
+        /** @var list<array{week: string, plays: int}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+        $byWeek = [];
+        foreach ($rows as $r) {
+            $byWeek[(string) $r['week']] = (int) $r['plays'];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $weeksBack; $i++) {
+            $key = $cursor->format('Y-m-d');
+            $out[] = ['week' => $key, 'plays' => $byWeek[$key] ?? 0];
+            $cursor = $cursor->modify('+1 week');
+        }
+
+        return $out;
+    }
+
+    /**
+     * Plays per day over the last $daysBack days (today included).
+     *
+     * @return list<array{day: string, plays: int}>
+     */
+    private function playsByDay(int $daysBack, ?string $user): array
+    {
+        $from = (new \DateTimeImmutable('today'))->modify(sprintf('-%d days', max(0, $daysBack - 1)));
+
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ['played_at >= :from'];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        $params['from'] = $from->format('Y-m-d H:i:s');
+
+        $sql = "SELECT date(played_at) AS day, COUNT(*) AS plays
+                FROM scrobbles
+                WHERE " . implode(' AND ', $clauses)
+            . ' GROUP BY day ORDER BY day ASC';
+
+        /** @var list<array{day: string, plays: int}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+        $byDay = [];
+        foreach ($rows as $r) {
+            $byDay[(string) $r['day']] = (int) $r['plays'];
+        }
+
+        $out = [];
+        $cursor = $from;
+        for ($i = 0; $i < $daysBack; $i++) {
+            $key = $cursor->format('Y-m-d');
+            $out[] = ['day' => $key, 'plays' => $byDay[$key] ?? 0];
+            $cursor = $cursor->modify('+1 day');
         }
 
         return $out;

--- a/src/Service/NavidromeStatsService.php
+++ b/src/Service/NavidromeStatsService.php
@@ -65,6 +65,8 @@ class NavidromeStatsService
             'top_tracks' => $this->navidrome->getTopTracksWithDetails(null, null, 15),
             'top_albums' => $this->navidrome->getTopAlbums(null, null, 15),
             'plays_by_month' => $this->navidrome->getPlaysByMonth(12),
+            'plays_by_week' => $this->navidrome->getPlaysByWeek(15),
+            'plays_by_day' => $this->navidrome->getPlaysByDay(15),
         ];
 
         $snapshot = $this->snapshots->findOneByPeriod(self::SNAPSHOT_KEY);

--- a/templates/lastfm/stats.html.twig
+++ b/templates/lastfm/stats.html.twig
@@ -104,23 +104,36 @@
     </div>
     {% endif %}
 
-    {# Lectures par mois (12 derniers) #}
-    {% if data.plays_by_month is not empty %}
+    {# Scrobbles par mois / semaine / jour #}
+    {% set charts = [
+        { title: 'Scrobbles — 12 derniers mois', rows: data.plays_by_month, key: 'month' },
+        { title: 'Scrobbles — 15 dernières semaines', rows: data.plays_by_week ?? [], key: 'week' },
+        { title: 'Scrobbles — 15 derniers jours', rows: data.plays_by_day ?? [], key: 'day' },
+    ] %}
+    {% for chart in charts %}
+    {% if chart.rows is not empty %}
     <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
-        <div class="text-sm font-semibold mb-3">Scrobbles — 12 derniers mois</div>
-        {% set max_month = max(data.plays_by_month|map(r => r.plays)) %}
+        <div class="text-sm font-semibold mb-3">{{ chart.title }}</div>
+        {% set max_v = max(chart.rows|map(r => r.plays)) %}
         <div class="flex items-end gap-1 h-24">
-            {% for row in data.plays_by_month %}
+            {% for row in chart.rows %}
             <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
                 <div class="w-full bg-sky-400 rounded-t-sm"
-                     style="height: {{ max_month > 0 ? ((row.plays / max_month * 88)|round) : 0 }}px"
-                     title="{{ row.month }} : {{ row.plays }} scrobbles"></div>
-                <div class="text-xs text-slate-400 truncate" style="font-size:9px">{{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}</div>
+                     style="height: {{ max_v > 0 ? ((row.plays / max_v * 88)|round) : 0 }}px"
+                     title="{{ attribute(row, chart.key) }} : {{ row.plays }} scrobbles"></div>
+                <div class="text-xs text-slate-400 truncate" style="font-size:9px">
+                    {%- if chart.key == 'month' -%}
+                        {{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}
+                    {%- else -%}
+                        {{ attribute(row, chart.key)|slice(8, 2) }}/{{ attribute(row, chart.key)|slice(5, 2) }}
+                    {%- endif -%}
+                </div>
             </div>
             {% endfor %}
         </div>
     </div>
     {% endif %}
+    {% endfor %}
 
     {# Top all-time #}
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">

--- a/templates/navidrome/stats.html.twig
+++ b/templates/navidrome/stats.html.twig
@@ -121,23 +121,37 @@
     </div>
     {% endif %}
 
-    {# Lectures par mois (12 derniers) #}
-    {% if data.plays_by_month is not empty %}
+    {# Lectures par mois / semaine / jour #}
+    {% set unit = 'lectures' %}
+    {% set charts = [
+        { title: 'Lectures — 12 derniers mois', rows: data.plays_by_month, key: 'month' },
+        { title: 'Lectures — 15 dernières semaines', rows: data.plays_by_week ?? [], key: 'week' },
+        { title: 'Lectures — 15 derniers jours', rows: data.plays_by_day ?? [], key: 'day' },
+    ] %}
+    {% for chart in charts %}
+    {% if chart.rows is not empty %}
     <div class="bg-white shadow-sm rounded-sm p-4 mb-6">
-        <div class="text-sm font-semibold mb-3">Lectures — 12 derniers mois</div>
-        {% set max_month = max(data.plays_by_month|map(r => r.plays)) %}
+        <div class="text-sm font-semibold mb-3">{{ chart.title }}</div>
+        {% set max_v = max(chart.rows|map(r => r.plays)) %}
         <div class="flex items-end gap-1 h-24">
-            {% for row in data.plays_by_month %}
+            {% for row in chart.rows %}
             <div class="flex-1 flex flex-col items-center gap-1 min-w-0">
                 <div class="w-full bg-sky-400 rounded-t-sm"
-                     style="height: {{ max_month > 0 ? ((row.plays / max_month * 88)|round) : 0 }}px"
-                     title="{{ row.month }} : {{ row.plays }} lectures"></div>
-                <div class="text-xs text-slate-400 truncate" style="font-size:9px">{{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}</div>
+                     style="height: {{ max_v > 0 ? ((row.plays / max_v * 88)|round) : 0 }}px"
+                     title="{{ attribute(row, chart.key) }} : {{ row.plays }} {{ unit }}"></div>
+                <div class="text-xs text-slate-400 truncate" style="font-size:9px">
+                    {%- if chart.key == 'month' -%}
+                        {{ row.month|slice(5, 2) }}/{{ row.month|slice(2, 2) }}
+                    {%- else -%}
+                        {{ attribute(row, chart.key)|slice(8, 2) }}/{{ attribute(row, chart.key)|slice(5, 2) }}
+                    {%- endif -%}
+                </div>
             </div>
             {% endfor %}
         </div>
     </div>
     {% endif %}
+    {% endfor %}
 
     {# Top all-time #}
     <div class="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">


### PR DESCRIPTION
## Summary

Ajoute deux histogrammes sous le graphe mensuel existant, sur les **deux** écrans (`/navidrome/stats` et `/lastfm/stats`) :

- **15 dernières semaines** (buckets lundi → dimanche)
- **15 derniers jours**

`NavidromeRepository` expose `getPlaysByWeek()` / `getPlaysByDay()` ; `LastFmStatsService` les calcule en local via `played_at`. Les semaines sont alignées sur le lundi (décalage SQLite `strftime %w`). Buckets vides remplis à 0 pour un axe continu. Données stockées dans le snapshot → zéro coût additionnel à l'affichage. Les templates factorisent les trois graphes dans une boucle.

## Test plan

- [ ] Recalculer chaque snapshot puis visiter `/navidrome/stats` et `/lastfm/stats` → 3 histogrammes (mois / semaines / jours)
- [ ] Vérifier les tooltips (date + nb de lectures) et les labels jj/mm sur les graphes semaine/jour
- [ ] Périodes sans écoute → barres à 0, axe continu

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_