### PR TITLE
feat(web): pages top artistes Last.fm + Navidrome avec filtres date

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -163,6 +163,10 @@ services:
         arguments:
             $defaultUser: '%lastfm.user%'
 
+    App\Controller\LastFmTopArtistsController:
+        arguments:
+            $defaultUser: '%lastfm.user%'
+
     App\Controller\StatsController:
         arguments:
             $defaultUser: '%lastfm.user%'

--- a/src/Controller/LastFmTopArtistsController.php
+++ b/src/Controller/LastFmTopArtistsController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Controller;
+
+use App\Filter\DateCascadeFilter;
+use App\Repository\ScrobbleRepository;
+use App\Service\LastFmStatsService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Top 100 artists by Last.fm scrobble volume, with per-artist first /
+ * last play. Filterable on a year / month / day cascade — same UX as
+ * `/lastfm/scrobbles` and the Navidrome counterpart. Reads only the
+ * tools DB.
+ */
+class LastFmTopArtistsController extends AbstractController
+{
+    private const TOP_N = 100;
+
+    public function __construct(
+        private readonly string $defaultUser,
+    ) {
+    }
+
+    #[Route('/lastfm/top-artists', name: 'app_lastfm_top_artists', methods: ['GET'])]
+    public function index(Request $request, LastFmStatsService $stats, ScrobbleRepository $scrobbles): Response
+    {
+        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
+        $cascade = DateCascadeFilter::parse(
+            $request->query->get('year'),
+            $request->query->get('month'),
+            $request->query->get('day'),
+        );
+
+        $rows = $stats->topArtistsWithDates(
+            $user,
+            $cascade['year'],
+            $cascade['month'],
+            $cascade['day'],
+            self::TOP_N,
+        );
+
+        return $this->render('lastfm/top_artists.html.twig', [
+            'rows' => $rows,
+            'top_n' => self::TOP_N,
+            'available_years' => $scrobbles->availableYears($user),
+            'filters' => [
+                'year' => $cascade['year'] !== null ? (string) $cascade['year'] : '',
+                'month' => $cascade['month'] !== null ? sprintf('%02d', $cascade['month']) : '',
+                'day' => $cascade['day'] !== null ? sprintf('%02d', $cascade['day']) : '',
+            ],
+        ]);
+    }
+}

--- a/src/Controller/NavidromeTopArtistsController.php
+++ b/src/Controller/NavidromeTopArtistsController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Controller;
+
+use App\Filter\DateCascadeFilter;
+use App\Navidrome\NavidromeRepository;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Top 100 artists ranked by Navidrome plays, with per-artist first /
+ * last play. Filterable on a year / month / day cascade — same UX as
+ * `/lastfm/scrobbles`. Reads only the Navidrome `scrobbles` table
+ * (read-only).
+ */
+class NavidromeTopArtistsController extends AbstractController
+{
+    private const TOP_N = 100;
+
+    #[Route('/navidrome/top-artists', name: 'app_navidrome_top_artists', methods: ['GET'])]
+    public function index(Request $request, NavidromeRepository $navidrome): Response
+    {
+        $cascade = DateCascadeFilter::parse(
+            $request->query->get('year'),
+            $request->query->get('month'),
+            $request->query->get('day'),
+        );
+
+        $rows = $navidrome->getTopArtistsWithDates(
+            $cascade['year'],
+            $cascade['month'],
+            $cascade['day'],
+            self::TOP_N,
+        );
+
+        return $this->render('navidrome/top_artists.html.twig', [
+            'rows' => $rows,
+            'top_n' => self::TOP_N,
+            'available_years' => $navidrome->getAvailableScrobbleYears(),
+            'filters' => [
+                'year' => $cascade['year'] !== null ? (string) $cascade['year'] : '',
+                'month' => $cascade['month'] !== null ? sprintf('%02d', $cascade['month']) : '',
+                'day' => $cascade['day'] !== null ? sprintf('%02d', $cascade['day']) : '',
+            ],
+        ]);
+    }
+}

--- a/src/Filter/DateCascadeFilter.php
+++ b/src/Filter/DateCascadeFilter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filter;
+
+/**
+ * Validates the year / month / day cascade used by the scrobble history
+ * and top-artist pages : `day` requires `month`+`year`, `month` requires
+ * `year`. Garbage in is silently ignored — we'd rather show the unfiltered
+ * default than 500 on a malformed query string.
+ *
+ * Returns the three components as `?int` so callers can build SQL clauses
+ * without re-parsing.
+ */
+final class DateCascadeFilter
+{
+    /**
+     * @return array{year: ?int, month: ?int, day: ?int}
+     */
+    public static function parse(mixed $year, mixed $month, mixed $day): array
+    {
+        $y = self::asYear($year);
+        $m = $y !== null ? self::asMonth($month) : null;
+        $d = $m !== null ? self::asDay($day) : null;
+
+        return ['year' => $y, 'month' => $m, 'day' => $d];
+    }
+
+    private static function asYear(mixed $v): ?int
+    {
+        if (!is_string($v) || !preg_match('/^\d{4}$/', $v)) {
+            return null;
+        }
+
+        return (int) $v;
+    }
+
+    private static function asMonth(mixed $v): ?int
+    {
+        if (!is_string($v) || !preg_match('/^\d{1,2}$/', $v)) {
+            return null;
+        }
+        $n = (int) $v;
+
+        return $n >= 1 && $n <= 12 ? $n : null;
+    }
+
+    private static function asDay(mixed $v): ?int
+    {
+        if (!is_string($v) || !preg_match('/^\d{1,2}$/', $v)) {
+            return null;
+        }
+        $n = (int) $v;
+
+        return $n >= 1 && $n <= 31 ? $n : null;
+    }
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -760,6 +760,98 @@ class NavidromeRepository
     }
 
     /**
+     * Top artists ranked by play volume on a year / month / day cascade.
+     * Returns the artist's first and last play in the chosen window as
+     * `YYYY-MM-DD HH:MM:SS` strings (built from `submission_time` unix
+     * epoch via `datetime(..., 'unixepoch')`) so the consumer can format
+     * them directly.
+     *
+     * Feeds the `/navidrome/top-artists` page. Reads the Navidrome
+     * `scrobbles` table only; falls back to `[]` when it's not available
+     * (Navidrome &lt; 0.55 — the `annotation`-based count has no per-play
+     * timestamps, so the page is meaningless there).
+     *
+     * @return list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}>
+     */
+    public function getTopArtistsWithDates(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = "SELECT mf.artist AS artist,
+                       COUNT(*) AS plays,
+                       datetime(MIN(s.submission_time), 'unixepoch') AS first_played_at,
+                       datetime(MAX(s.submission_time), 'unixepoch') AS last_played_at
+                FROM scrobbles s
+                JOIN media_file mf ON mf.id = s.media_file_id
+                WHERE s.user_id = :uid AND mf.artist != ''";
+        $params = ['uid' => $userId, 'lim' => $limit];
+        $types = ['lim' => \Doctrine\DBAL\ParameterType::INTEGER];
+
+        if ($year !== null) {
+            if ($day !== null && $month !== null) {
+                $sql .= " AND strftime('%Y-%m-%d', s.submission_time, 'unixepoch') = :ymd";
+                $params['ymd'] = sprintf('%04d-%02d-%02d', $year, $month, $day);
+            } elseif ($month !== null) {
+                $sql .= " AND strftime('%Y-%m', s.submission_time, 'unixepoch') = :ym";
+                $params['ym'] = sprintf('%04d-%02d', $year, $month);
+            } else {
+                $sql .= " AND strftime('%Y', s.submission_time, 'unixepoch') = :y";
+                $params['y'] = (string) $year;
+            }
+        }
+
+        $sql .= ' GROUP BY mf.artist ORDER BY plays DESC, artist ASC LIMIT :lim';
+
+        $rows = $this->connection()->fetchAllAssociative($sql, $params, $types);
+
+        return array_map(
+            static fn (array $r) => [
+                'artist' => (string) $r['artist'],
+                'plays' => (int) $r['plays'],
+                'first_played_at' => (string) ($r['first_played_at'] ?? ''),
+                'last_played_at' => (string) ($r['last_played_at'] ?? ''),
+            ],
+            $rows,
+        );
+    }
+
+    /**
+     * Distinct years (YYYY, descending) actually present in Navidrome's
+     * `scrobbles` table for the resolved user. Feeds the year `<select>`
+     * of the top-artists page. Returns `[]` when scrobbles aren't tracked
+     * yet.
+     *
+     * @return list<string>
+     */
+    public function getAvailableScrobbleYears(): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT strftime('%Y', submission_time, 'unixepoch') AS y
+             FROM scrobbles WHERE user_id = :uid
+             ORDER BY y DESC",
+            ['uid' => $userId],
+        );
+
+        $out = [];
+        foreach ($rows as $r) {
+            $year = (string) $r['y'];
+            if ($year !== '') {
+                $out[] = $year;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
      * Top tracks (with full metadata) by aggregated plays in [from, to).
      * Pass null/null for all-time.
      *

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -404,6 +404,59 @@ class LastFmStatsService
     }
 
     /**
+     * Top artists by play volume on a year / month / day cascade, with
+     * the artist's first and last scrobble inside the window (both as
+     * `YYYY-MM-DD HH:MM:SS` strings from `played_at`). Feeds the
+     * `/lastfm/top-artists` page.
+     *
+     * @return list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}>
+     */
+    public function topArtistsWithDates(
+        ?string $user,
+        ?int $year,
+        ?int $month,
+        ?int $day,
+        int $limit,
+    ): array {
+        [$where, $params] = $this->buildWhere($user);
+        $clauses = ["artist != ''"];
+        if ($where !== '') {
+            $clauses[] = $where;
+        }
+        if ($year !== null) {
+            if ($day !== null && $month !== null) {
+                $clauses[] = "strftime('%Y-%m-%d', played_at) = :ymd";
+                $params['ymd'] = sprintf('%04d-%02d-%02d', $year, $month, $day);
+            } elseif ($month !== null) {
+                $clauses[] = "strftime('%Y-%m', played_at) = :ym";
+                $params['ym'] = sprintf('%04d-%02d', $year, $month);
+            } else {
+                $clauses[] = "strftime('%Y', played_at) = :y";
+                $params['y'] = (string) $year;
+            }
+        }
+        $sql = 'SELECT artist,
+                       COUNT(*) AS plays,
+                       MIN(played_at) AS first_played_at,
+                       MAX(played_at) AS last_played_at
+                FROM scrobbles WHERE ' . implode(' AND ', $clauses)
+            . ' GROUP BY artist ORDER BY plays DESC, artist ASC LIMIT ' . max(1, $limit);
+
+        /** @var list<array{artist: string, plays: int, first_played_at: ?string, last_played_at: ?string}> $rows */
+        $rows = $this->connection->fetchAllAssociative($sql, $params);
+
+        return array_map(
+            static fn (array $r): array => [
+                'artist' => (string) $r['artist'],
+                'plays' => (int) $r['plays'],
+                'first_played_at' => (string) ($r['first_played_at'] ?? ''),
+                'last_played_at' => (string) ($r['last_played_at'] ?? ''),
+            ],
+            $rows,
+        );
+    }
+
+    /**
      * @return list<array{artist: string, title: string, album: ?string, plays: int}>
      */
     private function topTracks(?string $user, int $limit): array

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -14,6 +14,7 @@
             { label: 'Import', route: 'app_lastfm_import' },
             { label: 'Stats', route: 'app_lastfm_stats' },
             { label: 'Scrobbles', route: 'app_lastfm_scrobbles' },
+            { label: 'Top artistes', route: 'app_lastfm_top_artists' },
         ]},
         { heading: 'Aliases', items: [
             { label: 'Tracks', route: 'app_lastfm_alias_index' },
@@ -25,6 +26,7 @@
             { label: 'Sync', route: 'app_navidrome_sync' },
             { label: 'Unmatched', route: 'app_navidrome_unmatched' },
             { label: 'Stats', route: 'app_navidrome_stats' },
+            { label: 'Top artistes', route: 'app_navidrome_top_artists' },
         ]},
     ]},
     { type: 'dropdown', label: 'Strawberry', width: 'w-56', groups: [

--- a/templates/_top_artists_filter_form.html.twig
+++ b/templates/_top_artists_filter_form.html.twig
@@ -1,0 +1,35 @@
+{# Filter form shared by /navidrome/top-artists and /lastfm/top-artists.
+   Caller passes `route` (Symfony route name to submit / reset to). #}
+<form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+    <div>
+        <label class="block text-xs uppercase text-slate-500 mb-1">Année</label>
+        <select name="year" class="border rounded-sm px-2 py-1 text-sm w-24">
+            <option value="">—</option>
+            {% for year in available_years %}
+                <option value="{{ year }}" {% if filters.year == year %}selected{% endif %}>{{ year }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label class="block text-xs uppercase text-slate-500 mb-1">Mois</label>
+        <select name="month" class="border rounded-sm px-2 py-1 text-sm w-20">
+            <option value="">—</option>
+            {% for m in 1..12 %}
+                {% set mm = '%02d'|format(m) %}
+                <option value="{{ mm }}" {% if filters.month == mm %}selected{% endif %}>{{ mm }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <div>
+        <label class="block text-xs uppercase text-slate-500 mb-1">Jour</label>
+        <select name="day" class="border rounded-sm px-2 py-1 text-sm w-20">
+            <option value="">—</option>
+            {% for d in 1..31 %}
+                {% set dd = '%02d'|format(d) %}
+                <option value="{{ dd }}" {% if filters.day == dd %}selected{% endif %}>{{ dd }}</option>
+            {% endfor %}
+        </select>
+    </div>
+    <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+    <a href="{{ path(route) }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
+</form>

--- a/templates/lastfm/top_artists.html.twig
+++ b/templates/lastfm/top_artists.html.twig
@@ -1,0 +1,60 @@
+{% extends 'base.html.twig' %}
+{% block title %}Top artistes — Last.fm{% endblock %}
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <a href="{{ path('app_lastfm_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Last.fm</a>
+            <h1 class="text-2xl font-semibold mt-1">Top artistes — Last.fm</h1>
+            <p class="text-sm text-slate-500">Top {{ top_n }} artistes par scrobbles sur la base outils.</p>
+        </div>
+        <div class="flex gap-2 text-xs">
+            <a href="{{ path('app_navidrome_top_artists') }}" class="text-sky-700 hover:underline self-center">
+                Voir côté Navidrome →
+            </a>
+        </div>
+    </div>
+
+    {% include '_top_artists_filter_form.html.twig' with { route: 'app_lastfm_top_artists' } only %}
+
+    {% if rows is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucun scrobble pour ces filtres.</div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-3 py-2 text-right w-12">#</th>
+                        <th class="px-3 py-2 text-left">Artiste</th>
+                        <th class="px-3 py-2 text-right">Scrobbles</th>
+                        <th class="px-3 py-2 text-left">Premier</th>
+                        <th class="px-3 py-2 text-left">Dernier</th>
+                        <th class="px-3 py-2 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for row in rows %}
+                    {% set lidarr = lidarr_artist_url(row.artist) %}
+                    {% set lastfm = lastfm_artist_url(row.artist) %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 text-right font-mono text-xs text-slate-400">{{ loop.index }}</td>
+                        <td class="px-3 py-1.5 font-medium">
+                            {{ row.artist }}
+                            {% if lastfm %}<a href="{{ lastfm }}" target="_blank" rel="noopener" class="text-xs text-rose-500 hover:underline" title="Last.fm artiste">[L]</a>{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-right font-mono">{{ row.plays|number_format(0, '.', ' ') }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 whitespace-nowrap">{{ row.first_played_at ? row.first_played_at|date('d/m/Y H:i') : '—' }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 whitespace-nowrap">{{ row.last_played_at ? row.last_played_at|date('d/m/Y H:i') : '—' }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            {% if lidarr %}
+                                <a href="{{ lidarr }}" target="_blank" rel="noopener"
+                                   class="text-xs text-emerald-700 hover:underline"
+                                   title="Chercher dans Lidarr">⇗ Lidarr</a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/navidrome/top_artists.html.twig
+++ b/templates/navidrome/top_artists.html.twig
@@ -1,0 +1,60 @@
+{% extends 'base.html.twig' %}
+{% block title %}Top artistes — Navidrome{% endblock %}
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <a href="{{ path('app_navidrome_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Navidrome</a>
+            <h1 class="text-2xl font-semibold mt-1">Top artistes — Navidrome</h1>
+            <p class="text-sm text-slate-500">Top {{ top_n }} artistes par lectures sur la base Navidrome.</p>
+        </div>
+        <div class="flex gap-2 text-xs">
+            <a href="{{ path('app_lastfm_top_artists') }}" class="text-sky-700 hover:underline self-center">
+                Voir côté Last.fm →
+            </a>
+        </div>
+    </div>
+
+    {% include '_top_artists_filter_form.html.twig' with { route: 'app_navidrome_top_artists' } only %}
+
+    {% if rows is empty %}
+        <div class="bg-white rounded-sm p-6 text-center text-slate-500">Aucune lecture pour ces filtres.</div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-4">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-3 py-2 text-right w-12">#</th>
+                        <th class="px-3 py-2 text-left">Artiste</th>
+                        <th class="px-3 py-2 text-right">Lectures</th>
+                        <th class="px-3 py-2 text-left">Première</th>
+                        <th class="px-3 py-2 text-left">Dernière</th>
+                        <th class="px-3 py-2 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                {% for row in rows %}
+                    {% set lidarr = lidarr_artist_url(row.artist) %}
+                    <tr class="hover:bg-slate-50">
+                        <td class="px-3 py-1.5 text-right font-mono text-xs text-slate-400">{{ loop.index }}</td>
+                        <td class="px-3 py-1.5 font-medium">
+                            {{ row.artist }}
+                            {% set lastfm = lastfm_artist_url(row.artist) %}
+                            {% if lastfm %}<a href="{{ lastfm }}" target="_blank" rel="noopener" class="text-xs text-rose-500 hover:underline" title="Last.fm artiste">[L]</a>{% endif %}
+                        </td>
+                        <td class="px-3 py-1.5 text-right font-mono">{{ row.plays|number_format(0, '.', ' ') }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 whitespace-nowrap">{{ row.first_played_at ? row.first_played_at|date('d/m/Y H:i') : '—' }}</td>
+                        <td class="px-3 py-1.5 text-xs text-slate-500 whitespace-nowrap">{{ row.last_played_at ? row.last_played_at|date('d/m/Y H:i') : '—' }}</td>
+                        <td class="px-3 py-1.5 text-right whitespace-nowrap">
+                            {% if lidarr %}
+                                <a href="{{ lidarr }}" target="_blank" rel="noopener"
+                                   class="text-xs text-emerald-700 hover:underline"
+                                   title="Chercher dans Lidarr">⇗ Lidarr</a>
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Filter/DateCascadeFilterTest.php
+++ b/tests/Filter/DateCascadeFilterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Tests\Filter;
+
+use App\Filter\DateCascadeFilter;
+use PHPUnit\Framework\TestCase;
+
+class DateCascadeFilterTest extends TestCase
+{
+    public function testAllNullWhenNothingProvided(): void
+    {
+        $this->assertSame(
+            ['year' => null, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse(null, null, null),
+        );
+    }
+
+    public function testYearAloneIsKept(): void
+    {
+        $this->assertSame(
+            ['year' => 2024, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse('2024', null, null),
+        );
+    }
+
+    public function testYearPlusMonth(): void
+    {
+        $this->assertSame(
+            ['year' => 2024, 'month' => 6, 'day' => null],
+            DateCascadeFilter::parse('2024', '06', null),
+        );
+    }
+
+    public function testFullCascade(): void
+    {
+        $this->assertSame(
+            ['year' => 2024, 'month' => 6, 'day' => 15],
+            DateCascadeFilter::parse('2024', '6', '15'),
+        );
+    }
+
+    public function testMonthIgnoredWithoutYear(): void
+    {
+        $this->assertSame(
+            ['year' => null, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse(null, '06', null),
+        );
+    }
+
+    public function testDayIgnoredWithoutMonth(): void
+    {
+        $this->assertSame(
+            ['year' => 2024, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse('2024', null, '15'),
+        );
+    }
+
+    public function testGarbageDateValuesRejected(): void
+    {
+        $this->assertSame(
+            ['year' => null, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse('abcd', '13', '32'),
+        );
+    }
+
+    public function testNonStringValuesRejected(): void
+    {
+        $this->assertSame(
+            ['year' => null, 'month' => null, 'day' => null],
+            DateCascadeFilter::parse(2024, 6, 15),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Deux nouvelles pages symétriques :

- **`/navidrome/top-artists`** — top 100 artistes par lectures (table `scrobbles` Navidrome), avec première et dernière écoute.
- **`/lastfm/top-artists`** — top 100 artistes par scrobbles (table `scrobbles` outils), idem.

Filtres GET en cascade **année → mois → jour** (même UX que `/lastfm/scrobbles`). Validation silencieuse : `month` sans `year` ignoré, `day` sans `month` ignoré, valeurs hors plage rejetées (regex stricte, bornes 1-12 et 1-31).

### Pipeline

- **`src/Filter/DateCascadeFilter`** — helper static qui valide et renvoie un triplet `(?int year, ?int month, ?int day)`. Source de vérité unique partagée par les deux controllers.
- **`LastFmStatsService::topArtistsWithDates(user, y, m, d, limit)`** — `SELECT GROUP BY artist` + `MIN/MAX(played_at)`, clauses date via `strftime` sur `played_at`.
- **`NavidromeRepository::getTopArtistsWithDates(y, m, d, limit)`** — équivalent côté Navidrome avec `datetime(submission_time, 'unixepoch')` pour first/last et `strftime` côté WHERE. Renvoie `[]` si Navidrome est en mode pré-0.55 (annotation seul, pas de per-play timestamps).
- **`NavidromeRepository::getAvailableScrobbleYears()`** pour peupler le `<select>` année côté Navidrome (pendant de `ScrobbleRepository::availableYears()` qui existe déjà pour Last.fm).

### UI

Templates `lastfm/top_artists.html.twig` et `navidrome/top_artists.html.twig` partagent leur formulaire de filtre via `_top_artists_filter_form.html.twig` (route passée en argument). Tableau : rang, artiste (+ icône Last.fm), lectures, première, dernière, bouton ⇗ Lidarr quand `LIDARR_URL` est configuré, et cross-link vers l'autre source en haut.

Navbar : entrée **« Top artistes »** ajoutée dans les dropdowns Last.fm et Navidrome.

## Suite

Top albums et top morceaux à venir dans une PR séparée — même pattern.

## Test plan

- [x] `composer phpcs` → vert (135 fichiers)
- [x] `phpunit` → 111 tests / 335 assertions, tous verts (8 nouveaux dans `DateCascadeFilterTest`)
- [x] `phpstan` → 10 erreurs **pré-existantes** identiques à `develop`, rien sur le nouveau code
- [x] `lint:twig` → 4 templates valides
- [x] `debug:router` → les 2 nouvelles routes apparaissent
- [ ] Visite : navbar Last.fm → Top artistes, filtre `year=2024&month=06` → tri par scrobbles décroissant, première/dernière du mois affichées
- [ ] Navidrome → Top artistes même test
- [ ] Filtre vide → top 100 all-time
- [ ] Sans `LIDARR_URL` → boutons cachés
- [ ] Navidrome &lt; 0.55 / sans scrobbles → page vide cohérente

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_