### PR TITLE
fix(lastfm): --date-max YYYY-MM-DD inclut tout le jour

### DIFF
--- a/src/LastFm/FetchWindowResolver.php
+++ b/src/LastFm/FetchWindowResolver.php
@@ -32,7 +32,7 @@ final class FetchWindowResolver
      */
     public function resolve(string $user, ?string $explicitDateMin, ?string $explicitDateMax): array
     {
-        $dateMax = $explicitDateMax !== null ? new \DateTimeImmutable($explicitDateMax) : null;
+        $dateMax = $explicitDateMax !== null ? self::parseDateMax($explicitDateMax) : null;
 
         if ($explicitDateMin !== null) {
             return [
@@ -69,5 +69,26 @@ final class FetchWindowResolver
     public function markFetchedAt(string $user, \DateTimeImmutable $at): void
     {
         $this->settings->set(self::SETTING_KEY_PREFIX . $user, $at->format('Y-m-d H:i:s'));
+    }
+
+    /**
+     * Parse the explicit date-max. The CLI doc advertises `YYYY-MM-DD`, and
+     * the web form sends an HTML `<input type="date">` value in the same
+     * shape — both naturally mean « inclure tout ce jour-là ». PHP's
+     * default new DateTimeImmutable('YYYY-MM-DD') would set 00:00:00, i.e.
+     * the START of the day; sent as `to=` to Last.fm that excludes every
+     * scrobble of the day. Promote bare dates to the start of the NEXT day
+     * so today's scrobbles aren't dropped.
+     *
+     * Inputs that already carry a time component are kept verbatim — power
+     * users may want precise windows for backfills.
+     */
+    private static function parseDateMax(string $value): \DateTimeImmutable
+    {
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $value) === 1) {
+            return (new \DateTimeImmutable($value))->modify('+1 day');
+        }
+
+        return new \DateTimeImmutable($value);
     }
 }

--- a/tests/LastFm/FetchWindowResolverTest.php
+++ b/tests/LastFm/FetchWindowResolverTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Tests\LastFm;
+
+use App\LastFm\FetchWindowResolver;
+use App\Repository\SettingRepository;
+use PHPUnit\Framework\TestCase;
+
+class FetchWindowResolverTest extends TestCase
+{
+    public function testExplicitDateMaxAsYmdMustCoverWholeDay(): void
+    {
+        // Reproduce: the CLI option doc says `--date-max=YYYY-MM-DD`. A
+        // user picking today as date-max naturally expects « inclure tout
+        // ce qui s'est passé aujourd'hui ». PHP's new DateTimeImmutable
+        // ('2026-05-29') parses to 2026-05-29 00:00:00 UTC — the START
+        // of the day. Sent verbatim as `to=` to Last.fm, that excludes
+        // every scrobble made on 2026-05-29.
+        //
+        // Expected behaviour: a date-only value means « end of that day ».
+        $settings = $this->createMock(SettingRepository::class);
+        $resolver = new FetchWindowResolver($settings);
+
+        $window = $resolver->resolve('alice', null, '2026-05-29');
+
+        $this->assertNotNull($window['dateMax']);
+        $this->assertSame(
+            '2026-05-30 00:00:00',
+            $window['dateMax']->format('Y-m-d H:i:s'),
+            'date-only date-max must promote to end-of-day so today is included',
+        );
+    }
+
+    public function testExplicitDateMaxWithTimeIsPreservedAsIs(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $resolver = new FetchWindowResolver($settings);
+
+        $window = $resolver->resolve('alice', null, '2026-05-29 14:00:00');
+
+        $this->assertNotNull($window['dateMax']);
+        $this->assertSame('2026-05-29 14:00:00', $window['dateMax']->format('Y-m-d H:i:s'));
+    }
+
+    public function testExplicitDateMinAsYmdStaysAtMidnight(): void
+    {
+        // Symmetric: date-min as Y-m-d means « from the start of that day »,
+        // which already corresponds to midnight. No promotion needed.
+        $settings = $this->createMock(SettingRepository::class);
+        $resolver = new FetchWindowResolver($settings);
+
+        $window = $resolver->resolve('alice', '2026-05-29', null);
+
+        $this->assertSame('2026-05-29 00:00:00', $window['dateMin']->format('Y-m-d H:i:s'));
+    }
+}


### PR DESCRIPTION
## Summary

PHP's `new DateTimeImmutable('2026-05-29')` ↦ `2026-05-29 00:00:00`, i.e. le **début** du jour. Passé tel quel en `to=` à `user.getRecentTracks`, ce timestamp **exclut** tout ce qui s'est scrobblé ce jour-là — d'où la sensation que la fenêtre se ferme la veille au soir.

`FetchWindowResolver::parseDateMax()` promeut les entrées date-only (regex `^\d{4}-\d{2}-\d{2}$`) au début du jour suivant (`+1 day`). Les entrées avec composant horaire (`2026-05-29 14:00:00`) restent telles quelles pour permettre des backfills précis.

Côté `date-min`, pas de changement : « depuis 00:00:00 du jour J » inclut déjà J. Le branch smart-date n'est pas concerné non plus puisque `last_fetch` est toujours stocké en `Y-m-d H:i:s`.

⚠️ Si la symptomatique persiste après ce fix sans qu'aucun `--date-max` ne soit passé, ça veut dire qu'il y a une autre cause (ex: cache snapshot stats pas recalculé, ou Last.fm API qui lag) — pinger pour creuser.

## Test plan

- [ ] `php bin/console app:lastfm:fetch --date-max=$(date +%F)` → scrobbles d'aujourd'hui inclus
- [ ] Web : `/lastfm/import` avec « date-max = today » → idem
- [ ] `php bin/console app:lastfm:fetch --date-max=2026-05-29 14:00:00` → fenêtre s'arrête bien à 14h
- [ ] Tests `FetchWindowResolverTest` (3 cas couverts : date-only promotion, time-explicit preservation, date-min symétrie)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_