### PR TITLE
feat(stats): intervalles de date sur les streaks « plus longues »

### DIFF
--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -59,7 +59,11 @@ class LastFmStatsService
             'last_scrobble_at' => $bounds['last'],
             'streaks' => [
                 'longest_alltime' => $alltime['longest'],
+                'longest_alltime_started_at' => $alltime['longest_started_at'],
+                'longest_alltime_ended_at' => $alltime['longest_ended_at'],
                 'longest_period' => $period['longest'],
+                'longest_period_started_at' => $period['longest_started_at'],
+                'longest_period_ended_at' => $period['longest_ended_at'],
                 'current' => $alltime['current'],
                 'current_started_at' => $alltime['current_started_at'],
                 'current_ended_at' => $alltime['current_ended_at'],

--- a/src/Service/NavidromeStatsService.php
+++ b/src/Service/NavidromeStatsService.php
@@ -53,7 +53,11 @@ class NavidromeStatsService
             'distinct_played' => $this->navidrome->getDistinctTracksPlayed(null, null),
             'streaks' => [
                 'longest_alltime' => $alltime['longest'],
+                'longest_alltime_started_at' => $alltime['longest_started_at'],
+                'longest_alltime_ended_at' => $alltime['longest_ended_at'],
                 'longest_period' => $period['longest'],
+                'longest_period_started_at' => $period['longest_started_at'],
+                'longest_period_ended_at' => $period['longest_ended_at'],
                 'current' => $alltime['current'],
                 'current_started_at' => $alltime['current_started_at'],
                 'current_ended_at' => $alltime['current_ended_at'],

--- a/src/Service/StreakStats.php
+++ b/src/Service/StreakStats.php
@@ -16,7 +16,14 @@ final class StreakStats
     /**
      * @param iterable<string> $days Y-m-d strings, any order, duplicates allowed.
      *
-     * @return array{longest: int, current: int, current_started_at: ?string, current_ended_at: ?string}
+     * @return array{
+     *     longest: int,
+     *     longest_started_at: ?string,
+     *     longest_ended_at: ?string,
+     *     current: int,
+     *     current_started_at: ?string,
+     *     current_ended_at: ?string
+     * }
      */
     public static function compute(iterable $days, ?\DateTimeImmutable $today = null): array
     {
@@ -25,7 +32,14 @@ final class StreakStats
             $set[$d] = true;
         }
         if ($set === []) {
-            return ['longest' => 0, 'current' => 0, 'current_started_at' => null, 'current_ended_at' => null];
+            return [
+                'longest' => 0,
+                'longest_started_at' => null,
+                'longest_ended_at' => null,
+                'current' => 0,
+                'current_started_at' => null,
+                'current_ended_at' => null,
+            ];
         }
         $sorted = array_keys($set);
         sort($sorted);
@@ -33,14 +47,28 @@ final class StreakStats
         $longest = 1;
         $run = 1;
         $prev = null;
+        $runStart = $sorted[0];
+        $longestStart = $sorted[0];
+        $longestEnd = $sorted[0];
         foreach ($sorted as $d) {
             if ($prev === null) {
                 $prev = $d;
+                $runStart = $d;
                 continue;
             }
             $diff = (int) (new \DateTimeImmutable($prev))->diff(new \DateTimeImmutable($d))->days;
-            $run = $diff === 1 ? $run + 1 : 1;
-            $longest = max($longest, $run);
+            if ($diff === 1) {
+                $run++;
+            } else {
+                $run = 1;
+                $runStart = $d;
+            }
+            // Tie-break: keep the earliest streak of the maximal length (strict >).
+            if ($run > $longest) {
+                $longest = $run;
+                $longestStart = $runStart;
+                $longestEnd = $d;
+            }
             $prev = $d;
         }
 
@@ -63,6 +91,8 @@ final class StreakStats
 
         return [
             'longest' => $longest,
+            'longest_started_at' => $longestStart,
+            'longest_ended_at' => $longestEnd,
             'current' => $current,
             'current_started_at' => $startedAt,
             'current_ended_at' => $endedAt,

--- a/templates/lastfm/stats.html.twig
+++ b/templates/lastfm/stats.html.twig
@@ -96,10 +96,22 @@
         <div class="bg-white shadow-sm rounded-sm p-4">
             <div class="text-xs uppercase text-slate-500">Plus longue (12 mois)</div>
             <div class="text-3xl font-semibold">{{ data.streaks.longest_period|number_format(0, '.', ' ') }}<span class="text-base text-slate-500"> j</span></div>
+            {% if data.streaks.longest_period > 0 and data.streaks.longest_period_started_at %}
+                <div class="text-xs text-slate-500">
+                    du {{ data.streaks.longest_period_started_at|date('d/m/Y') }}
+                    au {{ data.streaks.longest_period_ended_at|date('d/m/Y') }}
+                </div>
+            {% endif %}
         </div>
         <div class="bg-white shadow-sm rounded-sm p-4">
             <div class="text-xs uppercase text-slate-500">Plus longue (all-time)</div>
             <div class="text-3xl font-semibold">{{ data.streaks.longest_alltime|number_format(0, '.', ' ') }}<span class="text-base text-slate-500"> j</span></div>
+            {% if data.streaks.longest_alltime > 0 and data.streaks.longest_alltime_started_at %}
+                <div class="text-xs text-slate-500">
+                    du {{ data.streaks.longest_alltime_started_at|date('d/m/Y') }}
+                    au {{ data.streaks.longest_alltime_ended_at|date('d/m/Y') }}
+                </div>
+            {% endif %}
         </div>
     </div>
     {% endif %}

--- a/templates/navidrome/stats.html.twig
+++ b/templates/navidrome/stats.html.twig
@@ -113,10 +113,22 @@
         <div class="bg-white shadow-sm rounded-sm p-4">
             <div class="text-xs uppercase text-slate-500">Plus longue (12 mois)</div>
             <div class="text-3xl font-semibold">{{ data.streaks.longest_period|number_format(0, '.', ' ') }}<span class="text-base text-slate-500"> j</span></div>
+            {% if data.streaks.longest_period > 0 and data.streaks.longest_period_started_at %}
+                <div class="text-xs text-slate-500">
+                    du {{ data.streaks.longest_period_started_at|date('d/m/Y') }}
+                    au {{ data.streaks.longest_period_ended_at|date('d/m/Y') }}
+                </div>
+            {% endif %}
         </div>
         <div class="bg-white shadow-sm rounded-sm p-4">
             <div class="text-xs uppercase text-slate-500">Plus longue (all-time)</div>
             <div class="text-3xl font-semibold">{{ data.streaks.longest_alltime|number_format(0, '.', ' ') }}<span class="text-base text-slate-500"> j</span></div>
+            {% if data.streaks.longest_alltime > 0 and data.streaks.longest_alltime_started_at %}
+                <div class="text-xs text-slate-500">
+                    du {{ data.streaks.longest_alltime_started_at|date('d/m/Y') }}
+                    au {{ data.streaks.longest_alltime_ended_at|date('d/m/Y') }}
+                </div>
+            {% endif %}
         </div>
     </div>
     {% endif %}

--- a/tests/Service/LocalStatsServiceTest.php
+++ b/tests/Service/LocalStatsServiceTest.php
@@ -82,12 +82,13 @@ class LocalStatsServiceTest extends TestCase
         $startDow = (int) (new \DateTimeImmutable($heatmap['start']))->format('w');
         $this->assertSame(1, $startDow, 'heatmap start day must be Monday');
 
-        // Window spans ~366 days (365 + back-to-Monday snap).
+        // Window spans 366..372 days: HEATMAP_DAYS=365 + 0..6 snap-to-Monday
+        // + 1 (today is inclusive). Hits 372 when today itself is a Monday.
         $start = new \DateTimeImmutable($heatmap['start']);
         $end = new \DateTimeImmutable($heatmap['end']);
         $days = $start->diff($end)->days + 1;
-        $this->assertGreaterThanOrEqual(365, $days);
-        $this->assertLessThanOrEqual(371, $days);
+        $this->assertGreaterThanOrEqual(366, $days);
+        $this->assertLessThanOrEqual(372, $days);
 
         // Each week is exactly 7 cells (Monday..Sunday), null-padded after today.
         foreach ($heatmap['weeks'] as $week) {

--- a/tests/Service/StreakStatsTest.php
+++ b/tests/Service/StreakStatsTest.php
@@ -12,6 +12,8 @@ class StreakStatsTest extends TestCase
         $r = StreakStats::compute([], new \DateTimeImmutable('2026-01-15'));
 
         $this->assertSame(0, $r['longest']);
+        $this->assertNull($r['longest_started_at']);
+        $this->assertNull($r['longest_ended_at']);
         $this->assertSame(0, $r['current']);
         $this->assertNull($r['current_started_at']);
     }
@@ -22,7 +24,32 @@ class StreakStatsTest extends TestCase
         $r = StreakStats::compute($days, new \DateTimeImmutable('2026-02-01'));
 
         $this->assertSame(3, $r['longest']);
+        $this->assertSame('2026-01-01', $r['longest_started_at']);
+        $this->assertSame('2026-01-03', $r['longest_ended_at']);
         $this->assertSame(0, $r['current'], 'no play near today → current is 0');
+    }
+
+    public function testLongestRunTieBreaksOnEarliest(): void
+    {
+        // Two runs of length 3 — keep the earliest interval.
+        $days = [
+            '2026-01-01', '2026-01-02', '2026-01-03',
+            '2026-02-10', '2026-02-11', '2026-02-12',
+        ];
+        $r = StreakStats::compute($days, new \DateTimeImmutable('2026-03-01'));
+
+        $this->assertSame(3, $r['longest']);
+        $this->assertSame('2026-01-01', $r['longest_started_at']);
+        $this->assertSame('2026-01-03', $r['longest_ended_at']);
+    }
+
+    public function testSingleDayHasMatchingLongestBounds(): void
+    {
+        $r = StreakStats::compute(['2026-04-12'], new \DateTimeImmutable('2026-05-01'));
+
+        $this->assertSame(1, $r['longest']);
+        $this->assertSame('2026-04-12', $r['longest_started_at']);
+        $this->assertSame('2026-04-12', $r['longest_ended_at']);
     }
 
     public function testCurrentStreakEndsToday(): void


### PR DESCRIPTION
## Summary

Les cartes « Plus longue (12 mois) » et « Plus longue (all-time) » ressemblaient à des chiffres isolés alors que la streak courante affichait déjà « depuis le … ». Cette PR ajoute l'intervalle de date sous les deux cartes record.

- `StreakStats::compute()` retourne maintenant `longest_started_at` / `longest_ended_at` en plus de la longueur, calculés dans la même passe en suivant le début du run courant. Tie-break sur `>` strict → on garde le record le plus ancien quand deux runs ont la même longueur.
- `NavidromeStatsService` et `LastFmStatsService` propagent les bornes 12 mois (`longest_period_*`) et all-time (`longest_alltime_*`) dans le payload `streaks`.
- Les deux templates `stats.html.twig` (navidrome + lastfm) affichent « du JJ/MM/YYYY au JJ/MM/YYYY » sous chaque carte record.
- 3 cas ajoutés dans `StreakStatsTest` : empty set, sélection du max, tie-break sur l'antériorité, run d'un seul jour.

## Test plan

- [x] `composer phpcs` → vert
- [x] `phpunit tests/Service/StreakStatsTest.php` → 8 tests / 26 assertions vert
- [ ] Ouvrir `/navidrome/stats` et `/lastfm/stats` après reconstruction du snapshot → les deux cartes « Plus longue » affichent leur intervalle
- [ ] Cas sans aucune écoute → les intervalles n'apparaissent pas (guard `> 0 and started_at`)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_