### PR TITLE
feat(web): bouton ⇗ Lidarr sur la page /navidrome/unmatched

### DIFF
--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -57,13 +57,19 @@
             </thead>
             <tbody class="divide-y">
             {% for row in rows %}
+                {% set lidarr = row.album ? lidarr_album_url(row.artist, row.album) : lidarr_artist_url(row.artist) %}
                 <tr class="hover:bg-slate-50">
                     <td class="px-3 py-1.5">{{ row.artist }}</td>
                     <td class="px-3 py-1.5">{{ row.title }}</td>
                     <td class="px-3 py-1.5 text-slate-400 text-xs">{{ row.album ?? '—' }}</td>
                     <td class="px-3 py-1.5 text-right font-mono">{{ row.count }}</td>
                     <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ row.last_played_at|date('d/m/Y') }}</td>
-                    <td class="px-3 py-1.5 text-right">
+                    <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                        {% if lidarr %}
+                            <a href="{{ lidarr }}" target="_blank" rel="noopener"
+                               class="text-xs text-emerald-700 hover:underline mr-2"
+                               title="Chercher dans Lidarr">⇗ Lidarr</a>
+                        {% endif %}
                         <a href="{{ path('app_lastfm_alias_new', {artist: row.artist, title: row.title}) }}"
                            class="text-xs text-sky-700 hover:underline">✏️ Alias</a>
                     </td>


### PR DESCRIPTION
## Summary

Ajoute le bouton **⇗ Lidarr** dans la colonne *Actions* de `/navidrome/unmatched`, à gauche du bouton « ✏️ Alias » existant.

Réutilise sans nouveau code :
- `lidarr_album_url(artist, album)` quand le scrobble a un album renseigné.
- `lidarr_artist_url(artist)` en fallback sinon.

Les deux helpers sont déjà exposés par `LidarrExtension` (ajouté dans PR #179). Quand `LIDARR_URL` est vide, les helpers retournent `null` et le `{% if lidarr %}` cache simplement le bouton — comportement cohérent avec `/lastfm/scrobbles`.

Aucune logique métier touchée, juste 7 lignes de Twig.

## Test plan

- [x] `lint:twig` → vert
- [ ] `LIDARR_URL` configuré : la page `/navidrome/unmatched` affiche un bouton ⇗ Lidarr par ligne, cliquable, qui ouvre l'écran *Add new* pré-rempli
- [ ] `LIDARR_URL` vide : seul le bouton ✏️ Alias reste visible (pas de cadre vide ni d'erreur)
- [ ] Scrobble avec album → l'URL Lidarr embarque artiste + album ; sans album → artiste seul

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_