### PR TITLE
feat: page /help + fix annotation.play_count au sync + doc wipe/ré-import

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -69,6 +69,13 @@ BACKUP_RETENTION_DAYS=7
 RUN_HISTORY_RETENTION_DAYS=90
 ###< Run history ###
 
+###> Help page ###
+# Name of the docker compose service running this app — surfaced on the
+# /help page in the `docker compose exec <service> php bin/console …`
+# snippets so they can be copy-pasted as-is.
+HELP_COMPOSE_SERVICE=navidrome-tools-web
+###< Help page ###
+
 ###> Notifications ###
 NOTIFY_DRIVERS=
 NOTIFY_ON=error

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ pour que les compteurs de lecture reflètent l'historique Last.fm.
 - [Interface web](#interface-web)
 - [Commandes console](#commandes-console)
 - [Workflow type](#workflow-type)
+- [Wipe complet + ré-import](#wipe-complet--ré-import)
 - [Le matching en détail](#le-matching-en-détail)
 - [Développement](#développement)
 
@@ -226,6 +227,7 @@ Authentification par utilisateur unique (`APP_AUTH_USER` / `APP_AUTH_PASSWORD`).
 | `/lastfm/aliases`, `/lastfm/artist-aliases` | gestion des alias (piste / artiste) |
 | `/navidrome/container/{start,stop}` | contrôle du conteneur Navidrome |
 | `/history` | historique des runs |
+| `/help` | cheat-sheet : commandes Docker compose, enchaînements, procédure de wipe + ré-import |
 
 ---
 
@@ -435,6 +437,69 @@ Ordre recommandé pour les alias : **`app:aliases:generate` →
 n'écrivent pas dans Navidrome — l'offline d'abord puisqu'il ne coûte rien et
 épuise les cas faciles, l'online ensuite pour ce qui reste ; le rematch
 applique les alias et insère les écoutes nouvellement résolues).
+
+### Note sur le compteur de lecture Navidrome
+
+`app:scrobbles:sync-navidrome` met à jour **deux** tables côté Navidrome :
+
+- `scrobbles` — historique brut, une ligne par écoute importée.
+- `annotation` — `play_count` (incrémenté) et `play_date` (mis à jour), c'est
+  là que l'UI Navidrome lit le **compteur de lecture** affiché sur chaque
+  piste / album / artiste.
+
+Le reconcile annotation est appliqué après chaque batch d'inserts, dans la
+même transaction d'écriture. Conséquence pratique : après un sync, les
+compteurs de lecture affichés par le client Navidrome reflètent bien tout
+l'historique Last.fm importé, pas seulement les écoutes émises depuis
+Navidrome lui-même.
+
+---
+
+## Wipe complet + ré-import
+
+Procédure pour repartir d'une page blanche côté Navidrome (par exemple après
+un gros nettoyage d'alias ou une refonte de bibliothèque) :
+
+```bash
+# 0. Backup explicite — le wrapper scripts/navidrome-sync.sh en fait un
+#    automatiquement, sinon copier navidrome.db + -wal + -shm avant.
+
+# 1. Wiper l'historique Navidrome (scrobbles + annotation.play_count) et
+#    remettre scrobble_sync en pending.  --dry-run pour preview.
+php bin/console app:navidrome:wipe-scrobbles --dry-run
+php bin/console app:navidrome:wipe-scrobbles --auto-stop
+
+# 2. (Optionnel) re-fetcher l'historique Last.fm si la base outils n'est pas
+#    à jour.  Sinon le wipe n'a touché que Navidrome, pas la base locale.
+php bin/console app:lastfm:fetch --max-scrobbles=0
+
+# 3. (Optionnel) re-générer les alias avant le ré-import — typiquement on
+#    aura ajouté des pistes ou retouché des alias.
+php bin/console app:aliases:generate
+php bin/console app:aliases:musicbrainz
+
+# 4. Ré-importer tout l'historique dans Navidrome.  Le sync écrit dans
+#    scrobbles ET dans annotation, donc l'UI Navidrome affichera bien les
+#    bons compteurs en sortie.
+php bin/console app:scrobbles:sync-navidrome --auto-stop
+
+# 5. Recalculer les stats côté outils (le snapshot est stale après un wipe).
+php bin/console app:navidrome:stats:compute
+```
+
+Ce que la commande de wipe fait, dans une seule transaction Navidrome :
+
+- `DELETE FROM scrobbles WHERE user_id = …` (table d'écoutes vidée).
+- `UPDATE annotation SET play_count = 0, play_date = NULL` (compteurs UI
+  remis à zéro). `starred` / `rating` / `starred_at` sont **préservés** —
+  les coups de cœur survivent au wipe.
+- `UPDATE scrobble_sync SET status='pending'` côté outils (le ré-import
+  reprend de zéro).
+
+Garde-fous : pré-flight conteneur (sauf `--skip-pre-check`), backup
+automatique de la DB Navidrome, prompt de confirmation, run_history avec
+métriques. Tout est documenté en plus de détail sur la page **`/help`** de
+l'UI web.
 
 ---
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,6 +21,7 @@ parameters:
     musicbrainz.user_agent: '%env(MUSICBRAINZ_USER_AGENT)%'
     musicbrainz.base_url: '%env(MUSICBRAINZ_BASE_URL)%'
     lidarr.url: '%env(default::LIDARR_URL)%'
+    help.compose_service: '%env(default::HELP_COMPOSE_SERVICE)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
@@ -166,6 +167,10 @@ services:
     App\Controller\LastFmTopArtistsController:
         arguments:
             $defaultUser: '%lastfm.user%'
+
+    App\Controller\HelpController:
+        arguments:
+            $composeService: '%help.compose_service%'
 
     App\Controller\StatsController:
         arguments:

--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class HelpController extends AbstractController
+{
+    private readonly string $composeService;
+
+    public function __construct(?string $composeService = null)
+    {
+        // Defaultable env (`default::HELP_COMPOSE_SERVICE`) resolves to null
+        // when the variable isn't set at all — fall back to the conventional
+        // service name from docker-compose.dev.yml so a fresh checkout still
+        // renders useful snippets without extra config.
+        $composeService = is_string($composeService) ? trim($composeService) : '';
+        $this->composeService = $composeService !== '' ? $composeService : 'navidrome-tools-web';
+    }
+
+    #[Route('/help', name: 'app_help', methods: ['GET'])]
+    public function index(): Response
+    {
+        return $this->render('help.html.twig', [
+            'compose_service' => $this->composeService,
+        ]);
+    }
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2702,6 +2702,100 @@ class NavidromeRepository
     }
 
     /**
+     * Bring `annotation.play_count` and `annotation.play_date` back in sync
+     * with the source-of-truth `scrobbles` table for the given media_files.
+     * Required after any batch of {@see insertScrobble()} calls — the raw
+     * insert only writes to `scrobbles`, but Navidrome's own UI still
+     * derives the displayed play count from `annotation.play_count`. Without
+     * this reconcile step, an imported play history shows up correctly in
+     * our own stats pages (which read `scrobbles` when available) but stays
+     * at 0 plays in the Navidrome client.
+     *
+     * Update first (covers media_files that already have an annotation row,
+     * typically because they were starred or had a previous play_count
+     * before the wipe). For media_files with no annotation row yet, insert
+     * a fresh one carrying the new play_count / play_date — one INSERT per
+     * missing row because SQLite has no native UUID generator and the
+     * `ann_id` column expects a v4 (matching what Navidrome itself emits).
+     *
+     * Must be called inside the same write transaction as the inserts.
+     * Returns the total number of annotation rows touched.
+     *
+     * @param list<string> $mediaFileIds
+     */
+    public function reconcileAnnotationForMediaFiles(string $userId, array $mediaFileIds): int
+    {
+        $mediaFileIds = array_values(array_unique($mediaFileIds));
+        if ($mediaFileIds === []) {
+            return 0;
+        }
+
+        $placeholders = implode(',', array_fill(0, count($mediaFileIds), '?'));
+        $conn = $this->connection();
+
+        // 1. Refresh existing annotation rows. Correlated subqueries against
+        //    `scrobbles` keep things atomic and immune to count drift if a
+        //    second writer somehow slips in (shouldn't — we hold BEGIN
+        //    IMMEDIATE — but the cost is negligible).
+        $updated = (int) $conn->executeStatement(
+            "UPDATE annotation
+                SET play_count = (
+                        SELECT COUNT(*) FROM scrobbles
+                         WHERE user_id = annotation.user_id
+                           AND media_file_id = annotation.item_id
+                    ),
+                    play_date = (
+                        SELECT datetime(MAX(submission_time), 'unixepoch') FROM scrobbles
+                         WHERE user_id = annotation.user_id
+                           AND media_file_id = annotation.item_id
+                    )
+              WHERE user_id = ?
+                AND item_type = 'media_file'
+                AND item_id IN ($placeholders)",
+            array_merge([$userId], $mediaFileIds),
+        );
+
+        // 2. Identify media_files that still have no annotation row and need
+        //    one created. We avoid SQLite-side UUID generation (no native
+        //    `uuid()`) by inserting one-by-one.
+        $missing = $conn->fetchFirstColumn(
+            "SELECT s.media_file_id
+               FROM scrobbles s
+              WHERE s.user_id = ?
+                AND s.media_file_id IN ($placeholders)
+                AND NOT EXISTS (
+                    SELECT 1 FROM annotation a
+                     WHERE a.user_id = s.user_id
+                       AND a.item_id = s.media_file_id
+                       AND a.item_type = 'media_file'
+                )
+              GROUP BY s.media_file_id",
+            array_merge([$userId], $mediaFileIds),
+        );
+
+        $inserted = 0;
+        foreach ($missing as $mfid) {
+            /** @var array{pc: int|string, pd: ?string}|false $row */
+            $row = $conn->fetchAssociative(
+                "SELECT COUNT(*) AS pc, datetime(MAX(submission_time), 'unixepoch') AS pd
+                   FROM scrobbles WHERE user_id = ? AND media_file_id = ?",
+                [$userId, (string) $mfid],
+            );
+            if ($row === false || ((int) $row['pc']) === 0) {
+                continue;
+            }
+            $inserted += (int) $conn->executeStatement(
+                "INSERT OR IGNORE INTO annotation
+                    (ann_id, user_id, item_id, item_type, play_count, play_date, rating, starred)
+                 VALUES (?, ?, ?, 'media_file', ?, ?, 0, 0)",
+                [self::uuidV4(), $userId, (string) $mfid, (int) $row['pc'], (string) ($row['pd'] ?? '')],
+            );
+        }
+
+        return $updated + $inserted;
+    }
+
+    /**
      * Open a write transaction with `BEGIN IMMEDIATE` — takes the RESERVED
      * lock right away and fails fast if another writer (Navidrome
      * accidentally restarted by Docker auto-restart, a parallel

--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -194,10 +194,20 @@ class NavidromeSyncService
         // 1. Write to Navidrome atomically.
         $this->navidrome->beginWriteTransaction();
         try {
+            $touched = [];
             foreach ($batch as $row) {
                 if ($row['willInsert'] && $row['matchedId'] !== null) {
                     $this->navidrome->insertScrobble($userId, $row['matchedId'], $row['sync']->getScrobble()->getPlayedAt());
+                    $touched[$row['matchedId']] = true;
                 }
+            }
+            // Sync the displayed play_count / play_date in `annotation` from
+            // the freshly populated `scrobbles` rows. Without this, Navidrome's
+            // UI keeps showing 0 plays for the imported tracks — `insertScrobble`
+            // only touches the `scrobbles` table, while the player reads from
+            // `annotation`.
+            if ($touched !== []) {
+                $this->navidrome->reconcileAnnotationForMediaFiles($userId, array_keys($touched));
             }
             $this->navidrome->commitWrite();
         } catch (\Throwable $e) {

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -37,6 +37,7 @@
     ]},
     { type: 'link', label: 'Stats', route: 'app_stats' },
     { type: 'link', label: 'Historique', route: 'app_history' },
+    { type: 'link', label: 'Aide', route: 'app_help' },
 ] %}
 
 {% if variant == 'desktop' %}

--- a/templates/help.html.twig
+++ b/templates/help.html.twig
@@ -1,0 +1,220 @@
+{% extends 'base.html.twig' %}
+{% block title %}Aide — navidrome-tools{% endblock %}
+{% block body %}
+    {% set dc = 'docker compose exec -T ' ~ compose_service %}
+
+    <div class="mb-6">
+        <h1 class="text-2xl font-semibold">Aide & cheat-sheet</h1>
+        <p class="text-sm text-slate-500 mt-1">
+            Référence rapide des commandes, des enchaînements typiques et des procédures sensibles.
+            Toutes les commandes CLI sont préfixées par <code class="bg-slate-100 px-1 rounded-sm">{{ dc }}</code> :
+            adapte le nom du service si ton <code class="bg-slate-100 px-1 rounded-sm">compose.yml</code> diffère.
+        </p>
+    </div>
+
+    {# Sommaire #}
+    <div class="bg-white rounded-sm p-4 mb-6 text-sm shadow-sm">
+        <div class="font-semibold mb-2 text-xs uppercase text-slate-500">Sommaire</div>
+        <ul class="list-disc list-inside space-y-1 text-sky-700">
+            <li><a href="#flow" class="hover:underline">Flow type — premier import</a></li>
+            <li><a href="#fetch" class="hover:underline">Récupérer / mettre à jour l'historique Last.fm</a></li>
+            <li><a href="#sync" class="hover:underline">Synchroniser dans Navidrome / Strawberry</a></li>
+            <li><a href="#rematch" class="hover:underline">Rejouer le matching après changement de bibliothèque</a></li>
+            <li><a href="#aliases" class="hover:underline">Générer / suggérer des alias</a></li>
+            <li><a href="#loves" class="hover:underline">Synchroniser les loved ↔ starred</a></li>
+            <li><a href="#stats" class="hover:underline">Recalculer les stats</a></li>
+            <li><a href="#wipe" class="hover:underline">⚠️ Wipe complet + ré-import (procédure dangereuse)</a></li>
+            <li><a href="#crontab" class="hover:underline">Crontab type</a></li>
+            <li><a href="#tips" class="hover:underline">Astuces & pièges</a></li>
+        </ul>
+    </div>
+
+    {# Flow type #}
+    <section id="flow" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Flow type — premier import</h2>
+        <ol class="list-decimal list-inside space-y-2 text-sm">
+            <li>Remplir <code>LASTFM_API_KEY</code>, <code>LASTFM_USER</code> et <code>NAVIDROME_*</code> dans <code>.env</code>.</li>
+            <li>Récupérer tout l'historique Last.fm :
+                <pre class="bg-slate-100 p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:lastfm:fetch --max-scrobbles=0</pre>
+            </li>
+            <li>(Optionnel) auto-générer des alias à haute confiance avant le sync :
+                <pre class="bg-slate-100 p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:aliases:generate --dry-run
+{{ dc }} php bin/console app:aliases:generate</pre>
+            </li>
+            <li>Synchroniser vers Navidrome (le conteneur est stoppé pendant l'écriture) :
+                <pre class="bg-slate-100 p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:scrobbles:sync-navidrome --auto-stop</pre>
+            </li>
+            <li>(Optionnel) re-tenter les non-matchés après avoir ajouté des pistes :
+                <pre class="bg-slate-100 p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:scrobbles:rematch --target navidrome --auto-stop</pre>
+            </li>
+            <li>Propager les coups de cœur :
+                <pre class="bg-slate-100 p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:loves:lastfm-to-navidrome --auto-stop</pre>
+            </li>
+        </ol>
+    </section>
+
+    {# Fetch #}
+    <section id="fetch" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Récupérer / mettre à jour l'historique Last.fm</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Fetch incrémental par défaut (depuis le dernier scrobble en base). <code>--max-scrobbles=0</code> = pas de limite.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto"># Récupérer ce qui est nouveau depuis le dernier sync
+{{ dc }} php bin/console app:lastfm:fetch
+
+# Backfill complet
+{{ dc }} php bin/console app:lastfm:fetch --max-scrobbles=0
+
+# Backfill bornée (utile pour tester sur un sous-ensemble)
+{{ dc }} php bin/console app:lastfm:fetch --date-min=2024-01-01 --date-max=2024-12-31
+
+# Rafraîchir l'attribut « loved » sur les anciens scrobbles
+{{ dc }} php bin/console app:lastfm:loved:sync</pre>
+    </section>
+
+    {# Sync #}
+    <section id="sync" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Synchroniser dans Navidrome / Strawberry</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Écrit dans la base SQLite Navidrome (le conteneur doit être arrêté). <code>--auto-stop</code> gère l'arrêt
+            et le redémarrage du conteneur. Met également à jour <code>annotation.play_count</code> pour que le
+            compteur de lecture s'affiche correctement dans l'UI Navidrome.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto"># Sync Navidrome (recommandé : --auto-stop)
+{{ dc }} php bin/console app:scrobbles:sync-navidrome --auto-stop
+
+# Aperçu sans écrire
+{{ dc }} php bin/console app:scrobbles:sync-navidrome --dry-run
+
+# Sync Strawberry (lecture/écriture sur strawberry.db, pas de conteneur à arrêter)
+{{ dc }} php bin/console app:scrobbles:sync-strawberry</pre>
+    </section>
+
+    {# Rematch #}
+    <section id="rematch" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Rejouer le matching après changement de bibliothèque</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Reset les <code>unmatched</code> → <code>pending</code> et relance la cascade. À lancer après avoir ajouté
+            des pistes à Navidrome, créé des alias manuels ou tourné une commande <code>app:aliases:*</code>.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto">{{ dc }} php bin/console app:scrobbles:rematch --target navidrome --auto-stop
+{{ dc }} php bin/console app:scrobbles:rematch --target strawberry</pre>
+    </section>
+
+    {# Aliases #}
+    <section id="aliases" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Générer / suggérer des alias</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            <strong>Ordre recommandé :</strong> <code>aliases:generate</code> (offline, MBID-only) →
+            <code>aliases:musicbrainz</code> (online) → <code>scrobbles:rematch</code> pour ré-injecter les écoutes
+            nouvellement résolues.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto"># 1) Offline — joue sur les MBID déjà portés par les scrobbles
+{{ dc }} php bin/console app:aliases:generate --dry-run
+{{ dc }} php bin/console app:aliases:generate
+
+# 2) Online — interroge MusicBrainz pour les artistes encore non aliasés
+{{ dc }} php bin/console app:aliases:musicbrainz --dry-run --limit=20
+{{ dc }} php bin/console app:aliases:musicbrainz                   # applique unique-match
+{{ dc }} php bin/console app:aliases:musicbrainz -i                # prompt pour les ambigus
+
+# 3) Reprise du sync avec les nouveaux alias
+{{ dc }} php bin/console app:scrobbles:rematch --target navidrome --auto-stop</pre>
+        <p class="text-xs text-slate-500 mt-2">
+            <code>app:aliases:musicbrainz</code> exige un <code>MUSICBRAINZ_USER_AGENT</code> contact-bearing (ToS MB)
+            et respecte le rate-limit 1 req/s.
+        </p>
+    </section>
+
+    {# Loves #}
+    <section id="loves" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Synchroniser les loved ↔ starred</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Politique « loved wins » : on ne retire jamais un cœur, on n'en propage que de nouveaux. Setup unique :
+            <code>app:lastfm:auth</code> stocke la session key pour le push retour Last.fm.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto"># Setup (une seule fois) — prompt interactif
+{{ dc }} php bin/console app:lastfm:auth
+
+# Last.fm → Navidrome (écrit dans la DB Navidrome)
+{{ dc }} php bin/console app:loves:lastfm-to-navidrome --auto-stop
+
+# Navidrome → Last.fm (pure API, Navidrome reste up)
+{{ dc }} php bin/console app:loves:navidrome-to-lastfm</pre>
+    </section>
+
+    {# Stats #}
+    <section id="stats" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Recalculer les stats</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Les pages <code>/lastfm/stats</code> et <code>/navidrome/stats</code> sont servies depuis un snapshot
+            persisté. Recalculer en CLI permet d'avoir des stats fraîches sans solliciter l'UI.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto">{{ dc }} php bin/console app:lastfm:stats:compute
+{{ dc }} php bin/console app:navidrome:stats:compute
+{{ dc }} php bin/console app:stats                          # résumé compact dans la console</pre>
+    </section>
+
+    {# Wipe #}
+    <section id="wipe" class="bg-rose-50 border border-rose-200 rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2 text-rose-800">⚠️ Wipe complet + ré-import — procédure dangereuse</h2>
+        <p class="text-sm text-rose-900 mb-3">
+            Cette procédure efface <strong>toute</strong> l'historique de lecture Navidrome (table <code>scrobbles</code>,
+            compteurs <code>annotation.play_count</code> remis à zéro) et remet le suivi local <code>scrobble_sync</code>
+            en <code>pending</code> pour permettre un ré-import propre depuis Last.fm. <strong>Faire un backup avant.</strong>
+        </p>
+        <ol class="list-decimal list-inside space-y-2 text-sm text-rose-900">
+            <li><strong>Backup explicite</strong> de la DB Navidrome (le wrapper bash <code>scripts/navidrome-sync.sh</code>
+                en fait un automatiquement, sinon copier <code>navidrome.db</code> + <code>-wal</code> + <code>-shm</code>).</li>
+            <li><strong>Arrêter Navidrome</strong> (manuellement ou via <code>--auto-stop</code> de la commande wipe).</li>
+            <li><strong>Wipe</strong> — toujours commencer en <code>--dry-run</code> pour voir ce qui va être effacé :
+                <pre class="bg-white p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:navidrome:wipe-scrobbles --dry-run
+{{ dc }} php bin/console app:navidrome:wipe-scrobbles --auto-stop</pre>
+            </li>
+            <li><strong>Ré-import</strong> complet depuis l'historique Last.fm local :
+                <pre class="bg-white p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:scrobbles:sync-navidrome --auto-stop</pre>
+                Le sync écrit dans <code>scrobbles</code> <em>et</em> dans <code>annotation</code> (compteurs de lecture),
+                donc l'UI Navidrome affichera bien les bonnes valeurs en sortie.
+            </li>
+            <li><strong>Vérifier</strong> via <code>/navidrome/stats</code> (puis recalcul du snapshot) :
+                <pre class="bg-white p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:navidrome:stats:compute</pre>
+            </li>
+            <li>(Optionnel) re-générer les alias et rematcher si la lib a changé entre temps :
+                <pre class="bg-white p-2 rounded-sm text-xs mt-1 overflow-x-auto">{{ dc }} php bin/console app:aliases:generate
+{{ dc }} php bin/console app:aliases:musicbrainz
+{{ dc }} php bin/console app:scrobbles:rematch --target navidrome --auto-stop</pre>
+            </li>
+        </ol>
+        <p class="text-xs text-rose-700 mt-3">
+            Si le wipe échoue en cours, <code>--auto-stop</code> garantit le redémarrage de Navidrome dans le
+            <code>finally</code> de la commande. <code>app:scrobbles:sync-navidrome</code> remet aussi le conteneur en
+            ligne après l'écriture.
+        </p>
+    </section>
+
+    {# Crontab #}
+    <section id="crontab" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Crontab type</h2>
+        <p class="text-sm text-slate-500 mb-2">
+            Pour un sync quotidien automatique, utiliser <code>scripts/navidrome-sync.sh</code> (recopier
+            <code>scripts/navidrome-sync.sh.example</code>) qui orchestre stop conteneur → backup → sync → quick_check
+            → restart → purge backups, avec rollback DB sur erreur.
+        </p>
+        <pre class="bg-slate-100 p-2 rounded-sm text-xs overflow-x-auto"># Toutes les 6 heures
+0 */6 * * * /chemin/vers/scripts/navidrome-sync.sh >> /var/log/navidrome-sync.log 2>&1</pre>
+    </section>
+
+    {# Tips #}
+    <section id="tips" class="bg-white rounded-sm p-4 mb-6 shadow-sm">
+        <h2 class="text-lg font-semibold mb-2">Astuces & pièges</h2>
+        <ul class="list-disc list-inside space-y-1 text-sm text-slate-700">
+            <li><strong>Toujours préfixer <code>-T</code></strong> sur <code>docker compose exec</code> en cron — sans ça, <code>docker exec</code> râle « the input device is not a TTY ».</li>
+            <li><strong>Toujours <code>--auto-stop</code></strong> pour les commandes qui écrivent dans Navidrome — l'arrêt
+                propre force un WAL checkpoint et évite la corruption.</li>
+            <li><strong>Ne jamais partager <code>APP_CACHE_DIR</code></strong> entre les conteneurs <code>web</code> et <code>worker</code> (race sur <code>cache/prod</code>).</li>
+            <li><strong>SQLite et <code>NAVIDROME_STOP_TIMEOUT_SECONDS</code></strong> : laisser au moins 60 secondes pour que le WAL se checkpoint avant SIGKILL.</li>
+            <li><strong>Pas de relance des syncs en parallèle</strong> — le verrou <code>BEGIN IMMEDIATE</code> empêche deux processus d'écrire en même temps mais le second fail-fast au lieu d'attendre.</li>
+            <li><strong>Voir aussi</strong> : <a href="{{ path('app_history') }}" class="text-sky-700 hover:underline">l'historique des runs</a> garde la trace de chaque exécution (succès / erreur, durée, métriques).</li>
+        </ul>
+    </section>
+{% endblock %}


### PR DESCRIPTION
## Summary

Trois choses qui vont ensemble parce qu'on les déclenche dans la même session quand on veut repartir d'une page blanche côté Navidrome.

### 1. 🐛 `fix(navidrome): annotation.play_count maintenant à jour au sync`

**Bug réel détecté en revue.** `insertScrobble()` n'écrit que dans la table `scrobbles` ; or l'UI Navidrome affiche le compteur de lecture depuis `annotation.play_count`. Conséquence avant ce fix : après un sync (et pire, après un wipe + ré-import), tous les compteurs UI restent à 0 alors que les écoutes sont bien en base.

Nouvelle méthode `NavidromeRepository::reconcileAnnotationForMediaFiles` qui, **dans la même transaction d'écriture** que les inserts :

1. UPDATE les annotations existantes : `play_count = COUNT(*)` côté scrobbles, `play_date = datetime(MAX(submission_time), 'unixepoch')`.
2. INSERT une annotation neuve pour les `media_file` sans annotation (typiquement après wipe qui ne re-crée pas les lignes, il les reset). UUID v4 généré côté PHP (SQLite n'a pas de `uuid()` natif).

Appelée depuis `NavidromeSyncService::flushBatch` après le bloc d'inserts, sur l'ensemble des `media_file` touchés. Coût : 1 UPDATE bulk + 0..N INSERTs pour les media_files novel — négligeable comparé au gain.

### 2. ✨ `feat(web): page /help`

Cheat-sheet long-form accessible depuis le navbar (« Aide » en bas, à côté de Historique). Couvre :

- Flow type premier import
- Fetch / sync / rematch / aliases / loves / stats
- **⚠️ Section wipe + ré-import** avec étapes explicites et garde-fous
- Crontab type pointant vers `scripts/navidrome-sync.sh`
- Astuces & pièges (TTY sous cron, `--auto-stop`, lock SQLite, partage de cache)

Toutes les commandes CLI sont préfixées par `docker compose exec -T <service>` où le nom vient de `HELP_COMPOSE_SERVICE` (env optionnelle, defaultable à `navidrome-tools-web`). Le `-T` est important — sans lui `docker exec` râle « no TTY » sous cron.

### 3. 📄 `docs(readme): section Wipe complet + ré-import`

Procédure pas-à-pas dans le README avec la **note explicite sur le double write scrobbles + annotation** (en réponse direct à ton « vérifier au passage que le compteur de lecture est bien maj »). TOC mis à jour, ligne `/help` ajoutée dans la table Interface web.

## Test plan

- [x] `composer phpcs` → vert
- [x] `phpunit` → 111 tests / 335 assertions, tous verts
- [x] `phpstan` → 10 erreurs **pré-existantes** identiques à develop, rien sur le nouveau code
- [x] `lint:twig` + `debug:router` → `app_help` apparaît
- [ ] Visite `/help` : navbar Aide visible, snippets `docker compose exec -T navidrome-tools-web …` cohérents
- [ ] **Validation du fix** : avant la PR, le compteur Navidrome UI restait à 0 après un sync. Après merge, lancer un sync sur quelques pistes connues et vérifier que le compteur dans l'UI Navidrome augmente bien
- [ ] Lancer un wipe `--dry-run` puis un wipe + ré-import complet et confirmer que l'UI Navidrome affiche les bons compteurs au final

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_