### PR TITLE
feat(web): page d'historique scrobbles Last.fm avec filtres + statut Navidrome + liens Lidarr/MB

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -48,6 +48,14 @@ MUSICBRAINZ_USER_AGENT="navidrome-tools/dev (+https://github.com/kgaut/navidrome
 MUSICBRAINZ_BASE_URL=https://musicbrainz.org/ws/2/
 ###< MusicBrainz ###
 
+###> Lidarr ###
+# Optional. Self-hosted Lidarr URL — when set, the scrobble history page
+# shows a "⇗ Lidarr" link on every unmatched scrobble that opens the Add
+# new screen pre-filled with the artist (or artist + album when known).
+# Leave empty to hide the links.
+LIDARR_URL=
+###< Lidarr ###
+
 ###> Strawberry ###
 # Path to strawberry.db inside the container. Empty = disabled.
 STRAWBERRY_DB_PATH=

--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ Utilisé par `app:aliases:musicbrainz` (lookup en ligne pour la génération d'a
 | `MUSICBRAINZ_USER_AGENT` | — | UA contact-bearing exigé par le ToS MB (ex. `mon-projet/1.0 (mon@mail.tld)`) |
 | `MUSICBRAINZ_BASE_URL` | `https://musicbrainz.org/ws/2/` | racine de l'API ; à changer pour viser un mirror ou un mbserver local |
 
+### Lidarr
+
+Optionnel. Quand renseigné, la page **`/lastfm/scrobbles`** affiche un lien « ⇗ Lidarr » sur chaque scrobble non matché — il ouvre l'écran *Add new* de votre instance pré-rempli avec le nom de l'artiste (ou artiste + album quand l'album est connu).
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `LIDARR_URL` | — | URL de votre Lidarr (vide = liens masqués) |
+
 ### Strawberry / Backups / Historique / Notifications
 
 | Variable | Défaut | Description |
@@ -212,6 +220,7 @@ Authentification par utilisateur unique (`APP_AUTH_USER` / `APP_AUTH_PASSWORD`).
 | `/` | dashboard (état, compteurs, actions rapides) |
 | `/stats`, `/lastfm/stats`, `/navidrome/stats` | statistiques (incluant la **disparité** Last.fm ↔ Navidrome sur `/navidrome/stats` : top mois et années avec le plus d'écoutes Last.fm sans équivalent Navidrome, bornés au premier scrobble Navidrome) |
 | `/lastfm/import` | import d'historique Last.fm |
+| `/lastfm/scrobbles` | historique paginé des scrobbles avec filtres (année / mois / jour / artiste / titre / statut), statut de matching Navidrome par ligne, pochette + ♥ loved + liens externes (Last.fm, MusicBrainz, Lidarr, Navidrome) |
 | `/navidrome/sync`, `/navidrome/rematch`, `/navidrome/unmatched` | matching/sync Navidrome |
 | `/strawberry/*` | sync Strawberry (upload/download de la base) |
 | `/lastfm/aliases`, `/lastfm/artist-aliases` | gestion des alias (piste / artiste) |

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -20,6 +20,7 @@ parameters:
     lastfm.match_cache_ttl_days: '%env(int:LASTFM_MATCH_CACHE_TTL_DAYS)%'
     musicbrainz.user_agent: '%env(MUSICBRAINZ_USER_AGENT)%'
     musicbrainz.base_url: '%env(MUSICBRAINZ_BASE_URL)%'
+    lidarr.url: '%env(default::LIDARR_URL)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
@@ -145,6 +146,20 @@ services:
             $defaultUser: '%lastfm.user%'
 
     App\Service\DisparityStatsService:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
+    App\Twig\LidarrExtension:
+        arguments:
+            $lidarrUrl: '%lidarr.url%'
+        tags: ['twig.extension']
+
+    App\Twig\ScrobbleLinksExtension:
+        arguments:
+            $navidromeUrl: '%navidrome.url%'
+        tags: ['twig.extension']
+
+    App\Controller\LastFmScrobblesController:
         arguments:
             $defaultUser: '%lastfm.user%'
 

--- a/src/Controller/LastFmScrobblesController.php
+++ b/src/Controller/LastFmScrobblesController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\ScrobbleRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Last.fm scrobble history page — paginated, filterable view of every
+ * scrobble landed in the local tools DB, with the Navidrome matching
+ * status surfaced per row so the page doubles as a diagnostic view of
+ * what hasn't been bridged to the library yet.
+ *
+ * Reads only the tools DB; never touches Navidrome write-side. Default
+ * page returns the 100 most recent scrobbles for the configured user.
+ */
+class LastFmScrobblesController extends AbstractController
+{
+    private const PER_PAGE = 100;
+
+    public function __construct(
+        private readonly string $defaultUser,
+    ) {
+    }
+
+    #[Route('/lastfm/scrobbles', name: 'app_lastfm_scrobbles', methods: ['GET'])]
+    public function index(Request $request, ScrobbleRepository $scrobbles): Response
+    {
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        $page = max(1, (int) $request->query->get('page', 1));
+
+        $filters = [
+            'lastfm_user' => $user,
+            'year' => self::stringOrNull($request->query->get('year')),
+            'month' => self::stringOrNull($request->query->get('month')),
+            'day' => self::stringOrNull($request->query->get('day')),
+            'artist' => self::stringOrNull($request->query->get('artist')),
+            'title' => self::stringOrNull($request->query->get('title')),
+            'status' => self::stringOrNull($request->query->get('status')),
+        ];
+
+        $rows = $scrobbles->findRecentWithSyncStatus(
+            filters: $filters,
+            limit: self::PER_PAGE,
+            offset: ($page - 1) * self::PER_PAGE,
+        );
+        $total = $scrobbles->countWithFilters($filters);
+        $pages = max(1, (int) ceil($total / self::PER_PAGE));
+
+        return $this->render('lastfm/scrobbles.html.twig', [
+            'rows' => $rows,
+            'total' => $total,
+            'page' => $page,
+            'pages' => $pages,
+            'available_years' => $scrobbles->availableYears($user),
+            'filters' => [
+                'year' => $filters['year'] ?? '',
+                'month' => $filters['month'] ?? '',
+                'day' => $filters['day'] ?? '',
+                'artist' => $filters['artist'] ?? '',
+                'title' => $filters['title'] ?? '',
+                'status' => $filters['status'] ?? '',
+            ],
+        ]);
+    }
+
+    private static function stringOrNull(mixed $v): ?string
+    {
+        if (!is_string($v)) {
+            return null;
+        }
+        $v = trim($v);
+
+        return $v === '' ? null : $v;
+    }
+}

--- a/src/Repository/ScrobbleRepository.php
+++ b/src/Repository/ScrobbleRepository.php
@@ -322,7 +322,7 @@ class ScrobbleRepository extends ServiceEntityRepository
     public function countWithFilters(array $filters): int
     {
         [$where, $params] = self::buildFilterClauses($filters);
-        $needsJoin = isset($filters['status']) && $filters['status'] !== null && $filters['status'] !== '' && $filters['status'] !== 'all';
+        $needsJoin = isset($filters['status']) && $filters['status'] !== '' && $filters['status'] !== 'all';
         $sql = 'SELECT COUNT(*) FROM scrobbles s';
         if ($needsJoin) {
             $sql .= " LEFT JOIN scrobble_sync ss ON ss.scrobble_id = s.id AND ss.target = 'navidrome'";

--- a/src/Repository/ScrobbleRepository.php
+++ b/src/Repository/ScrobbleRepository.php
@@ -231,4 +231,201 @@ class ScrobbleRepository extends ServiceEntityRepository
 
         return $found !== false;
     }
+
+    /**
+     * Distinct years (YYYY, descending) present in the `scrobbles` table —
+     * feeds the year `<select>` of the scrobble history page so the user
+     * can only pick years that actually contain scrobbles.
+     *
+     * @return list<string>
+     */
+    public function availableYears(?string $user): array
+    {
+        $sql = "SELECT DISTINCT strftime('%Y', played_at) AS y FROM scrobbles";
+        $params = [];
+        if ($user !== null && $user !== '') {
+            $sql .= ' WHERE lastfm_user = ?';
+            $params[] = $user;
+        }
+        $sql .= ' ORDER BY y DESC';
+        $rows = $this->getEntityManager()->getConnection()->fetchAllAssociative($sql, $params);
+
+        $out = [];
+        foreach ($rows as $r) {
+            $year = (string) $r['y'];
+            if ($year !== '') {
+                $out[] = $year;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Filtered scrobble listing for the history page. LEFT-joins
+     * `scrobble_sync` (target = navidrome) so each row carries its match
+     * status / strategy / target_id alongside the raw scrobble fields.
+     *
+     * Filters silently degrade on inconsistency: `day` is ignored without
+     * `month`+`year`, `month` without `year`. Empty strings are treated
+     * as absent. Ordered `played_at DESC`.
+     *
+     * @param array{
+     *     lastfm_user?: ?string,
+     *     year?: ?string, month?: ?string, day?: ?string,
+     *     artist?: ?string, title?: ?string,
+     *     status?: ?string
+     * } $filters
+     *
+     * @return list<array{
+     *     id: int, artist: string, album: ?string, title: string,
+     *     mbid_track: ?string, mbid_artist: ?string, mbid_album: ?string,
+     *     image_url: ?string, loved: int, played_at: string,
+     *     sync_status: ?string, sync_strategy: ?string, sync_target_id: ?string
+     * }>
+     */
+    public function findRecentWithSyncStatus(array $filters, int $limit, int $offset): array
+    {
+        [$where, $params] = self::buildFilterClauses($filters);
+        $sql = "SELECT s.id, s.artist, s.album, s.title,
+                       s.mbid_track, s.mbid_artist, s.mbid_album,
+                       s.image_url, s.loved, s.played_at,
+                       ss.status AS sync_status, ss.strategy AS sync_strategy, ss.target_id AS sync_target_id
+                FROM scrobbles s
+                LEFT JOIN scrobble_sync ss ON ss.scrobble_id = s.id AND ss.target = 'navidrome'";
+        if ($where !== '') {
+            $sql .= ' WHERE ' . $where;
+        }
+        $sql .= ' ORDER BY s.played_at DESC, s.id DESC LIMIT ? OFFSET ?';
+        $params[] = max(1, $limit);
+        $params[] = max(0, $offset);
+
+        /** @var list<array{
+         *     id: int, artist: string, album: ?string, title: string,
+         *     mbid_track: ?string, mbid_artist: ?string, mbid_album: ?string,
+         *     image_url: ?string, loved: int, played_at: string,
+         *     sync_status: ?string, sync_strategy: ?string, sync_target_id: ?string
+         * }> $rows */
+        $rows = $this->getEntityManager()->getConnection()->fetchAllAssociative($sql, $params);
+
+        return $rows;
+    }
+
+    /**
+     * Total count of scrobbles matching the same filters as
+     * {@see findRecentWithSyncStatus()}. Joins `scrobble_sync` only when
+     * the `status` filter is non-empty and not `all` — keeps the unfiltered
+     * COUNT fast on the indexed `(played_at)` path.
+     *
+     * @param array<string, ?string> $filters
+     */
+    public function countWithFilters(array $filters): int
+    {
+        [$where, $params] = self::buildFilterClauses($filters);
+        $needsJoin = isset($filters['status']) && $filters['status'] !== null && $filters['status'] !== '' && $filters['status'] !== 'all';
+        $sql = 'SELECT COUNT(*) FROM scrobbles s';
+        if ($needsJoin) {
+            $sql .= " LEFT JOIN scrobble_sync ss ON ss.scrobble_id = s.id AND ss.target = 'navidrome'";
+        }
+        if ($where !== '') {
+            $sql .= ' WHERE ' . $where;
+        }
+
+        return (int) $this->getEntityManager()->getConnection()->fetchOne($sql, $params);
+    }
+
+    /**
+     * Translates a filter array into a WHERE clause + positional params.
+     * Returns `['', []]` when nothing applies. Status filters are emitted
+     * against the LEFT-joined `ss.status`, with the special case
+     * `status=unmatched` also matching scrobbles that have no `scrobble_sync`
+     * row at all yet (NULL after LEFT JOIN) — those *are* unmatched from
+     * the user's point of view.
+     *
+     * Public for unit-testability only — non-API surface, no BC guarantee.
+     *
+     * @param array<string, ?string> $filters
+     *
+     * @return array{0: string, 1: list<mixed>}
+     */
+    public static function buildFilterClauses(array $filters): array
+    {
+        $clauses = [];
+        $params = [];
+
+        $user = $filters['lastfm_user'] ?? null;
+        if ($user !== null && $user !== '') {
+            $clauses[] = 's.lastfm_user = ?';
+            $params[] = $user;
+        }
+
+        $year = self::asYear($filters['year'] ?? null);
+        $month = $year !== null ? self::asMonth($filters['month'] ?? null) : null;
+        $day = $month !== null ? self::asDay($filters['day'] ?? null) : null;
+
+        if ($year !== null) {
+            if ($day !== null) {
+                $clauses[] = "strftime('%Y-%m-%d', s.played_at) = ?";
+                $params[] = sprintf('%04d-%02d-%02d', $year, $month, $day);
+            } elseif ($month !== null) {
+                $clauses[] = "strftime('%Y-%m', s.played_at) = ?";
+                $params[] = sprintf('%04d-%02d', $year, $month);
+            } else {
+                $clauses[] = "strftime('%Y', s.played_at) = ?";
+                $params[] = (string) $year;
+            }
+        }
+
+        $artist = isset($filters['artist']) ? trim((string) $filters['artist']) : '';
+        if ($artist !== '') {
+            $clauses[] = 'LOWER(s.artist) LIKE LOWER(?)';
+            $params[] = '%' . $artist . '%';
+        }
+        $title = isset($filters['title']) ? trim((string) $filters['title']) : '';
+        if ($title !== '') {
+            $clauses[] = 'LOWER(s.title) LIKE LOWER(?)';
+            $params[] = '%' . $title . '%';
+        }
+
+        $status = isset($filters['status']) ? trim((string) $filters['status']) : '';
+        if ($status !== '' && $status !== 'all') {
+            if ($status === 'unmatched') {
+                $clauses[] = "(ss.status = 'unmatched' OR ss.status IS NULL)";
+            } else {
+                $clauses[] = 'ss.status = ?';
+                $params[] = $status;
+            }
+        }
+
+        return [implode(' AND ', $clauses), $params];
+    }
+
+    private static function asYear(mixed $value): ?int
+    {
+        if (!is_string($value) || !preg_match('/^\d{4}$/', $value)) {
+            return null;
+        }
+
+        return (int) $value;
+    }
+
+    private static function asMonth(mixed $value): ?int
+    {
+        if (!is_string($value) || !preg_match('/^\d{1,2}$/', $value)) {
+            return null;
+        }
+        $n = (int) $value;
+
+        return $n >= 1 && $n <= 12 ? $n : null;
+    }
+
+    private static function asDay(mixed $value): ?int
+    {
+        if (!is_string($value) || !preg_match('/^\d{1,2}$/', $value)) {
+            return null;
+        }
+        $n = (int) $value;
+
+        return $n >= 1 && $n <= 31 ? $n : null;
+    }
 }

--- a/src/Twig/LidarrExtension.php
+++ b/src/Twig/LidarrExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Builds deep links into a self-hosted Lidarr instance for quick "add this
+ * artist / album to my library" actions from the scrobble history listing
+ * (and any other view that surfaces unmatched scrobbles).
+ *
+ * Returns `null` when `LIDARR_URL` is empty — the template should `{% if %}`
+ * around the result so the link disappears when Lidarr isn't configured.
+ *
+ * Note: Lidarr's UI doesn't expose a per-album deep link in current versions
+ * (2.x). The album helper pre-fills the artist + album in the search term
+ * so the Lucene-style match on MB surfaces the right artist page and the
+ * user picks the album from there.
+ */
+class LidarrExtension extends AbstractExtension
+{
+    private readonly string $lidarrUrl;
+
+    public function __construct(?string $lidarrUrl = '')
+    {
+        $this->lidarrUrl = (string) $lidarrUrl;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('lidarr_artist_url', $this->artistUrl(...)),
+            new TwigFunction('lidarr_album_url', $this->albumUrl(...)),
+        ];
+    }
+
+    public function artistUrl(string $artist): ?string
+    {
+        $base = $this->base();
+        $artist = trim($artist);
+        if ($base === null || $artist === '') {
+            return null;
+        }
+
+        return $base . '/add/new?term=' . rawurlencode($artist);
+    }
+
+    public function albumUrl(string $artist, string $album): ?string
+    {
+        $base = $this->base();
+        $artist = trim($artist);
+        $album = trim($album);
+        if ($base === null || $artist === '') {
+            return null;
+        }
+        $term = $album !== '' ? $artist . ' ' . $album : $artist;
+
+        return $base . '/add/new?term=' . rawurlencode($term);
+    }
+
+    private function base(): ?string
+    {
+        $url = trim($this->lidarrUrl);
+
+        return $url === '' ? null : rtrim($url, '/');
+    }
+}

--- a/src/Twig/ScrobbleLinksExtension.php
+++ b/src/Twig/ScrobbleLinksExtension.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * Outbound links surfaced on the scrobble history page (and reusable
+ * elsewhere): canonical Last.fm track page (built from artist + title with
+ * the same path scheme Last.fm uses), MusicBrainz entity URLs from MBIDs
+ * already stored on `scrobbles`, and Navidrome's web UI track URL for the
+ * scrobble whose match landed on a known `media_file.id`.
+ *
+ * All helpers return `null` when the input is empty / missing — the
+ * template `{% if %}` guards then hide the icon rather than rendering a
+ * broken stub.
+ */
+class ScrobbleLinksExtension extends AbstractExtension
+{
+    private const LASTFM_BASE = 'https://www.last.fm/music';
+    private const MUSICBRAINZ_BASE = 'https://musicbrainz.org';
+    private const ALLOWED_MB_TYPES = ['artist', 'release', 'release-group', 'recording'];
+
+    private readonly string $navidromeUrl;
+
+    public function __construct(?string $navidromeUrl = '')
+    {
+        $this->navidromeUrl = (string) $navidromeUrl;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('lastfm_track_url', $this->lastFmTrackUrl(...)),
+            new TwigFunction('lastfm_artist_url', $this->lastFmArtistUrl(...)),
+            new TwigFunction('musicbrainz_url', $this->musicbrainzUrl(...)),
+            new TwigFunction('navidrome_track_url', $this->navidromeTrackUrl(...)),
+        ];
+    }
+
+    public function lastFmTrackUrl(string $artist, string $title): ?string
+    {
+        $artist = trim($artist);
+        $title = trim($title);
+        if ($artist === '' || $title === '') {
+            return null;
+        }
+        // Last.fm uses `+` as a space marker in its canonical URLs and
+        // double-encodes the rest. rawurlencode keeps the rest safe while we
+        // swap spaces back to `+` for visual parity with what the user sees
+        // when copying a link from the Last.fm UI.
+        return sprintf(
+            '%s/%s/_/%s',
+            self::LASTFM_BASE,
+            str_replace('%20', '+', rawurlencode($artist)),
+            str_replace('%20', '+', rawurlencode($title)),
+        );
+    }
+
+    public function lastFmArtistUrl(string $artist): ?string
+    {
+        $artist = trim($artist);
+        if ($artist === '') {
+            return null;
+        }
+
+        return self::LASTFM_BASE . '/' . str_replace('%20', '+', rawurlencode($artist));
+    }
+
+    public function musicbrainzUrl(string $type, ?string $mbid): ?string
+    {
+        if ($mbid === null || trim($mbid) === '' || !in_array($type, self::ALLOWED_MB_TYPES, true)) {
+            return null;
+        }
+
+        return sprintf('%s/%s/%s', self::MUSICBRAINZ_BASE, $type, trim($mbid));
+    }
+
+    public function navidromeTrackUrl(?string $mediaFileId): ?string
+    {
+        $base = trim($this->navidromeUrl);
+        if ($base === '' || $mediaFileId === null || trim($mediaFileId) === '') {
+            return null;
+        }
+
+        return rtrim($base, '/') . '/app/#/song/' . rawurlencode(trim($mediaFileId)) . '/show';
+    }
+}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -13,6 +13,7 @@
         { heading: null, items: [
             { label: 'Import', route: 'app_lastfm_import' },
             { label: 'Stats', route: 'app_lastfm_stats' },
+            { label: 'Scrobbles', route: 'app_lastfm_scrobbles' },
         ]},
         { heading: 'Aliases', items: [
             { label: 'Tracks', route: 'app_lastfm_alias_index' },

--- a/templates/lastfm/scrobbles.html.twig
+++ b/templates/lastfm/scrobbles.html.twig
@@ -1,0 +1,164 @@
+{% extends 'base.html.twig' %}
+{% block title %}Historique des scrobbles — Last.fm{% endblock %}
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <a href="{{ path('app_lastfm_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Last.fm</a>
+            <h1 class="text-2xl font-semibold mt-1">Historique des scrobbles</h1>
+            <p class="text-sm text-slate-500">{{ total }} scrobble{{ total != 1 ? 's' : '' }} — page {{ page }} / {{ pages }}</p>
+        </div>
+    </div>
+
+    <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Année</label>
+            <select name="year" class="border rounded-sm px-2 py-1 text-sm w-24">
+                <option value="">—</option>
+                {% for year in available_years %}
+                    <option value="{{ year }}" {% if filters.year == year %}selected{% endif %}>{{ year }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Mois</label>
+            <select name="month" class="border rounded-sm px-2 py-1 text-sm w-20">
+                <option value="">—</option>
+                {% for m in 1..12 %}
+                    {% set mm = '%02d'|format(m) %}
+                    <option value="{{ mm }}" {% if filters.month == mm %}selected{% endif %}>{{ mm }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Jour</label>
+            <select name="day" class="border rounded-sm px-2 py-1 text-sm w-20">
+                <option value="">—</option>
+                {% for d in 1..31 %}
+                    {% set dd = '%02d'|format(d) %}
+                    <option value="{{ dd }}" {% if filters.day == dd %}selected{% endif %}>{{ dd }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Artiste</label>
+            <input type="text" name="artist" value="{{ filters.artist }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Titre</label>
+            <input type="text" name="title" value="{{ filters.title }}" placeholder="Rechercher…"
+                   class="border rounded-sm px-2 py-1 text-sm w-40">
+        </div>
+        <div>
+            <label class="block text-xs uppercase text-slate-500 mb-1">Statut</label>
+            <select name="status" class="border rounded-sm px-2 py-1 text-sm w-32">
+                {% for value, label in {
+                    '': 'Tous',
+                    matched: 'Matché',
+                    unmatched: 'Non matché',
+                    pending: 'En attente',
+                    duplicate: 'Doublon',
+                    skipped: 'Ignoré',
+                } %}
+                    <option value="{{ value }}" {% if filters.status == value %}selected{% endif %}>{{ label }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <a href="{{ path('app_lastfm_scrobbles') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+    </form>
+
+    {% if rows is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun scrobble pour ces filtres.</div>
+    {% else %}
+        {% set status_classes = {
+            matched:   'text-emerald-700 bg-emerald-50',
+            unmatched: 'text-rose-700 bg-rose-50',
+            pending:   'text-slate-600 bg-slate-100',
+            duplicate: 'text-sky-700 bg-sky-50',
+            skipped:   'text-amber-700 bg-amber-50',
+        } %}
+        {% set status_labels = {
+            matched: 'matché', unmatched: 'non matché', pending: 'pending',
+            duplicate: 'doublon', skipped: 'ignoré',
+        } %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-2 py-2 w-6"></th>
+                        <th class="px-2 py-2 w-12 hidden md:table-cell"></th>
+                        <th class="px-3 py-2 text-left">Date</th>
+                        <th class="px-3 py-2 text-left">Artiste</th>
+                        <th class="px-3 py-2 text-left">Album</th>
+                        <th class="px-3 py-2 text-left">Titre</th>
+                        <th class="px-3 py-2 text-left">Statut</th>
+                        <th class="px-3 py-2 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for row in rows %}
+                    {% set effective_status = row.sync_status ?? 'unmatched' %}
+                    {% set lastfm_track = lastfm_track_url(row.artist, row.title) %}
+                    {% set mb_artist = musicbrainz_url('artist', row.mbid_artist) %}
+                    {% set mb_album = musicbrainz_url('release', row.mbid_album) %}
+                    {% set mb_track = musicbrainz_url('recording', row.mbid_track) %}
+                    {% set lidarr_link = effective_status != 'matched'
+                        ? (row.album ? lidarr_album_url(row.artist, row.album) : lidarr_artist_url(row.artist))
+                        : null %}
+                    {% set navidrome_link = effective_status == 'matched' ? navidrome_track_url(row.sync_target_id) : null %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-2 py-1.5 text-center">
+                            {% if row.loved %}<span class="text-rose-500" title="Loved sur Last.fm">♥</span>{% endif %}
+                        </td>
+                        <td class="px-2 py-1.5 hidden md:table-cell">
+                            {% if row.image_url %}
+                                <img src="{{ row.image_url }}" alt="" width="32" height="32" class="rounded-sm" loading="lazy">
+                            {% else %}
+                                <div class="w-8 h-8 rounded-sm bg-slate-100"></div>
+                            {% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 whitespace-nowrap">{{ row.played_at|date('d/m/Y H:i') }}</td>
+                        <td class="px-3 py-1.5">
+                            {{ row.artist }}
+                            {% if mb_artist %}<a href="{{ mb_artist }}" target="_blank" rel="noopener" class="text-xs text-slate-400 hover:text-slate-700" title="MusicBrainz artiste">[MB]</a>{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-slate-500">
+                            {{ row.album ?? '—' }}
+                            {% if row.album and mb_album %}<a href="{{ mb_album }}" target="_blank" rel="noopener" class="text-xs text-slate-400 hover:text-slate-700" title="MusicBrainz album">[MB]</a>{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5">
+                            {{ row.title }}
+                            {% if lastfm_track %}<a href="{{ lastfm_track }}" target="_blank" rel="noopener" class="text-xs text-rose-500 hover:underline" title="Last.fm track">[L]</a>{% endif %}
+                            {% if mb_track %}<a href="{{ mb_track }}" target="_blank" rel="noopener" class="text-xs text-slate-400 hover:text-slate-700" title="MusicBrainz track">[MB]</a>{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5">
+                            <span class="inline-block rounded-sm px-2 py-0.5 text-xs {{ status_classes[effective_status] ?? 'text-slate-600 bg-slate-100' }}"
+                                  {% if row.sync_strategy %}title="stratégie : {{ row.sync_strategy }}"{% endif %}>
+                                {{ status_labels[effective_status] ?? effective_status }}
+                            </span>
+                        </td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            {% if navidrome_link %}
+                                <a href="{{ navidrome_link }}" target="_blank" rel="noopener" class="text-xs text-emerald-700 hover:underline" title="Ouvrir dans Navidrome">▶ Navidrome</a>
+                            {% elseif lidarr_link %}
+                                <a href="{{ lidarr_link }}" target="_blank" rel="noopener" class="text-xs text-emerald-700 hover:underline" title="Chercher dans Lidarr">⇗ Lidarr</a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+
+        {% if pages > 1 %}
+            {% set next_query = filters|merge({ page: page + 1 })|filter(v => v != '') %}
+            {% set prev_query = filters|merge({ page: page - 1 })|filter(v => v != '') %}
+            <div class="flex gap-2 items-center text-sm">
+                {% if page > 1 %}<a href="{{ path('app_lastfm_scrobbles', prev_query) }}" class="px-3 py-1 rounded-sm bg-white border">← Préc.</a>{% endif %}
+                <span class="text-slate-500">Page {{ page }} / {{ pages }}</span>
+                {% if page < pages %}<a href="{{ path('app_lastfm_scrobbles', next_query) }}" class="px-3 py-1 rounded-sm bg-white border">Suiv. →</a>{% endif %}
+            </div>
+        {% endif %}
+    {% endif %}
+{% endblock %}

--- a/tests/Repository/ScrobbleRepositoryFilterTest.php
+++ b/tests/Repository/ScrobbleRepositoryFilterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Repository\ScrobbleRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Focused on the static filter-clause builder — that's the part with real
+ * decision logic (date cascade validation, status NULL handling). The
+ * full COUNT / SELECT paths are exercised in the running app and would
+ * require a fully wired Doctrine EntityManager fixture to test, which is
+ * not the convention here (cf. ScrobbleSyncRepositoryTest pattern).
+ */
+class ScrobbleRepositoryFilterTest extends TestCase
+{
+    public function testEmptyFiltersYieldsEmptyWhere(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses([]);
+        $this->assertSame('', $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testYearAloneFiltersOnYear(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['year' => '2024']);
+        $this->assertSame("strftime('%Y', s.played_at) = ?", $where);
+        $this->assertSame(['2024'], $params);
+    }
+
+    public function testYearPlusMonthFiltersOnYearMonth(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['year' => '2024', 'month' => '06']);
+        $this->assertSame("strftime('%Y-%m', s.played_at) = ?", $where);
+        $this->assertSame(['2024-06'], $params);
+    }
+
+    public function testFullDateFiltersOnYearMonthDay(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses([
+            'year' => '2024', 'month' => '6', 'day' => '15',
+        ]);
+        $this->assertSame("strftime('%Y-%m-%d', s.played_at) = ?", $where);
+        $this->assertSame(['2024-06-15'], $params);
+    }
+
+    public function testDayWithoutMonthAndYearIsIgnored(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['day' => '15']);
+        $this->assertSame('', $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testMonthWithoutYearIsIgnored(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['month' => '06']);
+        $this->assertSame('', $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testGarbageInValuesIsRejected(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses([
+            'year' => 'abcd', 'month' => '13', 'day' => '32',
+        ]);
+        $this->assertSame('', $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testArtistAndTitleFiltersUseCaseInsensitiveLike(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses([
+            'artist' => 'Beyoncé', 'title' => 'Halo',
+        ]);
+        $this->assertSame('LOWER(s.artist) LIKE LOWER(?) AND LOWER(s.title) LIKE LOWER(?)', $where);
+        $this->assertSame(['%Beyoncé%', '%Halo%'], $params);
+    }
+
+    public function testStatusUnmatchedAlsoMatchesScrobblesWithoutSyncRow(): void
+    {
+        // Scrobbles never prepared for navidrome yet have no scrobble_sync
+        // row at all → LEFT JOIN yields ss.status IS NULL. From the user's
+        // perspective they're as good as unmatched, so the unmatched filter
+        // catches both.
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['status' => 'unmatched']);
+        $this->assertSame("(ss.status = 'unmatched' OR ss.status IS NULL)", $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testStatusOtherValuesEmitParameterizedEquality(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['status' => 'matched']);
+        $this->assertSame('ss.status = ?', $where);
+        $this->assertSame(['matched'], $params);
+    }
+
+    public function testStatusAllShortCircuits(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses(['status' => 'all']);
+        $this->assertSame('', $where);
+        $this->assertSame([], $params);
+    }
+
+    public function testCombinedFiltersChainWithAnd(): void
+    {
+        [$where, $params] = ScrobbleRepository::buildFilterClauses([
+            'lastfm_user' => 'alice',
+            'year' => '2024', 'month' => '06',
+            'artist' => 'Daft Punk',
+            'status' => 'matched',
+        ]);
+        $this->assertSame(
+            "s.lastfm_user = ? AND strftime('%Y-%m', s.played_at) = ? AND LOWER(s.artist) LIKE LOWER(?) AND ss.status = ?",
+            $where,
+        );
+        $this->assertSame(['alice', '2024-06', '%Daft Punk%', 'matched'], $params);
+    }
+}

--- a/tests/Service/DisparityStatsServiceTest.php
+++ b/tests/Service/DisparityStatsServiceTest.php
@@ -113,11 +113,12 @@ class DisparityStatsServiceTest extends TestCase
         $service = $this->makeService('2024-01', $lastfm, $navi);
         $r = $service->compute();
 
-        $byYear = array_column($r['by_year'], null, 'year');
-        $this->assertArrayHasKey('2024', $byYear);
-        $this->assertArrayHasKey('2025', $byYear);
-        $this->assertSame(600, $byYear['2024']['gap']);
-        $this->assertSame(1000, $byYear['2025']['gap']);
+        $gapByYear = [];
+        foreach ($r['by_year'] as $row) {
+            $gapByYear[$row['year']] = $row['gap'];
+        }
+        $this->assertSame(600, $gapByYear['2024'] ?? null);
+        $this->assertSame(1000, $gapByYear['2025'] ?? null);
         // 2025 has bigger gap → first.
         $this->assertSame('2025', $r['by_year'][0]['year']);
     }

--- a/tests/Twig/LidarrExtensionTest.php
+++ b/tests/Twig/LidarrExtensionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Twig;
+
+use App\Twig\LidarrExtension;
+use PHPUnit\Framework\TestCase;
+
+class LidarrExtensionTest extends TestCase
+{
+    public function testReturnsNullWhenLidarrUrlIsEmpty(): void
+    {
+        $ext = new LidarrExtension('');
+
+        $this->assertNull($ext->artistUrl('Beyoncé'));
+        $this->assertNull($ext->albumUrl('Beyoncé', 'Lemonade'));
+    }
+
+    public function testReturnsNullWhenArtistIsEmpty(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local');
+
+        $this->assertNull($ext->artistUrl('   '));
+        $this->assertNull($ext->albumUrl('', 'Some album'));
+    }
+
+    public function testArtistUrlEncodesAccentsAndSpaces(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local');
+
+        $this->assertSame(
+            'https://lidarr.local/add/new?term=Sigur%20R%C3%B3s',
+            $ext->artistUrl('Sigur Rós'),
+        );
+    }
+
+    public function testTrailingSlashOnLidarrUrlIsStripped(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local/');
+
+        $this->assertSame(
+            'https://lidarr.local/add/new?term=Foo',
+            $ext->artistUrl('Foo'),
+        );
+    }
+
+    public function testAlbumUrlCombinesArtistAndAlbumInOneSearchTerm(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local');
+
+        $this->assertSame(
+            'https://lidarr.local/add/new?term=Daft%20Punk%20Discovery',
+            $ext->albumUrl('Daft Punk', 'Discovery'),
+        );
+    }
+
+    public function testAlbumUrlFallsBackToArtistOnlyWhenAlbumEmpty(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local');
+
+        $this->assertSame(
+            'https://lidarr.local/add/new?term=Daft%20Punk',
+            $ext->albumUrl('Daft Punk', ''),
+        );
+    }
+
+    public function testRegistersTwoFunctions(): void
+    {
+        $ext = new LidarrExtension('https://lidarr.local');
+        $names = array_map(static fn ($f) => $f->getName(), $ext->getFunctions());
+
+        $this->assertSame(['lidarr_artist_url', 'lidarr_album_url'], $names);
+    }
+
+    public function testNullLidarrUrlIsToleratedFromEnvDefault(): void
+    {
+        // Symfony's default:: env processor resolves to null when LIDARR_URL
+        // isn't set at all — the ctor must accept that without crashing.
+        $ext = new LidarrExtension(null);
+
+        $this->assertNull($ext->artistUrl('Anyone'));
+    }
+}

--- a/tests/Twig/ScrobbleLinksExtensionTest.php
+++ b/tests/Twig/ScrobbleLinksExtensionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Tests\Twig;
+
+use App\Twig\ScrobbleLinksExtension;
+use PHPUnit\Framework\TestCase;
+
+class ScrobbleLinksExtensionTest extends TestCase
+{
+    public function testLastFmTrackUrlUsesPlusForSpacesAndKeepsAccents(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+
+        $this->assertSame(
+            'https://www.last.fm/music/Daft+Punk/_/Around+the+World',
+            $ext->lastFmTrackUrl('Daft Punk', 'Around the World'),
+        );
+        $this->assertSame(
+            'https://www.last.fm/music/Sigur+R%C3%B3s/_/Hopp%C3%ADpolla',
+            $ext->lastFmTrackUrl('Sigur Rós', 'Hoppípolla'),
+        );
+    }
+
+    public function testLastFmTrackUrlReturnsNullOnMissingPart(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+
+        $this->assertNull($ext->lastFmTrackUrl('', 'Title'));
+        $this->assertNull($ext->lastFmTrackUrl('Artist', '   '));
+    }
+
+    public function testLastFmArtistUrl(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+
+        $this->assertSame('https://www.last.fm/music/AC%2FDC', $ext->lastFmArtistUrl('AC/DC'));
+        $this->assertNull($ext->lastFmArtistUrl(''));
+    }
+
+    public function testMusicbrainzUrlForKnownTypes(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+        $mbid = 'b10bbbfc-cf9e-42e0-be17-e2c3e1d2600d';
+
+        $this->assertSame('https://musicbrainz.org/artist/' . $mbid, $ext->musicbrainzUrl('artist', $mbid));
+        $this->assertSame('https://musicbrainz.org/release/' . $mbid, $ext->musicbrainzUrl('release', $mbid));
+        $this->assertSame('https://musicbrainz.org/recording/' . $mbid, $ext->musicbrainzUrl('recording', $mbid));
+    }
+
+    public function testMusicbrainzUrlNullWhenMbidEmptyOrTypeUnknown(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+
+        $this->assertNull($ext->musicbrainzUrl('artist', null));
+        $this->assertNull($ext->musicbrainzUrl('artist', ''));
+        $this->assertNull($ext->musicbrainzUrl('artist', '   '));
+        $this->assertNull($ext->musicbrainzUrl('label', 'some-mbid'));
+    }
+
+    public function testNavidromeTrackUrlReturnsNullWhenBaseOrIdMissing(): void
+    {
+        $this->assertNull((new ScrobbleLinksExtension(''))->navidromeTrackUrl('media-1'));
+        $this->assertNull((new ScrobbleLinksExtension('https://navi.local'))->navidromeTrackUrl(null));
+        $this->assertNull((new ScrobbleLinksExtension('https://navi.local'))->navidromeTrackUrl('   '));
+    }
+
+    public function testNavidromeTrackUrlBuildsHashRouteAndStripsTrailingSlash(): void
+    {
+        $ext = new ScrobbleLinksExtension('https://navi.local/');
+
+        $this->assertSame(
+            'https://navi.local/app/#/song/abc-123/show',
+            $ext->navidromeTrackUrl('abc-123'),
+        );
+    }
+
+    public function testRegistersFourFunctions(): void
+    {
+        $ext = new ScrobbleLinksExtension('');
+        $names = array_map(static fn ($f) => $f->getName(), $ext->getFunctions());
+
+        $this->assertSame(
+            ['lastfm_track_url', 'lastfm_artist_url', 'musicbrainz_url', 'navidrome_track_url'],
+            $names,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Nouvelle route **`GET /lastfm/scrobbles`** exposée dans la dropdown Last.fm (sous **Scrobbles**, après *Stats*). Outil de diagnostic indépendant de `/lastfm/stats` : navigation de toute la base de scrobbles avec filtres et statut de matching Navidrome par ligne.

### Filtres (GET, cascade)

| Filtre | Effet |
|---|---|
| `year=YYYY` | peuplé depuis les années réellement présentes |
| `month=MM` | ignoré sans `year` |
| `day=DD` | ignoré sans `year`+`month` |
| `artist` / `title` | LIKE case-insensitive |
| `status` | `tous` / `matched` / `unmatched` / `pending` / `duplicate` / `skipped`. `unmatched` englobe aussi les scrobbles **sans** `scrobble_sync` (jamais préparés) — c'est cohérent avec ce que voit l'utilisateur. |

Pagination 100 par page sur `?page=N`.

### Pipeline

- `ScrobbleRepository::findRecentWithSyncStatus` via `LEFT JOIN scrobble_sync ON target = 'navidrome'` — surface `status`, `strategy`, `target_id` aux côtés des champs du scrobble. Trié `played_at DESC` (index `idx_scrobble_played_at` déjà en place).
- `countWithFilters` ne joint que si le filtre `status` l'exige (préserve le chemin indexé pour le COUNT sans filtre statut).
- `availableYears` alimente le `<select>` année.

### Liens externes — zéro appel API

| Helper Twig | URL |
|---|---|
| `lastfm_track_url(artist, title)` | `https://www.last.fm/music/{artist}/_/{title}` |
| `lastfm_artist_url(artist)` | `https://www.last.fm/music/{artist}` |
| `musicbrainz_url(type, mbid)` | `artist` / `release` / `release-group` / `recording` |
| `navidrome_track_url(id)` | `{NAVIDROME_URL}/app/#/song/{id}/show` |
| `lidarr_artist_url(artist)` / `lidarr_album_url(artist, album)` | re-création de l'extension dropée à PR #177 |

Tous retournent `null` quand l'input ou la base est vide → les `{% if %}` du template cachent simplement l'icône.

### Affichage par ligne

♥ loved · pochette (32×32) · date+heure · artiste [MB?] · album [MB?] · titre [L] [MB?] · pastille statut colorée (tooltip = stratégie) · action contextuelle (▶ Navidrome si matched, ⇗ Lidarr sinon).

### Wiring

- `LIDARR_URL` ajouté à `.env.dist` (vide par défaut), param `lidarr.url` dans `services.yaml`.
- Deux services Twig tagués `twig.extension`, le `ScrobbleLinksExtension` bindé sur `navidrome.url`.

## Test plan

- [x] `composer phpcs` → vert (131 fichiers + nouveaux)
- [x] `phpunit` → 103 tests / 328 assertions, tous verts (28 nouveaux : 8 + 8 + 12)
- [x] `lint:twig` → 2 templates valides
- [x] `debug:router | grep app_lastfm_scrobbles` → la route apparaît
- [ ] Visite manuelle : navbar dropdown Last.fm → Scrobbles, les 100 derniers s'affichent avec pochettes
- [ ] Filtre `year=2024&month=06` → range correct ; ajouter `day=15`, idem ; `day=15` seul → silently ignoré
- [ ] Filtre `status=unmatched` → englobe bien les scrobbles encore jamais préparés (sans `scrobble_sync`)
- [ ] Sans `LIDARR_URL` → les boutons ⇗ Lidarr disparaissent ; renseigner et recharger → ils apparaissent
- [ ] Bouton ▶ Navidrome sur un scrobble matché → ouvre `{NAVIDROME_URL}/app/#/song/<id>/show`

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_