### PR TITLE
feat(web): top artistes/albums non matchés avec lien Lidarr (+ docs MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ d'environnement Docker en prod) :
 | `LASTFM_FUZZY_MAX_DISTANCE` | `0` | distance Levenshtein du matching fuzzy (0 = désactivé) |
 | `LASTFM_MATCH_CACHE_TTL_DAYS` | `30` | durée de vie des entrées négatives du cache de matching |
 
+### MusicBrainz
+
+Utilisé par `app:aliases:musicbrainz` (lookup en ligne pour la génération d'alias).
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `MUSICBRAINZ_USER_AGENT` | — | UA contact-bearing exigé par le ToS MB (ex. `mon-projet/1.0 (mon@mail.tld)`) |
+| `MUSICBRAINZ_BASE_URL` | `https://musicbrainz.org/ws/2/` | racine de l'API ; à changer pour viser un mirror ou un mbserver local |
+
 ### Strawberry / Backups / Historique / Notifications
 
 | Variable | Défaut | Description |
@@ -298,6 +307,35 @@ Stratégies (chaque alias par la première qui aboutit) :
 | `--artist-fuzzy-distance` | distance Levenshtein max (artiste, défaut `2`) |
 | `--limit` | nombre max de couples scannés (`0` = illimité) |
 
+#### `app:aliases:musicbrainz`
+Complète `app:aliases:generate` (offline, MBID-only) avec une passe **en ligne sur
+MusicBrainz** : récupère, pour chaque artiste non-matché, son nom canonique et
+ses aliases MB, et les confronte aux artistes possédés. Rattrape les cas que la
+normalisation n'attrape pas (`Beatles, The` ↔ `The Beatles`, `Sigur Ros` ↔
+`Sigur Rós`, `MPL` ↔ `Ma Pauvre Lucette`…), y compris quand Last.fm n'a jamais
+envoyé d'MBID. Lit Navidrome en lecture seule, n'écrit que `lastfm_artist_alias`
+et purge le cache de matching concerné.
+
+Stratégie :
+
+- intersecte les noms canoniques + aliases MB (score ≥ 80) avec les artistes
+  possédés (`np_normalize`) ;
+- **1 match lib unique → UNIQUE** → alias auto-appliqué ;
+- **plusieurs matches → AMBIGUOUS** → skip silencieux, ou prompt avec `-i` ;
+- **0 match → NO_MATCH** → simplement consigné dans le report.
+
+Throttle obligatoire (MB exige ≈ 1 req/s par UA) ; UA contact-bearing
+**requis** dans `MUSICBRAINZ_USER_AGENT` (cf. section *MusicBrainz* plus haut).
+Lancer `app:scrobbles:rematch` ensuite pour appliquer les alias créés.
+
+| Option | Description |
+|---|---|
+| `--target` / `-t` | `navidrome` (défaut) ou `strawberry` |
+| `--dry-run` | aperçu (échantillon + résumé), n'écrit rien |
+| `-i` / `--interactive` | prompt pour trancher les candidats ambigus |
+| `--limit` | nombre max d'artistes à requêter (`0` = illimité) |
+| `--rate-limit-ms` | délai entre requêtes MB (défaut `1100` ; warning sous `1000`) |
+
 #### `app:scrobbles:sync-strawberry`
 Synchronise les scrobbles en attente dans la base Strawberry (`playcount` /
 `lastplayed`).
@@ -368,8 +406,10 @@ Supprime les entrées `run_history` plus vieilles que
 php bin/console app:lastfm:fetch --max-scrobbles=0
 
 # 2. (optionnel) générer des alias pour les non-matchés résolubles
-php bin/console app:aliases:generate --dry-run     # aperçu
-php bin/console app:aliases:generate               # applique
+php bin/console app:aliases:generate --dry-run        # offline, MBID-only
+php bin/console app:aliases:generate                  # applique
+php bin/console app:aliases:musicbrainz --dry-run     # online, via MusicBrainz
+php bin/console app:aliases:musicbrainz               # applique les unique-matches
 
 # 3. Matcher + insérer dans Navidrome (Navidrome arrêté, ou --auto-stop)
 php bin/console app:scrobbles:sync-navidrome --auto-stop
@@ -381,9 +421,11 @@ php bin/console app:scrobbles:rematch --target navidrome --auto-stop
 php bin/console app:loves:lastfm-to-navidrome --auto-stop
 ```
 
-Ordre recommandé pour les alias : **`app:aliases:generate` → `app:scrobbles:rematch`**
-(la commande de génération n'écrit pas dans Navidrome ; le rematch applique les
-alias et insère les écoutes nouvellement résolues).
+Ordre recommandé pour les alias : **`app:aliases:generate` →
+`app:aliases:musicbrainz` → `app:scrobbles:rematch`** (les deux générateurs
+n'écrivent pas dans Navidrome — l'offline d'abord puisqu'il ne coûte rien et
+épuise les cas faciles, l'online ensuite pour ce qui reste ; le rematch
+applique les alias et insère les écoutes nouvellement résolues).
 
 ---
 
@@ -405,8 +447,9 @@ premier succès) :
 Normalisation (`np_normalize`) : minuscules, suppression des accents (NFKD) et
 de la ponctuation — `Beyoncé` = `Beyonce`, `AC/DC` = `ACDC`, etc.
 
-Les couples insolubles automatiquement se gèrent via les **alias** (UI ou
-`app:aliases:generate`).
+Les couples insolubles automatiquement se gèrent via les **alias** : UI,
+`app:aliases:generate` (offline, MBID-only) ou `app:aliases:musicbrainz`
+(online, MB).
 
 ---
 


### PR DESCRIPTION
## Summary

Trois lots sur cette branche (peuvent être squash-mergés tels quels) :

### 1. `feat(web): sous-menu Unmatched (top artistes / top albums) + lien Lidarr`

Le menu **Navidrome > Unmatched** s'enrichit de deux pages classées par volume de scrobbles non matchés, pour repérer d'un coup les plus gros trous dans la bibliothèque :

- **Top artistes non matchés** — `/navidrome/unmatched/top-artists` : groupe par `s.artist`, compte plays + titres distincts + dernier joué.
- **Top albums non matchés** — `/navidrome/unmatched/top-albums` : groupe par `(s.artist, s.album)`, ignore les scrobbles sans album renseigné (Last.fm omet parfois le tag album sur des scrobbles loose — les comptabiliser sous « (sans album) » donnerait une ligne géante peu actionnable).

**Lidarr** — nouvelle extension Twig `LidarrExtension` qui expose `lidarr_artist_url()` et `lidarr_album_url()`. Quand `LIDARR_URL` est vide, les helpers retournent `null` → les templates `{% if lidarr %}` cachent le lien. Sinon, l'URL ouvre l'écran *Add new* de Lidarr pré-rempli (Lidarr 2.x n'expose pas de deep-link album, donc la version album passe le terme `artiste + album` dans la recherche MB-side, qui dégote l'artiste contenant l'album).

**Navbar** — la dropdown Navidrome scinde maintenant en deux groupes : « Sync / Stats » puis groupe `Unmatched` avec Liste / Top artistes / Top albums, en profitant du pattern `groups + heading` déjà supporté côté desktop ET mobile sans modification du rendu.

### 2. `docs(readme): app:aliases:musicbrainz` (déjà sur la branche, commit antérieur)

Documentation de la commande `app:aliases:musicbrainz` mergée dans la PR #176 : section env `MusicBrainz`, section commande, workflow, ordre recommandé.

### 3. `docs(readme): top non matchés + LIDARR_URL`

Ajoute la section env `Lidarr` et la ligne route dans le tableau « Interface web ».

## Test plan

- [x] `composer phpcs` → vert (129 fichiers)
- [x] `phpunit` → 75 tests / 262 assertions, tous verts (7 nouveaux pour `LidarrExtension`)
- [x] `phpstan` → 10 erreurs **pré-existantes** identiques à `develop`, rien sur le nouveau code
- [x] `lint:twig` → 3 templates valides
- [x] `debug:router` → les 2 nouvelles routes apparaissent
- [ ] Visite des deux nouvelles pages dans le browser : navbar dropdown Unmatched OK, table affiche les bons compteurs, lien « ⇗ Lidarr » visible si `LIDARR_URL` configuré / masqué sinon