### PR TITLE
refactor(config): bind global $defaultUser au lieu de 17 déclarations (1/4)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -40,6 +40,7 @@ services:
         public: false
         bind:
             $projectDir: '%kernel.project_dir%'
+            $defaultUser: '%lastfm.user%'
 
     _instanceof:
         App\Notifier\NotifierDriverInterface:
@@ -111,12 +112,10 @@ services:
     App\Command\FetchLastFmCommand:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
-            $defaultUser: '%lastfm.user%'
 
     App\Controller\LastFmImportController:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
-            $defaultUser: '%lastfm.user%'
 
     App\LastFm\ScrobbleMatcher:
         arguments:
@@ -142,14 +141,6 @@ services:
         arguments:
             $varDir: '%kernel.project_dir%/var'
 
-    App\Command\ComputeStatsCommand:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Service\DisparityStatsService:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
     App\Twig\LidarrExtension:
         arguments:
             $lidarrUrl: '%lidarr.url%'
@@ -160,65 +151,28 @@ services:
             $navidromeUrl: '%navidrome.url%'
         tags: ['twig.extension']
 
-    App\Controller\LastFmScrobblesController:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Controller\LastFmTopArtistsController:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Controller\LastFmTopAlbumsController:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Controller\LastFmTopTracksController:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
     App\Controller\HelpController:
         arguments:
             $composeService: '%help.compose_service%'
 
-    App\Controller\StatsController:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
     App\Controller\LastFmStatsController:
         arguments:
-            $defaultUser: '%lastfm.user%'
             $defaultApiKey: '%lastfm.api_key%'
 
     App\Command\SyncLastFmLovedCommand:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
-            $defaultUser: '%lastfm.user%'
 
     App\Command\LastFmAuthCommand:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
             $defaultApiSecret: '%lastfm.api_secret%'
-            $defaultUser: '%lastfm.user%'
 
     App\Command\SyncLovesLastFmToNavidromeCommand:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
-            $defaultUser: '%lastfm.user%'
 
     App\Command\SyncLovesNavidromeToLastFmCommand:
         arguments:
             $defaultApiKey: '%lastfm.api_key%'
             $defaultApiSecret: '%lastfm.api_secret%'
-            $defaultUser: '%lastfm.user%'
-
-    App\Command\ComputeLastFmStatsCommand:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Command\StatsCommand:
-        arguments:
-            $defaultUser: '%lastfm.user%'
-
-    App\Controller\DashboardController:
-        arguments:
-            $defaultUser: '%lastfm.user%'


### PR DESCRIPTION
## Summary

PR 1/4 d'une série d'amélioration de la base de code. **Zéro impact fonctionnel.**

`$defaultUser: '%lastfm.user%'` déplacé dans `_defaults.bind` (à côté de `$projectDir`). **17 déclarations par-service supprimées** : 10 blocs `arguments` devenus vides retirés, 7 lignes ôtées de blocs qui gardent d'autres args (`$defaultApiKey`, etc.). Net : −47 lignes dans `config/services.yaml`.

### Note sur la piste PHPStan abandonnée

La première version de cette PR ajoutait une `phpstan-baseline.neon` pour les « 10 erreurs récurrentes ». La CI a révélé que **ces 10 erreurs n'existent qu'en local** : en CI les extensions `phpstan-doctrine` / `phpstan-symfony` (présentes dans `require-dev` + `extension-installer`) résolvent l'hydratation Doctrine et les generics de Form, donc la CI était **déjà phpstan-green à 0 erreur**. La baseline listait des patterns que CI ne produit jamais → `ignore.unmatched (non-ignorable)` → échec. Baseline supprimée, plus nécessaire.

## Test plan

- [x] `composer phpcs` → vert
- [x] `composer phpunit` → 113 / 344 verts
- [x] `php bin/console lint:container` → tous les services reçoivent bien `$defaultUser`
- [x] CI phpstan déjà à 0 erreur (pas de baseline)

## Suite

PR 2 (tests du code récent), PR 3 (dédup controllers top-*), PR 4 (split god object `NavidromeRepository`).