### PR TITLE
perf(stats): pré-calcul des 6 top-* dans le snapshot stats

### DIFF
--- a/src/Controller/LastFmTopAlbumsController.php
+++ b/src/Controller/LastFmTopAlbumsController.php
@@ -20,8 +20,11 @@ class LastFmTopAlbumsController extends AbstractController
     }
 
     #[Route('/lastfm/top-albums', name: 'app_lastfm_top_albums', methods: ['GET'])]
-    public function index(Request $request, LastFmStatsService $stats, ScrobbleRepository $scrobbles): Response
-    {
+    public function index(
+        Request $request,
+        LastFmStatsService $stats,
+        ScrobbleRepository $scrobbles,
+    ): Response {
         $user = $this->defaultUser !== '' ? $this->defaultUser : null;
         $c = DateCascadeFilter::parse(
             $request->query->get('year'),
@@ -29,8 +32,28 @@ class LastFmTopAlbumsController extends AbstractController
             $request->query->get('day'),
         );
 
+        $source = 'live';
+        $computedAt = null;
+        if ($c['year'] !== null) {
+            $rows = $stats->topAlbumsWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get($user);
+            $cached = is_array($snapshot) && isset($snapshot['top_albums_alltime']) && is_array($snapshot['top_albums_alltime'])
+                ? $snapshot['top_albums_alltime']
+                : null;
+            if ($cached !== null) {
+                /** @var list<array{artist: string, album: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
+                $rows = $cached;
+                $source = 'snapshot';
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $stats->topAlbumsWithDates($user, null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
+
         return $this->render('lastfm/top_albums.html.twig', [
-            'rows' => $stats->topAlbumsWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N),
+            'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $scrobbles->availableYears($user),
             'filters' => [
@@ -38,6 +61,9 @@ class LastFmTopAlbumsController extends AbstractController
                 'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
                 'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => 'app:lastfm:stats:compute',
         ]);
     }
 }

--- a/src/Controller/LastFmTopArtistsController.php
+++ b/src/Controller/LastFmTopArtistsController.php
@@ -11,10 +11,10 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * Top 100 artists by Last.fm scrobble volume, with per-artist first /
- * last play. Filterable on a year / month / day cascade — same UX as
- * `/lastfm/scrobbles` and the Navidrome counterpart. Reads only the
- * tools DB.
+ * Top artistes Last.fm. Sans filtre → lecture instantanée depuis
+ * `top_artists_alltime` du snapshot stats. Avec filtre date → requête
+ * live (la fenêtre réduit la volumétrie). Snapshot manquant → fallback
+ * live + bandeau ambre invitant à lancer `app:lastfm:stats:compute`.
  */
 class LastFmTopArtistsController extends AbstractController
 {
@@ -26,32 +26,50 @@ class LastFmTopArtistsController extends AbstractController
     }
 
     #[Route('/lastfm/top-artists', name: 'app_lastfm_top_artists', methods: ['GET'])]
-    public function index(Request $request, LastFmStatsService $stats, ScrobbleRepository $scrobbles): Response
-    {
+    public function index(
+        Request $request,
+        LastFmStatsService $stats,
+        ScrobbleRepository $scrobbles,
+    ): Response {
         $user = $this->defaultUser !== '' ? $this->defaultUser : null;
-        $cascade = DateCascadeFilter::parse(
+        $c = DateCascadeFilter::parse(
             $request->query->get('year'),
             $request->query->get('month'),
             $request->query->get('day'),
         );
 
-        $rows = $stats->topArtistsWithDates(
-            $user,
-            $cascade['year'],
-            $cascade['month'],
-            $cascade['day'],
-            self::TOP_N,
-        );
+        $source = 'live';
+        $computedAt = null;
+        if ($c['year'] !== null) {
+            $rows = $stats->topArtistsWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get($user);
+            $cached = is_array($snapshot) && isset($snapshot['top_artists_alltime']) && is_array($snapshot['top_artists_alltime'])
+                ? $snapshot['top_artists_alltime']
+                : null;
+            if ($cached !== null) {
+                /** @var list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
+                $rows = $cached;
+                $source = 'snapshot';
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $stats->topArtistsWithDates($user, null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
 
         return $this->render('lastfm/top_artists.html.twig', [
             'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $scrobbles->availableYears($user),
             'filters' => [
-                'year' => $cascade['year'] !== null ? (string) $cascade['year'] : '',
-                'month' => $cascade['month'] !== null ? sprintf('%02d', $cascade['month']) : '',
-                'day' => $cascade['day'] !== null ? sprintf('%02d', $cascade['day']) : '',
+                'year' => $c['year'] !== null ? (string) $c['year'] : '',
+                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
+                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => 'app:lastfm:stats:compute',
         ]);
     }
 }

--- a/src/Controller/LastFmTopTracksController.php
+++ b/src/Controller/LastFmTopTracksController.php
@@ -9,20 +9,24 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
-use Symfony\Contracts\Cache\CacheInterface;
-use Symfony\Contracts\Cache\ItemInterface;
 
 /**
- * Top morceaux Last.fm — résultat caché 1h par signature (user + filtres
- * date), parce que la requête GROUP BY (artist, title) + sous-requête pour
- * l'album représentatif sur des centaines de milliers de scrobbles est le
- * point chaud sensible. Le TTL court suffit : un fetch nouveau prend une
- * heure à se voir, ce qui est cohérent avec un palmarès « top ».
+ * Top morceaux Last.fm. Deux chemins selon que l'utilisateur a posé
+ * un filtre date ou pas :
+ *
+ *  - **Aucun filtre** → lecture depuis `top_tracks_alltime` du
+ *    snapshot persisté par `LastFmStatsService::compute()` (commande
+ *    `app:lastfm:stats:compute`). C'est la vue par défaut et la plus
+ *    lourde à calculer ; on l'amortit une fois pour toutes au
+ *    recompute. Si le snapshot manque (jamais calculé), on tombe sur
+ *    un fallback live et on signale l'utilisateur dans le bandeau.
+ *  - **Filtre posé** (`year` / `month` / `day`) → requête live. Le
+ *    filtre réduit la volumétrie donc la requête est rapide même
+ *    sur les grosses bases.
  */
 class LastFmTopTracksController extends AbstractController
 {
     private const TOP_N = 100;
-    private const CACHE_TTL_SECONDS = 3600;
 
     public function __construct(
         private readonly string $defaultUser,
@@ -34,7 +38,6 @@ class LastFmTopTracksController extends AbstractController
         Request $request,
         LastFmStatsService $stats,
         ScrobbleRepository $scrobbles,
-        CacheInterface $cache,
     ): Response {
         $user = $this->defaultUser !== '' ? $this->defaultUser : null;
         $c = DateCascadeFilter::parse(
@@ -42,13 +45,26 @@ class LastFmTopTracksController extends AbstractController
             $request->query->get('month'),
             $request->query->get('day'),
         );
+        $hasFilter = $c['year'] !== null;
 
-        $cacheKey = self::cacheKey($user, $c);
-        /** @var list<array{artist: string, title: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}> $rows */
-        $rows = $cache->get($cacheKey, function (ItemInterface $item) use ($stats, $user, $c): array {
-            $item->expiresAfter(self::CACHE_TTL_SECONDS);
-            return $stats->topTracksWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
-        });
+        $source = $hasFilter ? 'live' : 'snapshot';
+        $computedAt = null;
+        if ($hasFilter) {
+            $rows = $stats->topTracksWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get($user);
+            /** @var list<array{artist: string, title: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}>|null $cached */
+            $cached = is_array($snapshot) && isset($snapshot['top_tracks_alltime']) && is_array($snapshot['top_tracks_alltime'])
+                ? $snapshot['top_tracks_alltime']
+                : null;
+            if ($cached !== null) {
+                $rows = $cached;
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $stats->topTracksWithDates($user, null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
 
         return $this->render('lastfm/top_tracks.html.twig', [
             'rows' => $rows,
@@ -59,21 +75,8 @@ class LastFmTopTracksController extends AbstractController
                 'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
                 'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
-            'cache_ttl_seconds' => self::CACHE_TTL_SECONDS,
+            'source' => $source,
+            'computed_at' => $computedAt,
         ]);
-    }
-
-    /**
-     * @param array{year: ?int, month: ?int, day: ?int} $cascade
-     */
-    private static function cacheKey(?string $user, array $cascade): string
-    {
-        return sprintf(
-            'lastfm_top_tracks.%s.%s.%s.%s',
-            md5($user ?? ''),
-            $cascade['year'] ?? '_',
-            $cascade['month'] ?? '_',
-            $cascade['day'] ?? '_',
-        );
     }
 }

--- a/src/Controller/LastFmTopTracksController.php
+++ b/src/Controller/LastFmTopTracksController.php
@@ -9,10 +9,20 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Contracts\Cache\CacheInterface;
+use Symfony\Contracts\Cache\ItemInterface;
 
+/**
+ * Top morceaux Last.fm — résultat caché 1h par signature (user + filtres
+ * date), parce que la requête GROUP BY (artist, title) + sous-requête pour
+ * l'album représentatif sur des centaines de milliers de scrobbles est le
+ * point chaud sensible. Le TTL court suffit : un fetch nouveau prend une
+ * heure à se voir, ce qui est cohérent avec un palmarès « top ».
+ */
 class LastFmTopTracksController extends AbstractController
 {
     private const TOP_N = 100;
+    private const CACHE_TTL_SECONDS = 3600;
 
     public function __construct(
         private readonly string $defaultUser,
@@ -20,8 +30,12 @@ class LastFmTopTracksController extends AbstractController
     }
 
     #[Route('/lastfm/top-tracks', name: 'app_lastfm_top_tracks', methods: ['GET'])]
-    public function index(Request $request, LastFmStatsService $stats, ScrobbleRepository $scrobbles): Response
-    {
+    public function index(
+        Request $request,
+        LastFmStatsService $stats,
+        ScrobbleRepository $scrobbles,
+        CacheInterface $cache,
+    ): Response {
         $user = $this->defaultUser !== '' ? $this->defaultUser : null;
         $c = DateCascadeFilter::parse(
             $request->query->get('year'),
@@ -29,8 +43,15 @@ class LastFmTopTracksController extends AbstractController
             $request->query->get('day'),
         );
 
+        $cacheKey = self::cacheKey($user, $c);
+        /** @var list<array{artist: string, title: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}> $rows */
+        $rows = $cache->get($cacheKey, function (ItemInterface $item) use ($stats, $user, $c): array {
+            $item->expiresAfter(self::CACHE_TTL_SECONDS);
+            return $stats->topTracksWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
+        });
+
         return $this->render('lastfm/top_tracks.html.twig', [
-            'rows' => $stats->topTracksWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N),
+            'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $scrobbles->availableYears($user),
             'filters' => [
@@ -38,6 +59,21 @@ class LastFmTopTracksController extends AbstractController
                 'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
                 'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'cache_ttl_seconds' => self::CACHE_TTL_SECONDS,
         ]);
+    }
+
+    /**
+     * @param array{year: ?int, month: ?int, day: ?int} $cascade
+     */
+    private static function cacheKey(?string $user, array $cascade): string
+    {
+        return sprintf(
+            'lastfm_top_tracks.%s.%s.%s.%s',
+            md5($user ?? ''),
+            $cascade['year'] ?? '_',
+            $cascade['month'] ?? '_',
+            $cascade['day'] ?? '_',
+        );
     }
 }

--- a/src/Controller/LastFmTopTracksController.php
+++ b/src/Controller/LastFmTopTracksController.php
@@ -77,6 +77,7 @@ class LastFmTopTracksController extends AbstractController
             ],
             'source' => $source,
             'computed_at' => $computedAt,
+            'compute_command' => 'app:lastfm:stats:compute',
         ]);
     }
 }

--- a/src/Controller/NavidromeTopAlbumsController.php
+++ b/src/Controller/NavidromeTopAlbumsController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Filter\DateCascadeFilter;
 use App\Navidrome\NavidromeRepository;
+use App\Service\NavidromeStatsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,7 +15,7 @@ class NavidromeTopAlbumsController extends AbstractController
     private const TOP_N = 100;
 
     #[Route('/navidrome/top-albums', name: 'app_navidrome_top_albums', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome): Response
+    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
     {
         $c = DateCascadeFilter::parse(
             $request->query->get('year'),
@@ -22,8 +23,28 @@ class NavidromeTopAlbumsController extends AbstractController
             $request->query->get('day'),
         );
 
+        $source = 'live';
+        $computedAt = null;
+        if ($c['year'] !== null) {
+            $rows = $navidrome->getTopAlbumsWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get();
+            $cached = is_array($snapshot) && isset($snapshot['top_albums_alltime']) && is_array($snapshot['top_albums_alltime'])
+                ? $snapshot['top_albums_alltime']
+                : null;
+            if ($cached !== null) {
+                /** @var list<array{album_id: string, album: string, artist: string, plays: int, track_count: int, first_played_at: string, last_played_at: string}> $rows */
+                $rows = $cached;
+                $source = 'snapshot';
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $navidrome->getTopAlbumsWithDates(null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
+
         return $this->render('navidrome/top_albums.html.twig', [
-            'rows' => $navidrome->getTopAlbumsWithDates($c['year'], $c['month'], $c['day'], self::TOP_N),
+            'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $navidrome->getAvailableScrobbleYears(),
             'filters' => [
@@ -31,6 +52,9 @@ class NavidromeTopAlbumsController extends AbstractController
                 'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
                 'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => 'app:navidrome:stats:compute',
         ]);
     }
 }

--- a/src/Controller/NavidromeTopArtistsController.php
+++ b/src/Controller/NavidromeTopArtistsController.php
@@ -4,46 +4,57 @@ namespace App\Controller;
 
 use App\Filter\DateCascadeFilter;
 use App\Navidrome\NavidromeRepository;
+use App\Service\NavidromeStatsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-/**
- * Top 100 artists ranked by Navidrome plays, with per-artist first /
- * last play. Filterable on a year / month / day cascade — same UX as
- * `/lastfm/scrobbles`. Reads only the Navidrome `scrobbles` table
- * (read-only).
- */
 class NavidromeTopArtistsController extends AbstractController
 {
     private const TOP_N = 100;
 
     #[Route('/navidrome/top-artists', name: 'app_navidrome_top_artists', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome): Response
+    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
     {
-        $cascade = DateCascadeFilter::parse(
+        $c = DateCascadeFilter::parse(
             $request->query->get('year'),
             $request->query->get('month'),
             $request->query->get('day'),
         );
 
-        $rows = $navidrome->getTopArtistsWithDates(
-            $cascade['year'],
-            $cascade['month'],
-            $cascade['day'],
-            self::TOP_N,
-        );
+        $source = 'live';
+        $computedAt = null;
+        if ($c['year'] !== null) {
+            $rows = $navidrome->getTopArtistsWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get();
+            $cached = is_array($snapshot) && isset($snapshot['top_artists_alltime']) && is_array($snapshot['top_artists_alltime'])
+                ? $snapshot['top_artists_alltime']
+                : null;
+            if ($cached !== null) {
+                /** @var list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
+                $rows = $cached;
+                $source = 'snapshot';
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $navidrome->getTopArtistsWithDates(null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
 
         return $this->render('navidrome/top_artists.html.twig', [
             'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $navidrome->getAvailableScrobbleYears(),
             'filters' => [
-                'year' => $cascade['year'] !== null ? (string) $cascade['year'] : '',
-                'month' => $cascade['month'] !== null ? sprintf('%02d', $cascade['month']) : '',
-                'day' => $cascade['day'] !== null ? sprintf('%02d', $cascade['day']) : '',
+                'year' => $c['year'] !== null ? (string) $c['year'] : '',
+                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
+                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => 'app:navidrome:stats:compute',
         ]);
     }
 }

--- a/src/Controller/NavidromeTopTracksController.php
+++ b/src/Controller/NavidromeTopTracksController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Filter\DateCascadeFilter;
 use App\Navidrome\NavidromeRepository;
+use App\Service\NavidromeStatsService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,7 +15,7 @@ class NavidromeTopTracksController extends AbstractController
     private const TOP_N = 100;
 
     #[Route('/navidrome/top-tracks', name: 'app_navidrome_top_tracks', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome): Response
+    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
     {
         $c = DateCascadeFilter::parse(
             $request->query->get('year'),
@@ -22,8 +23,28 @@ class NavidromeTopTracksController extends AbstractController
             $request->query->get('day'),
         );
 
+        $source = 'live';
+        $computedAt = null;
+        if ($c['year'] !== null) {
+            $rows = $navidrome->getTopTracksWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
+        } else {
+            $snapshot = $stats->get();
+            $cached = is_array($snapshot) && isset($snapshot['top_tracks_alltime']) && is_array($snapshot['top_tracks_alltime'])
+                ? $snapshot['top_tracks_alltime']
+                : null;
+            if ($cached !== null) {
+                /** @var list<array{id: string, title: string, artist: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}> $rows */
+                $rows = $cached;
+                $source = 'snapshot';
+                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
+            } else {
+                $rows = $navidrome->getTopTracksWithDates(null, null, null, self::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
+
         return $this->render('navidrome/top_tracks.html.twig', [
-            'rows' => $navidrome->getTopTracksWithDates($c['year'], $c['month'], $c['day'], self::TOP_N),
+            'rows' => $rows,
             'top_n' => self::TOP_N,
             'available_years' => $navidrome->getAvailableScrobbleYears(),
             'filters' => [
@@ -31,6 +52,9 @@ class NavidromeTopTracksController extends AbstractController
                 'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
                 'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
             ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => 'app:navidrome:stats:compute',
         ]);
     }
 }

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -82,6 +82,8 @@ class LastFmStatsService
             // live — le filtre réduit la volumétrie donc la requête est
             // rapide de toute façon.
             'top_tracks_alltime' => $this->topTracksWithDates($user, null, null, null, self::TOP_PAGE_LIMIT),
+            'top_albums_alltime' => $this->topAlbumsWithDates($user, null, null, null, self::TOP_PAGE_LIMIT),
+            'top_artists_alltime' => $this->topArtistsWithDates($user, null, null, null, self::TOP_PAGE_LIMIT),
             'recent_scrobbles' => $this->recentScrobbles($user, self::RECENT_SCROBBLES_LIMIT),
             'recent_loved' => $this->recentLoved($user, self::RECENT_LOVED_LIMIT),
         ];

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -28,6 +28,7 @@ class LastFmStatsService
     private const PLAYS_BY_MONTH_COUNT = 12;
     private const PLAYS_BY_WEEK_COUNT = 15;
     private const PLAYS_BY_DAY_COUNT = 15;
+    private const TOP_PAGE_LIMIT = 100;
 
     public function __construct(
         private readonly Connection $connection,
@@ -75,6 +76,12 @@ class LastFmStatsService
             'top_artists' => $this->topArtists($user, self::TOP_LIMIT),
             'top_tracks' => $this->topTracks($user, self::TOP_LIMIT),
             'top_albums' => $this->topAlbums($user, self::TOP_LIMIT),
+            // Top 100 sans filtre, pré-calculés pour les pages /lastfm/top-*
+            // (lecture instantanée depuis le snapshot quand l'utilisateur
+            // n'a posé aucun filtre date). Les vues filtrées re-tirent en
+            // live — le filtre réduit la volumétrie donc la requête est
+            // rapide de toute façon.
+            'top_tracks_alltime' => $this->topTracksWithDates($user, null, null, null, self::TOP_PAGE_LIMIT),
             'recent_scrobbles' => $this->recentScrobbles($user, self::RECENT_SCROBBLES_LIMIT),
             'recent_loved' => $this->recentLoved($user, self::RECENT_LOVED_LIMIT),
         ];

--- a/src/Service/NavidromeStatsService.php
+++ b/src/Service/NavidromeStatsService.php
@@ -19,6 +19,8 @@ class NavidromeStatsService
 {
     public const SNAPSHOT_KEY = 'navidrome-stats';
 
+    private const TOP_PAGE_LIMIT = 100;
+
     public function __construct(
         private readonly NavidromeRepository $navidrome,
         private readonly StatsSnapshotRepository $snapshots,
@@ -73,6 +75,11 @@ class NavidromeStatsService
             'plays_by_week' => $this->navidrome->getPlaysByWeek(15),
             'plays_by_day' => $this->navidrome->getPlaysByDay(15),
             'disparity' => $this->disparity->compute(),
+            // Top 100 sans filtre pour /navidrome/top-* (lecture instantanée
+            // depuis le snapshot quand pas de filtre date posé).
+            'top_tracks_alltime' => $this->navidrome->getTopTracksWithDates(null, null, null, self::TOP_PAGE_LIMIT),
+            'top_albums_alltime' => $this->navidrome->getTopAlbumsWithDates(null, null, null, self::TOP_PAGE_LIMIT),
+            'top_artists_alltime' => $this->navidrome->getTopArtistsWithDates(null, null, null, self::TOP_PAGE_LIMIT),
         ];
 
         $snapshot = $this->snapshots->findOneByPeriod(self::SNAPSHOT_KEY);

--- a/templates/_top_source_indicator.html.twig
+++ b/templates/_top_source_indicator.html.twig
@@ -1,0 +1,11 @@
+{# Petit bandeau qui précise d'où viennent les rows : snapshot stats
+   préc-calculé, calcul en direct (filtre actif), ou fallback ambre quand
+   le snapshot n'a jamais tourné. Caller passe `source`, `computed_at` et
+   `compute_command`. #}
+{% if source == 'snapshot' and computed_at %}
+    <span class="text-xs text-slate-400">· snapshot du {{ computed_at|date('d/m/Y H:i') }} — recalcul via <code>{{ compute_command }}</code></span>
+{% elseif source == 'live_fallback' %}
+    <span class="text-xs text-amber-600">· snapshot indisponible — calcul en direct ; lancer <code>{{ compute_command }}</code> pour pré-générer</span>
+{% elseif source == 'live' %}
+    <span class="text-xs text-slate-400">· calcul en direct (filtre actif)</span>
+{% endif %}

--- a/templates/lastfm/top_albums.html.twig
+++ b/templates/lastfm/top_albums.html.twig
@@ -5,7 +5,10 @@
         <div>
             <a href="{{ path('app_lastfm_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Last.fm</a>
             <h1 class="text-2xl font-semibold mt-1">Top albums — Last.fm</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} albums par scrobbles. Les scrobbles sans album sont ignorés.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} albums par scrobbles. Les scrobbles sans album sont ignorés.
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_navidrome_top_albums') }}" class="text-sky-700 hover:underline self-center">

--- a/templates/lastfm/top_artists.html.twig
+++ b/templates/lastfm/top_artists.html.twig
@@ -5,7 +5,10 @@
         <div>
             <a href="{{ path('app_lastfm_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Last.fm</a>
             <h1 class="text-2xl font-semibold mt-1">Top artistes — Last.fm</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} artistes par scrobbles sur la base outils.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} artistes par scrobbles sur la base outils.
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_navidrome_top_artists') }}" class="text-sky-700 hover:underline self-center">

--- a/templates/lastfm/top_tracks.html.twig
+++ b/templates/lastfm/top_tracks.html.twig
@@ -7,13 +7,7 @@
             <h1 class="text-2xl font-semibold mt-1">Top morceaux — Last.fm</h1>
             <p class="text-sm text-slate-500">
                 Top {{ top_n }} morceaux par scrobbles.
-                {% if source == 'snapshot' and computed_at %}
-                    <span class="text-xs text-slate-400">· snapshot du {{ computed_at|date('d/m/Y H:i') }} — recalcul via <code>app:lastfm:stats:compute</code></span>
-                {% elseif source == 'live_fallback' %}
-                    <span class="text-xs text-amber-600">· snapshot indisponible — calcul en direct ; lancer <code>app:lastfm:stats:compute</code> pour pré-générer</span>
-                {% elseif source == 'live' %}
-                    <span class="text-xs text-slate-400">· calcul en direct (filtre actif)</span>
-                {% endif %}
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
             </p>
         </div>
         <div class="flex gap-2 text-xs">

--- a/templates/lastfm/top_tracks.html.twig
+++ b/templates/lastfm/top_tracks.html.twig
@@ -5,7 +5,12 @@
         <div>
             <a href="{{ path('app_lastfm_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Last.fm</a>
             <h1 class="text-2xl font-semibold mt-1">Top morceaux — Last.fm</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} morceaux par scrobbles.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} morceaux par scrobbles.
+                {% if cache_ttl_seconds is defined %}
+                    <span class="text-xs text-slate-400">· résultat caché {{ (cache_ttl_seconds / 60)|round }} min</span>
+                {% endif %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_navidrome_top_tracks') }}" class="text-sky-700 hover:underline self-center">

--- a/templates/lastfm/top_tracks.html.twig
+++ b/templates/lastfm/top_tracks.html.twig
@@ -7,8 +7,12 @@
             <h1 class="text-2xl font-semibold mt-1">Top morceaux — Last.fm</h1>
             <p class="text-sm text-slate-500">
                 Top {{ top_n }} morceaux par scrobbles.
-                {% if cache_ttl_seconds is defined %}
-                    <span class="text-xs text-slate-400">· résultat caché {{ (cache_ttl_seconds / 60)|round }} min</span>
+                {% if source == 'snapshot' and computed_at %}
+                    <span class="text-xs text-slate-400">· snapshot du {{ computed_at|date('d/m/Y H:i') }} — recalcul via <code>app:lastfm:stats:compute</code></span>
+                {% elseif source == 'live_fallback' %}
+                    <span class="text-xs text-amber-600">· snapshot indisponible — calcul en direct ; lancer <code>app:lastfm:stats:compute</code> pour pré-générer</span>
+                {% elseif source == 'live' %}
+                    <span class="text-xs text-slate-400">· calcul en direct (filtre actif)</span>
                 {% endif %}
             </p>
         </div>

--- a/templates/navidrome/top_albums.html.twig
+++ b/templates/navidrome/top_albums.html.twig
@@ -5,7 +5,10 @@
         <div>
             <a href="{{ path('app_navidrome_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Navidrome</a>
             <h1 class="text-2xl font-semibold mt-1">Top albums — Navidrome</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} albums par lectures.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} albums par lectures.
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_lastfm_top_albums') }}" class="text-sky-700 hover:underline self-center">

--- a/templates/navidrome/top_artists.html.twig
+++ b/templates/navidrome/top_artists.html.twig
@@ -5,7 +5,10 @@
         <div>
             <a href="{{ path('app_navidrome_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Navidrome</a>
             <h1 class="text-2xl font-semibold mt-1">Top artistes — Navidrome</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} artistes par lectures sur la base Navidrome.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} artistes par lectures sur la base Navidrome.
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_lastfm_top_artists') }}" class="text-sky-700 hover:underline self-center">

--- a/templates/navidrome/top_tracks.html.twig
+++ b/templates/navidrome/top_tracks.html.twig
@@ -5,7 +5,10 @@
         <div>
             <a href="{{ path('app_navidrome_stats') }}" class="text-sm text-sky-700 hover:underline">← Stats Navidrome</a>
             <h1 class="text-2xl font-semibold mt-1">Top morceaux — Navidrome</h1>
-            <p class="text-sm text-slate-500">Top {{ top_n }} morceaux par lectures.</p>
+            <p class="text-sm text-slate-500">
+                Top {{ top_n }} morceaux par lectures.
+                {% include '_top_source_indicator.html.twig' with { source: source, computed_at: computed_at, compute_command: compute_command } only %}
+            </p>
         </div>
         <div class="flex gap-2 text-xs">
             <a href="{{ path('app_lastfm_top_tracks') }}" class="text-sky-700 hover:underline self-center">


### PR DESCRIPTION
## Summary

Pattern de pré-calcul via snapshot stats étendu aux **6 pages top-***.

### Pipeline

- **`LastFmStatsService::compute()`** stocke `top_tracks_alltime`, `top_albums_alltime`, `top_artists_alltime` (top 100, sans filtre) dans le snapshot `lastfm-stats[-user]`. Tournée par `app:lastfm:stats:compute` ou par le bouton « ↻ Recalculer » sur `/lastfm/stats`.
- **`NavidromeStatsService::compute()`** stocke les 3 mêmes clés dans le snapshot `navidrome-stats`. Tournée par `app:navidrome:stats:compute`.
- **Les 6 controllers** `/{lastfm,navidrome}/top-{artists,albums,tracks}` basculent uniformément :
  - aucun filtre → lecture instantanée depuis le snapshot.
  - filtre `year` / `month` / `day` posé → requête live (la fenêtre réduit la volumétrie, c'est rapide).
  - snapshot manquant → fallback live + bandeau ambre qui pointe la commande à lancer.

### UI

Nouveau partial `_top_source_indicator.html.twig` factorise le bandeau dans le sous-titre des 6 pages :

- `· snapshot du DD/MM/YYYY HH:MM — recalcul via app:{lastfm,navidrome}:stats:compute`
- `· snapshot indisponible — calcul en direct ; lancer la commande pour pré-générer`
- `· calcul en direct (filtre actif)`

Chaque controller passe `source`, `computed_at` et `compute_command` au template.

### Bénéfice opérationnel

Une seule commande recalcule tous les top-* d'un côté (Last.fm ou Navidrome) à la fois. Une seule entrée `run_history` par recalcul, pas 6.

## Test plan

- [x] `composer phpcs` → vert
- [x] `phpunit` → 113 / 344 verts
- [x] `phpstan` → 10 erreurs **pré-existantes**, rien sur le nouveau code
- [x] `lint:twig` → 7 templates valides
- [ ] `php bin/console app:lastfm:stats:compute` puis visiter `/lastfm/top-{tracks,albums,artists}` → bandeau « snapshot du … » et chargement instantané sur les 3
- [ ] `php bin/console app:navidrome:stats:compute` idem côté Navidrome
- [ ] Poser un filtre date sur n'importe quelle page → bandeau « calcul en direct (filtre actif) », requête live
- [ ] Fresh DB sans snapshot → bandeau ambre, fallback live