### PR TITLE
fix(run-history): reset EM après échec de flush pour ne plus masquer la cause

### DIFF
--- a/src/Service/RunHistoryRecorder.php
+++ b/src/Service/RunHistoryRecorder.php
@@ -6,13 +6,18 @@ use App\Entity\RunHistory;
 use App\Notifier\Notification;
 use App\Notifier\Notifier;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 
 class RunHistoryRecorder
 {
+    private EntityManagerInterface $em;
+
     public function __construct(
-        private readonly EntityManagerInterface $em,
+        private readonly ManagerRegistry $registry,
+        EntityManagerInterface $em,
         private readonly ?Notifier $notifier = null,
     ) {
+        $this->em = $em;
     }
 
     /**
@@ -24,6 +29,16 @@ class RunHistoryRecorder
      * child entities to the run via foreign key. Existing arrow-fn callers
      * that don't declare the parameter ignore it (PHP silently discards
      * extra positional args).
+     *
+     * Robustness: when the wrapped action triggers a Doctrine flush failure
+     * (constraint violation, deadlock, schema mismatch…), Doctrine *closes*
+     * the EntityManager. Without recovery, the catch block's own flush —
+     * meant to mark the RunHistory row as errored — would itself throw
+     * « The EntityManager is closed », swallowing the original cause. We
+     * detect that here, reset the manager via {@see ManagerRegistry}, and
+     * re-hydrate the RunHistory entry on the fresh EM so the error trail
+     * is still persisted and surfaced. The original exception is re-thrown
+     * untouched, so the user sees the real failure.
      *
      * @template T
      *
@@ -49,12 +64,20 @@ class RunHistoryRecorder
         try {
             $result = $action($entry);
         } catch (\Throwable $e) {
+            $entry = $this->refreshEntryAfterFailure($entry);
             $entry->setStatus(RunHistory::STATUS_ERROR);
             $entry->setMessage($e->getMessage());
             $entry->setFinishedAt(new \DateTimeImmutable());
             $entry->setDurationMs((int) round((microtime(true) - $startedMicrotime) * 1000));
-            $this->em->flush();
-            $this->notify($entry);
+            try {
+                $this->em->flush();
+                $this->notify($entry);
+            } catch (\Throwable) {
+                // Best-effort error trail: if even the re-armed EM can't
+                // flush (DB unreachable, transient I/O…), don't shadow the
+                // original exception. The user's primary feedback is the
+                // re-thrown $e below.
+            }
             throw $e;
         }
 
@@ -74,6 +97,45 @@ class RunHistoryRecorder
         $this->notify($entry);
 
         return $result;
+    }
+
+    /**
+     * If the action's flush closed the EntityManager (typical on constraint
+     * violation), the existing $entry instance is detached and unusable.
+     * Reset the manager and re-fetch the row so we can update its status
+     * cleanly. When the EM is still open we just keep the same entry.
+     */
+    private function refreshEntryAfterFailure(RunHistory $entry): RunHistory
+    {
+        if ($this->em->isOpen()) {
+            return $entry;
+        }
+
+        $id = $entry->getId();
+        $this->registry->resetManager();
+        $fresh = $this->registry->getManager();
+        if (!$fresh instanceof EntityManagerInterface) {
+            // Should never happen with the default Doctrine bundle setup,
+            // but bail out cleanly: keep the old entry, the outer try/catch
+            // around flush() will absorb any subsequent failure.
+            return $entry;
+        }
+        $this->em = $fresh;
+
+        if ($id !== null) {
+            $reloaded = $this->em->find(RunHistory::class, $id);
+            if ($reloaded instanceof RunHistory) {
+                return $reloaded;
+            }
+        }
+
+        // Couldn't refetch (row deleted? id never assigned because the very
+        // first flush failed?). Persist a new pseudo-entry under the same
+        // type/reference/label so at least *something* lands in run_history.
+        $rebuilt = new RunHistory($entry->getType(), $entry->getReference(), $entry->getLabel());
+        $this->em->persist($rebuilt);
+
+        return $rebuilt;
     }
 
     private function notify(RunHistory $entry): void

--- a/tests/Service/RunHistoryRecorderTest.php
+++ b/tests/Service/RunHistoryRecorderTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Service;
 use App\Entity\RunHistory;
 use App\Service\RunHistoryRecorder;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use PHPUnit\Framework\TestCase;
 
 class RunHistoryRecorderTest extends TestCase
@@ -12,13 +13,16 @@ class RunHistoryRecorderTest extends TestCase
     public function testRecordSuccessCreatesRunHistory(): void
     {
         $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('isOpen')->willReturn(true);
         $persisted = [];
         $em->method('persist')->willReturnCallback(function (object $e) use (&$persisted): void {
             $persisted[] = $e;
         });
         $em->method('flush');
 
-        $recorder = new RunHistoryRecorder($em);
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $recorder = new RunHistoryRecorder($registry, $em);
         $result = $recorder->record(
             type: RunHistory::TYPE_LASTFM_FETCH,
             reference: 'alice',
@@ -37,10 +41,13 @@ class RunHistoryRecorderTest extends TestCase
     public function testRecordErrorSetsStatusAndRethrows(): void
     {
         $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('isOpen')->willReturn(true);
         $em->method('persist');
         $em->method('flush');
 
-        $recorder = new RunHistoryRecorder($em);
+        $registry = $this->createMock(ManagerRegistry::class);
+
+        $recorder = new RunHistoryRecorder($registry, $em);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('boom');
@@ -51,5 +58,56 @@ class RunHistoryRecorderTest extends TestCase
             label: 'Failing run',
             action: fn () => throw new \RuntimeException('boom'),
         );
+    }
+
+    public function testEntityManagerClosedDuringActionIsResetSoErrorTrailLands(): void
+    {
+        // Scenario: the wrapped action triggers a Doctrine flush failure
+        // (e.g. constraint violation in NavidromeSyncService::flushBatch),
+        // which closes the EM. The catch's own flush would otherwise throw
+        // « The EntityManager is closed », masking the real root cause.
+        // The recorder must reset the manager, re-fetch the entry, and
+        // persist the error state — then re-throw the original.
+
+        $closedEm = $this->createMock(EntityManagerInterface::class);
+        $closedEm->method('isOpen')->willReturn(false);
+        $closedEm->method('persist');
+        $closedEm->method('flush');
+
+        $entry = null;
+        $freshEm = $this->createMock(EntityManagerInterface::class);
+        $freshEm->method('isOpen')->willReturn(true);
+        $freshEm->method('find')->willReturnCallback(
+            fn (string $cls, mixed $id) => $cls === RunHistory::class
+                ? new RunHistory(RunHistory::TYPE_LASTFM_FETCH, 'alice', 'Resilient run')
+                : null,
+        );
+        $flushedFresh = false;
+        $freshEm->expects($this->atLeastOnce())
+            ->method('flush')
+            ->willReturnCallback(function () use (&$flushedFresh): void {
+                $flushedFresh = true;
+            });
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->once())->method('resetManager');
+        $registry->method('getManager')->willReturn($freshEm);
+
+        $recorder = new RunHistoryRecorder($registry, $closedEm);
+
+        $caughtMessage = null;
+        try {
+            $recorder->record(
+                type: RunHistory::TYPE_LASTFM_FETCH,
+                reference: 'alice',
+                label: 'Resilient run',
+                action: fn () => throw new \RuntimeException('real cause'),
+            );
+        } catch (\RuntimeException $e) {
+            $caughtMessage = $e->getMessage();
+        }
+
+        $this->assertSame('real cause', $caughtMessage, 'Original cause must propagate untouched.');
+        $this->assertTrue($flushedFresh, 'Error trail must land on the fresh EM.');
     }
 }


### PR DESCRIPTION
## Bug

```
The EntityManager is closed.
```

Levé pendant un sync (typiquement `app:scrobbles:sync-navidrome`) au milieu d'une commande, en **remplaçant** la cause réelle de la panne. L'utilisateur ne voit que le symptôme, jamais le bug d'origine.

## Cause

Quand l'action wrappée par `RunHistoryRecorder::record()` déclenche une exception au `flush()` Doctrine (contrainte d'unicité, schéma incompatible — cf. PR #184 sur `ann_id`, deadlock, etc.), **Doctrine ferme l'EntityManager** pour préserver la cohérence. Le `catch` du recorder essayait ensuite de re-flusher pour marquer la run en erreur — sur l'EM fermé — et levait l'exception générique qui supplantait la cause originale dans la stack du run.

## Fix

- **Constructeur** prend désormais un `ManagerRegistry` en plus de l'EM (autowiring Symfony transparent).
- **Dans le catch**, détection de `!$em->isOpen()` ; si l'EM est fermé :
  - `registry->resetManager()` ;
  - re-fetch du `RunHistory` par son id sur le nouvel EM ;
  - si le re-fetch échoue (id `null` parce que même le premier flush a planté, ou ligne disparue), on persiste un nouveau `RunHistory` minimal pour que la trace existe quand même.
- Le **flush du status d'erreur** est encapsulé dans son propre `try/catch` best-effort : si même le fresh EM n'arrive pas à flusher, on ne shadow PAS l'exception originale qui est ré-throw telle quelle.

## Conséquence pratique

À partir de cette PR, l'utilisateur voit la **vraie cause** dans la stack et dans `/history` (e.g. « table annotation has no column named ann_id » ou autre violation), au lieu d'un « EntityManager is closed » opaque.

## Test plan

- [x] `composer phpcs` → vert
- [x] `phpunit` → 113 tests / 344 assertions, tous verts (1 nouveau cas dédié à l'EM fermé : reset registry + flush sur fresh EM + propagation de la cause originale)
- [x] `phpstan` → 10 erreurs **pré-existantes** identiques à develop, rien sur le nouveau code
- [ ] Relancer un sync qui plantait sur `EntityManager is closed` ; vérifier que la stack remonte maintenant la cause réelle
- [ ] Vérifier que `/history` enregistre bien la ligne `STATUS_ERROR` avec le message d'origine

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_