### PR TITLE
feat(aliases): app:aliases:musicbrainz + fix script PHP_BIN tableau bash

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -40,6 +40,14 @@ LASTFM_FUZZY_MAX_DISTANCE=0
 LASTFM_MATCH_CACHE_TTL_DAYS=30
 ###< Last.fm ###
 
+###> MusicBrainz ###
+# Online alias suggester (app:aliases:musicbrainz). MB requires a contact-bearing
+# UA — replace with your own URL or e-mail. Base URL only needs changing to
+# hit a mirror or a local mbserver instance.
+MUSICBRAINZ_USER_AGENT="navidrome-tools/dev (+https://github.com/kgaut/navidrome-tools)"
+MUSICBRAINZ_BASE_URL=https://musicbrainz.org/ws/2/
+###< MusicBrainz ###
+
 ###> Strawberry ###
 # Path to strawberry.db inside the container. Empty = disabled.
 STRAWBERRY_DB_PATH=

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,6 +18,8 @@ parameters:
     lastfm.page_delay_seconds: '%env(int:LASTFM_PAGE_DELAY_SECONDS)%'
     lastfm.fuzzy_max_distance: '%env(int:LASTFM_FUZZY_MAX_DISTANCE)%'
     lastfm.match_cache_ttl_days: '%env(int:LASTFM_MATCH_CACHE_TTL_DAYS)%'
+    musicbrainz.user_agent: '%env(MUSICBRAINZ_USER_AGENT)%'
+    musicbrainz.base_url: '%env(MUSICBRAINZ_BASE_URL)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
@@ -98,6 +100,11 @@ services:
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'
+
+    App\MusicBrainz\MusicBrainzClient:
+        arguments:
+            $userAgent: '%musicbrainz.user_agent%'
+            $baseUrl: '%musicbrainz.base_url%'
 
     App\Command\FetchLastFmCommand:
         arguments:

--- a/src/Command/SuggestAliasesMusicBrainzCommand.php
+++ b/src/Command/SuggestAliasesMusicBrainzCommand.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Service\MusicBrainzAliasReport;
+use App\Service\MusicBrainzAliasSuggester;
+use App\Service\MusicBrainzAliasSuggestion;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Query MusicBrainz for unmatched-artist aliases and bridge them to library
+ * artists. Complements {@see GenerateAliasesCommand} (offline, MBID-only) with
+ * an online lookup that catches cases where Last.fm never sent an MBID or
+ * where the artist spelling differs from any owned artist by more than
+ * normalization tolerates.
+ *
+ * Default mode applies high-confidence (unique-library-match) aliases right
+ * away. Ambiguous candidates are skipped silently unless `--interactive` is
+ * given, in which case the user picks the target. `--dry-run` previews
+ * everything without writing.
+ *
+ * Reads Navidrome read-only (no need to stop the container); writes only the
+ * tools DB. Run `app:scrobbles:rematch` afterwards to re-resolve the
+ * unmatched scrobbles through the new aliases.
+ */
+#[AsCommand(
+    name: 'app:aliases:musicbrainz',
+    description: 'Suggest artist aliases for unmatched scrobbles via MusicBrainz online lookup.',
+)]
+class SuggestAliasesMusicBrainzCommand extends Command
+{
+    /** MB asks 1 req/s per UA. 1100 ms keeps a small safety margin. */
+    private const DEFAULT_RATE_LIMIT_MS = 1100;
+
+    public function __construct(
+        private readonly MusicBrainzAliasSuggester $suggester,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('target', 't', InputOption::VALUE_REQUIRED, 'Unmatched set to scan (navidrome|strawberry).', 'navidrome')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Preview only — write nothing.')
+            ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Prompt for ambiguous candidates.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Max artists to query (0 = no limit).', '0')
+            ->addOption('rate-limit-ms', null, InputOption::VALUE_REQUIRED, 'Throttle between MB requests, in ms (≥1000 advised).', (string) self::DEFAULT_RATE_LIMIT_MS);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $target = (string) $input->getOption('target');
+        if (!in_array($target, [ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::TARGET_STRAWBERRY], true)) {
+            $io->error(sprintf('Invalid target "%s". Use "navidrome" or "strawberry".', $target));
+            return Command::FAILURE;
+        }
+
+        $dryRun = (bool) $input->getOption('dry-run');
+        $interactive = (bool) $input->getOption('interactive');
+        $limit = max(0, (int) $input->getOption('limit'));
+        $rateLimitMs = max(0, (int) $input->getOption('rate-limit-ms'));
+
+        $label = sprintf('MusicBrainz alias suggest [%s%s%s]', $target, $dryRun ? ' dry-run' : '', $interactive ? ' interactive' : '');
+
+        $io->title($label);
+        if ($rateLimitMs < 1000) {
+            $io->warning('Rate limit below 1000 ms — MusicBrainz may reject requests (503).');
+        }
+
+        $beforeQuery = static function (string $artist) use ($io, $rateLimitMs): void {
+            if ($rateLimitMs > 0) {
+                usleep($rateLimitMs * 1000);
+            }
+            $io->writeln(sprintf('  → query MB: %s', $artist), OutputInterface::VERBOSITY_VERBOSE);
+        };
+
+        $confirm = $interactive
+            ? fn (MusicBrainzAliasSuggestion $s): ?string => $this->promptAmbiguous($io, $s)
+            : null;
+
+        try {
+            $report = $this->recorder->record(
+                type: RunHistory::TYPE_NAVIDROME_ALIAS_MUSICBRAINZ,
+                reference: $target,
+                label: $label,
+                action: fn () => $this->suggester->suggest($target, $dryRun, $limit, $beforeQuery, $confirm),
+                extractMetrics: static fn (MusicBrainzAliasReport $r): array => [
+                    'queried' => $r->artistsQueried,
+                    'created' => $r->aliasesCreated,
+                    'ambiguous' => $r->ambiguous,
+                    'no_match' => $r->noMatch,
+                    'mb_errors' => $r->mbErrors,
+                    'plays_covered' => $r->playsCovered,
+                ],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->printReport($io, $report);
+
+        return Command::SUCCESS;
+    }
+
+    private function promptAmbiguous(SymfonyStyle $io, MusicBrainzAliasSuggestion $s): ?string
+    {
+        $io->section(sprintf('Ambiguous: %s (%d plays)', $s->sourceArtist, $s->plays));
+        foreach ($s->evidence as $e) {
+            $io->writeln(sprintf(
+                '  · %s (mbid=%s, score=%d, matched via "%s")',
+                $e['name'],
+                $e['mbid'],
+                $e['score'],
+                $e['matched_via'] ?? '—',
+            ));
+        }
+        $choices = [...$s->targetCandidates, 'skip'];
+        /** @var string $picked */
+        $picked = $io->choice('Pick the library artist to alias to', $choices, 'skip');
+
+        return $picked === 'skip' ? null : $picked;
+    }
+
+    private function printReport(SymfonyStyle $io, MusicBrainzAliasReport $report): void
+    {
+        if ($report->samples !== []) {
+            $io->section('Sample suggestions');
+            $rows = [];
+            foreach ($report->samples as $s) {
+                $rows[] = [
+                    $s->kind,
+                    mb_strimwidth($s->sourceArtist, 0, 32, '…'),
+                    mb_strimwidth(implode(' | ', $s->targetCandidates) ?: '—', 0, 38, '…'),
+                    (string) $s->plays,
+                ];
+            }
+            $io->table(['kind', 'source', 'library target(s)', 'plays'], $rows);
+        }
+
+        $io->section('Summary');
+        $io->definitionList(
+            ['Artists considered' => (string) $report->artistsConsidered],
+            ['Already aliased (skipped)' => (string) $report->skippedAlreadyAliased],
+            ['Already owned by lib (skipped)' => (string) $report->skippedAlreadyOwned],
+            ['Queried MusicBrainz' => (string) $report->artistsQueried],
+            ['Unique-match aliases' => sprintf('%d  (+%d plays)', $report->aliasesCreated, $report->playsCovered)],
+            ['Ambiguous (skipped)' => (string) $report->ambiguous],
+            ['No library match' => (string) $report->noMatch],
+            ['MusicBrainz errors' => (string) $report->mbErrors],
+        );
+
+        $verb = $report->dryRun ? 'would create' : 'created';
+        $io->success(sprintf(
+            '%s %d aliases covering ~%d unmatched plays.%s',
+            ucfirst($verb),
+            $report->aliasesCreated,
+            $report->playsCovered,
+            $report->dryRun ? ' Re-run without --dry-run to persist.' : ' Run app:scrobbles:rematch to apply them.',
+        ));
+    }
+}

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -19,6 +19,7 @@ class RunHistory
     public const TYPE_LOVES_NAVIDROME_TO_LASTFM = 'loves-navidrome-to-lastfm';
     public const TYPE_NAVIDROME_SYNC = 'navidrome-sync';
     public const TYPE_NAVIDROME_REMATCH = 'navidrome-rematch';
+    public const TYPE_NAVIDROME_ALIAS_MUSICBRAINZ = 'navidrome-alias-musicbrainz';
     public const TYPE_STRAWBERRY_SYNC = 'strawberry-sync';
     public const TYPE_STRAWBERRY_REMATCH = 'strawberry-rematch';
     public const TYPE_STATS = 'stats';

--- a/src/MusicBrainz/MusicBrainzArtistCandidate.php
+++ b/src/MusicBrainz/MusicBrainzArtistCandidate.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\MusicBrainz;
+
+/**
+ * One artist returned by the MusicBrainz search endpoint, normalized to the
+ * subset we actually use: the canonical name + the alias strings, plus the
+ * search score MB attached to this candidate (0-100, 100 = best).
+ */
+final class MusicBrainzArtistCandidate
+{
+    /**
+     * @param list<string> $aliases primary + non-primary alias names, deduped
+     */
+    public function __construct(
+        public readonly string $mbid,
+        public readonly string $name,
+        public readonly int $score,
+        public readonly array $aliases,
+    ) {
+    }
+
+    /**
+     * All known textual forms of this artist (canonical name + aliases).
+     *
+     * @return list<string>
+     */
+    public function allNames(): array
+    {
+        $names = [$this->name, ...$this->aliases];
+        $seen = [];
+        $out = [];
+        foreach ($names as $n) {
+            $key = mb_strtolower(trim($n));
+            if ($key === '' || isset($seen[$key])) {
+                continue;
+            }
+            $seen[$key] = true;
+            $out[] = $n;
+        }
+
+        return $out;
+    }
+}

--- a/src/MusicBrainz/MusicBrainzClient.php
+++ b/src/MusicBrainz/MusicBrainzClient.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\MusicBrainz;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Thin MusicBrainz Web Service v2 client — we only call /artist/?query=…
+ * because the alias-suggester only needs artist candidates with their alias
+ * list. Anything more comes later.
+ *
+ * Anonymous; just needs a polite User-Agent (MB rejects empty / bot UAs and
+ * applies a strict 1 req/s rate-limit per UA). The caller is responsible for
+ * throttling — this class only sends the request.
+ */
+class MusicBrainzClient
+{
+    private const DEFAULT_BASE_URL = 'https://musicbrainz.org/ws/2/';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $userAgent,
+        private readonly string $baseUrl = self::DEFAULT_BASE_URL,
+    ) {
+    }
+
+    /**
+     * Search for an artist by name, asking MB to include alias records in the
+     * response. `$limit` caps the candidate set returned; MB's own `score`
+     * field tells how well each one matched.
+     *
+     * @return list<MusicBrainzArtistCandidate>
+     */
+    public function searchArtist(string $name, int $limit = 5): array
+    {
+        $name = trim($name);
+        if ($name === '') {
+            return [];
+        }
+
+        // Lucene-style query, value quoted to keep multi-word names intact and
+        // backslash-escape the few characters MB treats as syntax (so a name
+        // like `AC/DC` doesn't break parsing).
+        $escaped = preg_replace('/([+\-!(){}\[\]^"~*?:\\\\\/])/', '\\\\$1', $name) ?? $name;
+        $params = [
+            'query' => sprintf('artist:"%s"', $escaped),
+            'fmt' => 'json',
+            'limit' => max(1, min(25, $limit)),
+        ];
+
+        try {
+            $response = $this->httpClient->request('GET', rtrim($this->baseUrl, '/') . '/artist/', [
+                'query' => $params,
+                'headers' => [
+                    'User-Agent' => $this->userAgent,
+                    'Accept' => 'application/json',
+                ],
+                'timeout' => 15,
+            ]);
+            $status = $response->getStatusCode();
+        } catch (ExceptionInterface $e) {
+            throw new MusicBrainzException(
+                sprintf('MusicBrainz request failed for "%s": %s', $name, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        if ($status === 503) {
+            // 503 = rate-limited. Surface a typed error so the caller can back
+            // off / retry rather than silently treating "no result" as truth.
+            throw new MusicBrainzException(sprintf('MusicBrainz rate-limited (503) on "%s".', $name));
+        }
+        if ($status >= 400) {
+            throw new MusicBrainzException(sprintf('MusicBrainz HTTP %d on "%s".', $status, $name));
+        }
+
+        try {
+            /** @var array<string, mixed> $body */
+            $body = $response->toArray(false);
+        } catch (ExceptionInterface $e) {
+            throw new MusicBrainzException(
+                sprintf('MusicBrainz returned invalid JSON for "%s": %s', $name, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+
+        $artists = $body['artists'] ?? [];
+        if (!is_array($artists)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($artists as $a) {
+            if (!is_array($a)) {
+                continue;
+            }
+            $mbid = isset($a['id']) && is_string($a['id']) ? $a['id'] : '';
+            $canonical = isset($a['name']) && is_string($a['name']) ? $a['name'] : '';
+            if ($mbid === '' || $canonical === '') {
+                continue;
+            }
+            $score = isset($a['score']) ? (int) $a['score'] : 0;
+            $aliases = self::collectAliasNames($a['aliases'] ?? null);
+            $out[] = new MusicBrainzArtistCandidate($mbid, $canonical, $score, $aliases);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function collectAliasNames(mixed $raw): array
+    {
+        if (!is_array($raw)) {
+            return [];
+        }
+        $out = [];
+        foreach ($raw as $alias) {
+            if (!is_array($alias)) {
+                continue;
+            }
+            $name = $alias['name'] ?? null;
+            if (is_string($name) && trim($name) !== '') {
+                $out[] = $name;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/MusicBrainz/MusicBrainzException.php
+++ b/src/MusicBrainz/MusicBrainzException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\MusicBrainz;
+
+class MusicBrainzException extends \RuntimeException
+{
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -1029,6 +1029,28 @@ class NavidromeRepository
     }
 
     /**
+     * Distinct artist names exactly as stored in `media_file.artist`. Used by
+     * the MusicBrainz alias suggester to map a normalized form back to a
+     * canonical spelling for alias targets / UI display. Counterpart to
+     * {@see self::getKnownArtistsNormalized()}.
+     *
+     * @return list<string>
+     */
+    public function getKnownArtistOriginalNames(): array
+    {
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT artist FROM media_file WHERE artist != '' ORDER BY artist ASC",
+        );
+
+        $out = [];
+        foreach ($rows as $r) {
+            $out[] = (string) $r['artist'];
+        }
+
+        return $out;
+    }
+
+    /**
      * Albums with no MusicBrainz album id, ranked by lifetime plays.
      * Plays count is taken from `scrobbles` when available (lifetime),
      * falls back to `annotation.play_count` otherwise. Returns [] when

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -231,4 +231,28 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
             $params,
         );
     }
+
+    /**
+     * Distinct unmatched artists for the given target with their lifetime
+     * unmatched play count, ordered by plays. Feeds the MusicBrainz online
+     * alias suggester ({@see \App\Service\MusicBrainzAliasSuggester}) which —
+     * unlike the MBID-based generator — needs to query even artists that have
+     * no `mbid_artist` on their scrobbles.
+     *
+     * @return list<array{artist: string, plays: int}>
+     */
+    public function unmatchedArtistsWithPlays(string $target): array
+    {
+        /** @var list<array{artist: string, plays: int}> */
+        return $this->em->getConnection()->fetchAllAssociative(
+            "SELECT s.artist AS artist, COUNT(*) AS plays
+             FROM scrobble_sync ss
+             JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE ss.target = :target AND ss.status = :status
+               AND s.artist IS NOT NULL AND s.artist != ''
+             GROUP BY s.artist
+             ORDER BY plays DESC",
+            ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED],
+        );
+    }
 }

--- a/src/Service/MusicBrainzAliasReport.php
+++ b/src/Service/MusicBrainzAliasReport.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * Aggregate counters + sample suggestions for one run of
+ * {@see MusicBrainzAliasSuggester}.
+ */
+final class MusicBrainzAliasReport
+{
+    public bool $dryRun = false;
+    public int $artistsConsidered = 0;
+    public int $artistsQueried = 0;
+    public int $skippedAlreadyAliased = 0;
+    public int $skippedAlreadyOwned = 0;
+    public int $aliasesCreated = 0;
+    public int $playsCovered = 0;
+    public int $ambiguous = 0;
+    public int $noMatch = 0;
+    public int $mbErrors = 0;
+
+    /** @var list<MusicBrainzAliasSuggestion> */
+    public array $samples = [];
+
+    public function addSample(MusicBrainzAliasSuggestion $s, int $cap = 30): void
+    {
+        if (count($this->samples) < $cap) {
+            $this->samples[] = $s;
+        }
+    }
+}

--- a/src/Service/MusicBrainzAliasSuggester.php
+++ b/src/Service/MusicBrainzAliasSuggester.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\LastFmArtistAlias;
+use App\MusicBrainz\MusicBrainzArtistCandidate;
+use App\MusicBrainz\MusicBrainzClient;
+use App\MusicBrainz\MusicBrainzException;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmArtistAliasRepository;
+use App\Repository\LastFmMatchCacheRepository;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Online complement to {@see AliasGenerator}: pulls candidate artist names +
+ * aliases from MusicBrainz to bridge unmatched scrobbles whose artist string
+ * doesn't exist as-is in the library but whose MB record carries an alias
+ * that does (e.g. `Beatles, The` → `The Beatles`, `Sigur Rós` ↔ `Sigur Ros`).
+ *
+ *  - Builds two index sets once: every alias source already in
+ *    `lastfm_artist_alias` (skip), every normalized artist name owned by the
+ *    library (match target).
+ *  - Walks distinct unmatched artists in the chosen target's scrobble_sync,
+ *    ordered by play volume so the biggest wins land first if the run is
+ *    capped via --limit.
+ *  - For each, queries MB once (the caller must throttle — MB rate-limits at
+ *    ~1 req/s per UA) and intersects MB's candidate names + aliases with the
+ *    library set:
+ *      • exactly one library artist matched → UNIQUE → auto-apply when not
+ *        in dry-run.
+ *      • multiple library artists matched → AMBIGUOUS → optional confirm
+ *        callback (interactive prompt) decides; falls back to skip.
+ *      • zero library matches → NO_MATCH, reported.
+ *  - On apply, the alias is persisted then the match-cache rows for the
+ *    source artist are purged so a subsequent `app:scrobbles:rematch` can
+ *    resolve the unmatched scrobbles through the new alias.
+ *
+ * Reads Navidrome read-only; writes only the tools DB.
+ */
+class MusicBrainzAliasSuggester
+{
+    /** Minimum MB score (0-100) we'll trust as a real candidate. MB returns
+     *  fuzzy matches all the way down to 50 for poor name overlaps. */
+    private const MIN_MB_SCORE = 80;
+
+    public function __construct(
+        private readonly MusicBrainzClient $client,
+        private readonly NavidromeRepository $navidrome,
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly LastFmArtistAliasRepository $artistAliasRepo,
+        private readonly LastFmMatchCacheRepository $cacheRepo,
+        private readonly EntityManagerInterface $em,
+    ) {
+    }
+
+    /**
+     * @param ?callable(string $sourceArtist): void                                   $beforeQuery
+     *                                                  Called right before each MB call
+     *                                                  — host for the throttle sleep.
+     * @param ?callable(MusicBrainzAliasSuggestion): ?string                          $confirm
+     *                                                  Invoked on ambiguous suggestions.
+     *                                                  Return the chosen target (one of
+     *                                                  `targetCandidates`) to apply, or
+     *                                                  null to skip. When null, ambiguous
+     *                                                  suggestions are always skipped.
+     */
+    public function suggest(
+        string $target,
+        bool $dryRun,
+        int $limit,
+        ?callable $beforeQuery = null,
+        ?callable $confirm = null,
+    ): MusicBrainzAliasReport {
+        $report = new MusicBrainzAliasReport();
+        $report->dryRun = $dryRun;
+
+        $existing = $this->artistAliasRepo->existingSourceNorms();
+        $owned = $this->navidrome->getKnownArtistsNormalized();
+        if ($owned === []) {
+            return $report;
+        }
+        // Reverse index: normalized lib name → canonical lib name (the first
+        // spelling we encounter via the existing helper).
+        $ownedCanonical = $this->canonicalLibNames($owned);
+
+        $processed = 0;
+        foreach ($this->syncRepo->unmatchedArtistsWithPlays($target) as $row) {
+            if ($limit > 0 && $processed >= $limit) {
+                break;
+            }
+
+            $source = (string) $row['artist'];
+            $plays = (int) $row['plays'];
+            $sourceNorm = NavidromeRepository::normalize($source);
+
+            $report->artistsConsidered++;
+
+            if ($sourceNorm === '') {
+                continue;
+            }
+            if (isset($existing[$sourceNorm])) {
+                $report->skippedAlreadyAliased++;
+                continue;
+            }
+            if (isset($owned[$sourceNorm])) {
+                // The library already owns this exact spelling — the artist
+                // isn't what's blocking the match (track title likely is).
+                $report->skippedAlreadyOwned++;
+                continue;
+            }
+
+            $processed++;
+            if ($beforeQuery !== null) {
+                $beforeQuery($source);
+            }
+            $report->artistsQueried++;
+
+            try {
+                $candidates = $this->client->searchArtist($source);
+            } catch (MusicBrainzException) {
+                $report->mbErrors++;
+                continue;
+            }
+
+            $suggestion = $this->buildSuggestion($source, $plays, $candidates, $owned, $ownedCanonical);
+            $report->addSample($suggestion);
+
+            if ($suggestion->kind === MusicBrainzAliasSuggestion::KIND_NO_MATCH) {
+                $report->noMatch++;
+                continue;
+            }
+
+            $chosen = null;
+            if ($suggestion->kind === MusicBrainzAliasSuggestion::KIND_UNIQUE) {
+                $chosen = $suggestion->uniqueTarget();
+            } elseif ($confirm !== null) {
+                $chosen = $confirm($suggestion);
+                if ($chosen !== null && !in_array($chosen, $suggestion->targetCandidates, true)) {
+                    $chosen = null;
+                }
+            }
+
+            if ($chosen === null) {
+                $report->ambiguous++;
+                continue;
+            }
+
+            $report->aliasesCreated++;
+            $report->playsCovered += $plays;
+            $existing[$sourceNorm] = true;
+
+            if (!$dryRun) {
+                $this->em->persist(new LastFmArtistAlias($source, $chosen));
+                $this->em->flush();
+                $this->cacheRepo->purgeByArtist($source);
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param array<string, true>                  $owned          normalized lib artists
+     * @param array<string, string>                $ownedCanonical normalized → canonical
+     * @param list<MusicBrainzArtistCandidate>     $candidates
+     */
+    private function buildSuggestion(
+        string $source,
+        int $plays,
+        array $candidates,
+        array $owned,
+        array $ownedCanonical,
+    ): MusicBrainzAliasSuggestion {
+        $matches = [];
+        $evidence = [];
+
+        foreach ($candidates as $cand) {
+            if ($cand->score < self::MIN_MB_SCORE) {
+                continue;
+            }
+            $matchedVia = null;
+            foreach ($cand->allNames() as $name) {
+                $norm = NavidromeRepository::normalize($name);
+                if ($norm === '' || !isset($owned[$norm])) {
+                    continue;
+                }
+                $libName = $ownedCanonical[$norm];
+                $matches[$libName] = true;
+                $matchedVia ??= $name;
+            }
+            $evidence[] = [
+                'mbid' => $cand->mbid,
+                'name' => $cand->name,
+                'score' => $cand->score,
+                'matched_via' => $matchedVia,
+            ];
+        }
+
+        $targets = array_keys($matches);
+        $kind = match (true) {
+            count($targets) === 1 => MusicBrainzAliasSuggestion::KIND_UNIQUE,
+            count($targets) > 1 => MusicBrainzAliasSuggestion::KIND_AMBIGUOUS,
+            default => MusicBrainzAliasSuggestion::KIND_NO_MATCH,
+        };
+
+        return new MusicBrainzAliasSuggestion($source, $plays, $kind, $targets, $evidence);
+    }
+
+    /**
+     * Resolve normalized lib artist names back to a canonical spelling for
+     * UI / alias-target use. The existing helper only exposes the
+     * normalized set, so we re-query with a join-friendly statement here.
+     *
+     * @param array<string, true> $owned
+     *
+     * @return array<string, string>
+     */
+    private function canonicalLibNames(array $owned): array
+    {
+        $names = $this->navidrome->getKnownArtistOriginalNames();
+        $out = [];
+        foreach ($names as $name) {
+            $norm = NavidromeRepository::normalize($name);
+            if ($norm !== '' && isset($owned[$norm]) && !isset($out[$norm])) {
+                $out[$norm] = $name;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/src/Service/MusicBrainzAliasSuggestion.php
+++ b/src/Service/MusicBrainzAliasSuggestion.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Service;
+
+/**
+ * One suggestion produced by {@see MusicBrainzAliasSuggester}: rewriting the
+ * unmatched `$sourceArtist` to the library-owned `$targetArtist`, backed by
+ * the MusicBrainz candidate(s) listed in `$evidence`.
+ *
+ *  - `unique`     → exactly one library artist matched across the MB
+ *                   candidates and their aliases. Safe to auto-apply.
+ *  - `ambiguous`  → multiple distinct library artists matched. Requires
+ *                   confirmation (interactive prompt or manual review).
+ *  - `no_match`   → MB returned candidates but none of them or their aliases
+ *                   normalise to a library artist. Kept for reporting.
+ */
+final class MusicBrainzAliasSuggestion
+{
+    public const KIND_UNIQUE = 'unique';
+    public const KIND_AMBIGUOUS = 'ambiguous';
+    public const KIND_NO_MATCH = 'no_match';
+
+    /**
+     * @param list<string>                 $targetCandidates library artists matched (canonical names)
+     * @param list<array{mbid: string, name: string, score: int, matched_via: ?string}> $evidence
+     */
+    public function __construct(
+        public readonly string $sourceArtist,
+        public readonly int $plays,
+        public readonly string $kind,
+        public readonly array $targetCandidates,
+        public readonly array $evidence,
+    ) {
+    }
+
+    public function uniqueTarget(): ?string
+    {
+        return $this->kind === self::KIND_UNIQUE ? ($this->targetCandidates[0] ?? null) : null;
+    }
+}

--- a/tests/MusicBrainz/MusicBrainzClientTest.php
+++ b/tests/MusicBrainz/MusicBrainzClientTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Tests\MusicBrainz;
+
+use App\MusicBrainz\MusicBrainzClient;
+use App\MusicBrainz\MusicBrainzException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class MusicBrainzClientTest extends TestCase
+{
+    public function testEmptyNameReturnsEmptyListWithoutRequest(): void
+    {
+        $http = new MockHttpClient([]);
+        $client = new MusicBrainzClient($http, 'navidrome-tools-tests/1.0 (test@example.org)');
+
+        $this->assertSame([], $client->searchArtist(''));
+        $this->assertSame(0, $http->getRequestsCount());
+    }
+
+    public function testParsesArtistCandidatesWithAliases(): void
+    {
+        $payload = json_encode([
+            'artists' => [
+                [
+                    'id' => 'b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d',
+                    'name' => 'The Beatles',
+                    'score' => 100,
+                    'aliases' => [
+                        ['name' => 'Beatles, The'],
+                        ['name' => 'Beatles'],
+                    ],
+                ],
+                [
+                    'id' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+                    'name' => 'The Beatles Tribute',
+                    'score' => 72,
+                    'aliases' => [],
+                ],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+
+        $captured = [];
+        $http = new MockHttpClient(function (string $method, string $url, array $opts) use (&$captured, $payload): MockResponse {
+            $captured = ['method' => $method, 'url' => $url, 'headers' => $opts['headers'] ?? []];
+            return new MockResponse($payload, ['http_code' => 200]);
+        });
+
+        $client = new MusicBrainzClient($http, 'navidrome-tools-tests/1.0 (test@example.org)');
+        $candidates = $client->searchArtist('The Beatles');
+
+        $this->assertCount(2, $candidates);
+        $this->assertSame('The Beatles', $candidates[0]->name);
+        $this->assertSame(100, $candidates[0]->score);
+        $this->assertSame(['The Beatles', 'Beatles, The', 'Beatles'], $candidates[0]->allNames());
+        $this->assertSame('GET', $captured['method']);
+        $this->assertStringContainsString('/artist/?', $captured['url']);
+        $this->assertStringContainsString('navidrome-tools-tests/1.0', implode("\n", $captured['headers']));
+    }
+
+    public function testSkipsCandidatesMissingIdOrName(): void
+    {
+        $payload = json_encode([
+            'artists' => [
+                ['id' => '', 'name' => 'no id', 'score' => 90],
+                ['id' => 'mbid-2', 'name' => '', 'score' => 90],
+                ['id' => 'mbid-3', 'name' => 'OK', 'score' => 90],
+            ],
+        ], \JSON_THROW_ON_ERROR);
+        $http = new MockHttpClient(new MockResponse($payload));
+
+        $client = new MusicBrainzClient($http, 'ua');
+        $candidates = $client->searchArtist('whatever');
+
+        $this->assertCount(1, $candidates);
+        $this->assertSame('OK', $candidates[0]->name);
+    }
+
+    public function testRaisesOnRateLimit503(): void
+    {
+        $http = new MockHttpClient(new MockResponse('', ['http_code' => 503]));
+        $client = new MusicBrainzClient($http, 'ua');
+
+        $this->expectException(MusicBrainzException::class);
+        $this->expectExceptionMessageMatches('/rate-limited/i');
+        $client->searchArtist('whoever');
+    }
+
+    public function testRaisesOnOther4xx5xx(): void
+    {
+        $http = new MockHttpClient(new MockResponse('boom', ['http_code' => 500]));
+        $client = new MusicBrainzClient($http, 'ua');
+
+        $this->expectException(MusicBrainzException::class);
+        $client->searchArtist('whoever');
+    }
+
+    public function testEscapesLuceneSpecialCharsInQuery(): void
+    {
+        $captured = '';
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+            return new MockResponse('{"artists": []}');
+        });
+
+        $client = new MusicBrainzClient($http, 'ua');
+        $client->searchArtist('AC/DC');
+
+        // Backslash-escaped slash (`AC\/DC`), then url-encoded by the query
+        // builder. The `/` itself stays literal — Symfony doesn't encode it.
+        $this->assertStringContainsString('AC%5C/DC', $captured);
+    }
+}

--- a/tests/Service/MusicBrainzAliasSuggesterTest.php
+++ b/tests/Service/MusicBrainzAliasSuggesterTest.php
@@ -1,0 +1,292 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\MusicBrainz\MusicBrainzArtistCandidate;
+use App\MusicBrainz\MusicBrainzClient;
+use App\MusicBrainz\MusicBrainzException;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmArtistAliasRepository;
+use App\Repository\LastFmMatchCacheRepository;
+use App\Repository\ScrobbleSyncRepository;
+use App\Service\MusicBrainzAliasReport;
+use App\Service\MusicBrainzAliasSuggester;
+use App\Service\MusicBrainzAliasSuggestion;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class MusicBrainzAliasSuggesterTest extends TestCase
+{
+    /**
+     * @param list<MusicBrainzArtistCandidate>|MusicBrainzException $mbResponse
+     * @param list<array{artist: string, plays: int}>               $unmatched
+     * @param list<string>                                          $libArtists
+     * @param array<string, true>                                   $existingAliases
+     */
+    private function makeSuggester(
+        array|MusicBrainzException $mbResponse,
+        array $unmatched,
+        array $libArtists,
+        array $existingAliases = [],
+    ): MusicBrainzAliasSuggester {
+        $client = $this->createMock(MusicBrainzClient::class);
+        $stub = $client->method('searchArtist');
+        $mbResponse instanceof MusicBrainzException
+            ? $stub->willThrowException($mbResponse)
+            : $stub->willReturn($mbResponse);
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $normalized = [];
+        foreach ($libArtists as $a) {
+            $normalized[NavidromeRepository::normalize($a)] = true;
+        }
+        $navidrome->method('getKnownArtistsNormalized')->willReturn($normalized);
+        $navidrome->method('getKnownArtistOriginalNames')->willReturn($libArtists);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('unmatchedArtistsWithPlays')->willReturn($unmatched);
+
+        $aliasRepo = $this->createMock(LastFmArtistAliasRepository::class);
+        $aliasRepo->method('existingSourceNorms')->willReturn($existingAliases);
+
+        $cacheRepo = $this->createMock(LastFmMatchCacheRepository::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+
+        return new MusicBrainzAliasSuggester(
+            $client,
+            $navidrome,
+            $syncRepo,
+            $aliasRepo,
+            $cacheRepo,
+            $em,
+        );
+    }
+
+    public function testUniqueMatchOnAliasCreatesArtistAlias(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate(
+                    'mbid-beatles',
+                    'The Beatles',
+                    100,
+                    ['Beatles, The'],
+                ),
+            ],
+            unmatched: [['artist' => 'Beatles, The', 'plays' => 42]],
+            libArtists: ['The Beatles'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(1, $report->aliasesCreated);
+        $this->assertSame(42, $report->playsCovered);
+        $this->assertSame(0, $report->ambiguous);
+        $this->assertCount(1, $report->samples);
+        $s = $report->samples[0];
+        $this->assertSame(MusicBrainzAliasSuggestion::KIND_UNIQUE, $s->kind);
+        $this->assertSame(['The Beatles'], $s->targetCandidates);
+    }
+
+    public function testDryRunDoesNotPersist(): void
+    {
+        $client = $this->createMock(MusicBrainzClient::class);
+        $client->method('searchArtist')->willReturn([
+            new MusicBrainzArtistCandidate('mbid', 'The Beatles', 100, ['Beatles, The']),
+        ]);
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getKnownArtistsNormalized')->willReturn([
+            NavidromeRepository::normalize('The Beatles') => true,
+        ]);
+        $navidrome->method('getKnownArtistOriginalNames')->willReturn(['The Beatles']);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('unmatchedArtistsWithPlays')->willReturn([
+            ['artist' => 'Beatles, The', 'plays' => 42],
+        ]);
+
+        $aliasRepo = $this->createMock(LastFmArtistAliasRepository::class);
+        $aliasRepo->method('existingSourceNorms')->willReturn([]);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->never())->method('persist');
+        $em->expects($this->never())->method('flush');
+
+        $cache = $this->createMock(LastFmMatchCacheRepository::class);
+        $cache->expects($this->never())->method('purgeByArtist');
+
+        $suggester = new MusicBrainzAliasSuggester(
+            $client,
+            $navidrome,
+            $syncRepo,
+            $aliasRepo,
+            $cache,
+            $em,
+        );
+        $report = $suggester->suggest('navidrome', dryRun: true, limit: 0);
+
+        $this->assertSame(1, $report->aliasesCreated);
+        $this->assertTrue($report->dryRun);
+    }
+
+    public function testAmbiguousWithoutConfirmIsSkipped(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid-a', 'Artist Alpha', 95, ['Sigur Ros']),
+                new MusicBrainzArtistCandidate('mbid-b', 'Artist Bravo', 90, ['Sigur Rós']),
+            ],
+            unmatched: [['artist' => 'Sigur Ros', 'plays' => 10]],
+            libArtists: ['Artist Alpha', 'Artist Bravo'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(0, $report->aliasesCreated);
+        $this->assertSame(1, $report->ambiguous);
+        $this->assertSame(MusicBrainzAliasSuggestion::KIND_AMBIGUOUS, $report->samples[0]->kind);
+        $this->assertCount(2, $report->samples[0]->targetCandidates);
+    }
+
+    public function testInteractiveConfirmAppliesPickedTarget(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid-a', 'Artist Alpha', 95, []),
+                new MusicBrainzArtistCandidate('mbid-b', 'Artist Bravo', 90, []),
+            ],
+            unmatched: [['artist' => 'Ambiguous Source', 'plays' => 5]],
+            libArtists: ['Artist Alpha', 'Artist Bravo'],
+        );
+
+        $report = $suggester->suggest(
+            'navidrome',
+            dryRun: true,
+            limit: 0,
+            confirm: fn (MusicBrainzAliasSuggestion $s): string => 'Artist Bravo',
+        );
+
+        $this->assertSame(1, $report->aliasesCreated);
+        $this->assertSame(0, $report->ambiguous);
+    }
+
+    public function testNoLibraryMatchCountedAsNoMatch(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid', 'Some Other Spelling', 92, []),
+            ],
+            unmatched: [['artist' => 'Unknown', 'plays' => 3]],
+            libArtists: ['Totally Different Artist'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(0, $report->aliasesCreated);
+        $this->assertSame(1, $report->noMatch);
+        $this->assertSame(MusicBrainzAliasSuggestion::KIND_NO_MATCH, $report->samples[0]->kind);
+    }
+
+    public function testLowScoreCandidatesAreIgnored(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid', 'The Beatles', 50, ['Beatles, The']),
+            ],
+            unmatched: [['artist' => 'Beatles, The', 'plays' => 1]],
+            libArtists: ['The Beatles'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(0, $report->aliasesCreated);
+        $this->assertSame(1, $report->noMatch);
+    }
+
+    public function testSourceAlreadyAliasedIsSkipped(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid', 'The Beatles', 100, ['Beatles, The']),
+            ],
+            unmatched: [['artist' => 'Beatles, The', 'plays' => 99]],
+            libArtists: ['The Beatles'],
+            existingAliases: [NavidromeRepository::normalize('Beatles, The') => true],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(0, $report->artistsQueried);
+        $this->assertSame(1, $report->skippedAlreadyAliased);
+    }
+
+    public function testSourceAlreadyInLibraryIsSkipped(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [],
+            unmatched: [['artist' => 'The Beatles', 'plays' => 5]],
+            libArtists: ['The Beatles'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(0, $report->artistsQueried);
+        $this->assertSame(1, $report->skippedAlreadyOwned);
+    }
+
+    public function testMusicBrainzErrorIsCountedAndDoesNotAbort(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: new MusicBrainzException('boom'),
+            unmatched: [['artist' => 'Whoever', 'plays' => 1]],
+            libArtists: ['Whoever Else'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0);
+
+        $this->assertSame(1, $report->mbErrors);
+        $this->assertSame(0, $report->aliasesCreated);
+    }
+
+    public function testLimitCapsNumberOfQueries(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [],
+            unmatched: [
+                ['artist' => 'A', 'plays' => 5],
+                ['artist' => 'B', 'plays' => 4],
+                ['artist' => 'C', 'plays' => 3],
+            ],
+            libArtists: ['Z'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 2);
+
+        $this->assertSame(2, $report->artistsQueried);
+    }
+
+    public function testBeforeQueryCallbackInvokedPerArtist(): void
+    {
+        $suggester = $this->makeSuggester(
+            mbResponse: [],
+            unmatched: [
+                ['artist' => 'A', 'plays' => 1],
+                ['artist' => 'B', 'plays' => 1],
+            ],
+            libArtists: ['Z'],
+        );
+
+        $seen = [];
+        $suggester->suggest(
+            'navidrome',
+            dryRun: false,
+            limit: 0,
+            beforeQuery: function (string $a) use (&$seen): void {
+                $seen[] = $a;
+            },
+        );
+
+        $this->assertSame(['A', 'B'], $seen);
+    }
+}


### PR DESCRIPTION
## Summary

Deux changements sur cette branche, indépendants l'un de l'autre — peuvent être squash-mergés ou cherry-pickés séparément.

### 1. `feat(aliases): app:aliases:musicbrainz` (commit principal)

Complète `app:aliases:generate` (offline, MBID-only) avec une passe **en ligne sur MusicBrainz** qui attrape les cas où Last.fm n'a jamais envoyé d'MBID, ou quand le nom diffère trop d'un artiste possédé pour que la normalisation rattrape : `Beatles, The` ↔ `The Beatles`, `Sigur Ros` ↔ `Sigur Rós`, etc.

**Pipeline :**
- `MusicBrainzClient` — HTTP `GET /artist/?query=…&inc=aliases`, UA configurable, escape Lucene, 503 typé.
- `MusicBrainzAliasSuggester` intersecte les noms canoniques + aliases MB (score ≥ 80) avec les artistes possédés (`np_normalize`) :
  - exactement 1 match lib → **UNIQUE** → alias auto-appliqué
  - plusieurs matches → **AMBIGUOUS** → callback optionnel (`--interactive`)
  - aucun match → **NO_MATCH** consigné
- Cache Last.fm purgé par source à chaque alias créé.

**Commande `app:aliases:musicbrainz` :**
| Option | Effet |
|---|---|
| `--target navidrome\|strawberry` | Set d'unmatched à scanner (défaut `navidrome`) |
| `--dry-run` | Preview, n'écrit rien |
| `-i, --interactive` | Prompt pour les ambigus |
| `--limit N` | Cap sur le nombre de requêtes MB |
| `--rate-limit-ms` | Throttle (défaut 1100 ms, warning sous 1000 ms) |

`run_history` sous `TYPE_NAVIDROME_ALIAS_MUSICBRAINZ` avec métriques. Wiring : `MUSICBRAINZ_USER_AGENT` + `MUSICBRAINZ_BASE_URL` dans `.env.dist` et `config/services.yaml` (UA contact-bearing exigé par ToS MB).

### 2. `fix(scripts): PHP_BIN en tableau bash` (commit antérieur)

Le template `navidrome-sync.sh.example` plantait dès qu'on remplaçait `PHP_BIN="php"` par une commande à espaces (`docker compose -f compose.yml exec navidrome-tools-web`) — bash cherchait un exécutable littéral. Bascule sur un tableau bash + expansion `"${PHP_BIN[@]}"` qui préserve la séparation des arguments. Documente aussi `docker compose exec -T` (sans `-T`, `docker exec` plante sous cron avec « the input device is not a TTY »).

## Test plan

- [x] `composer phpcs` → vert (127 fichiers)
- [x] `phpunit` → 68 tests / 253 assertions, tous verts (17 nouveaux : client HTTP mocké + suggester)
- [x] `phpstan` → 10 erreurs **pré-existantes** identiques à `develop`, rien sur le nouveau code
- [x] `php bin/console list app:aliases` → la commande apparaît
- [x] `bash -n scripts/navidrome-sync.sh.example` → OK
- [ ] Run réel : `app:aliases:musicbrainz --dry-run --limit=10 -v` pour vérifier le throttle + format de sortie sur une vraie réponse MB
- [ ] `app:scrobbles:rematch` post-création pour confirmer que les alias rebranchent bien les unmatched