### PR TITLE
test(navidrome): top-* / annotation (ann_id) / sync+reconcile (2/4)

### DIFF
--- a/tests/Navidrome/NavidromeAnnotationTest.php
+++ b/tests/Navidrome/NavidromeAnnotationTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\DriverManager;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks in the schema-agnostic annotation INSERT (fix #184) on the two
+ * variants of Navidrome's `annotation` table : with `ann_id` (older) and
+ * without (mid-2025+, identity = UNIQUE composite). Same code path,
+ * both INSERTs must land cleanly.
+ *
+ * Also covers reconcileAnnotationForMediaFiles() — the bridge between
+ * the `scrobbles` table populated by `app:scrobbles:sync-navidrome` and
+ * the `annotation.play_count` column the Navidrome UI actually reads.
+ */
+class NavidromeAnnotationTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    /**
+     * @return array{0: NavidromeRepository, 1: string}
+     */
+    private function setupRepo(bool $withAnnId): array
+    {
+        $path = sys_get_temp_dir() . '/nd-ann-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true, withAnnId: $withAnnId);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-1', 'Get Lucky', 'Daft Punk');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-2', 'Da Funk', 'Daft Punk');
+        $conn->close();
+
+        return [new NavidromeRepository($path, 'admin'), $path];
+    }
+
+    #[DataProvider('schemas')]
+    public function testMarkStarredInsertsRowOnFreshAnnotation(bool $withAnnId): void
+    {
+        [$repo, $path] = $this->setupRepo($withAnnId);
+
+        $this->assertTrue($repo->markStarred('mf-1'));
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        $row = $conn->fetchAssociative(
+            "SELECT user_id, item_id, item_type, starred, starred_at FROM annotation
+              WHERE item_id = 'mf-1'",
+        );
+        $this->assertSame('user-1', $row['user_id']);
+        $this->assertSame(1, (int) $row['starred']);
+        $this->assertNotNull($row['starred_at']);
+        $conn->close();
+    }
+
+    #[DataProvider('schemas')]
+    public function testMarkStarredPromotesExistingRowFromPlaycountOnly(bool $withAnnId): void
+    {
+        [$repo, $path] = $this->setupRepo($withAnnId);
+
+        // Pre-seed an annotation row with play_count=5 but starred=0.
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        NavidromeFixtureFactory::insertAnnotation($conn, 'user-1', 'mf-1', playCount: 5, playDate: '2024-01-01 12:00:00');
+
+        $this->assertTrue($repo->markStarred('mf-1'));
+
+        $row = $conn->fetchAssociative("SELECT play_count, starred FROM annotation WHERE item_id = 'mf-1'");
+        $this->assertSame(5, (int) $row['play_count'], 'play_count must be preserved');
+        $this->assertSame(1, (int) $row['starred']);
+        $conn->close();
+    }
+
+    #[DataProvider('schemas')]
+    public function testMarkStarredIsIdempotentOnAlreadyStarred(bool $withAnnId): void
+    {
+        [$repo, $path] = $this->setupRepo($withAnnId);
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        NavidromeFixtureFactory::insertAnnotation($conn, 'user-1', 'mf-1', playCount: 0, playDate: '2024-01-01 12:00:00', starred: 1, starredAt: '2024-01-01 00:00:00');
+        $conn->close();
+
+        // Second call must not flip any row, and must not raise « table
+        // annotation has no column named ann_id » on the ann_id-less schema.
+        $this->assertFalse($repo->markStarred('mf-1'));
+    }
+
+    #[DataProvider('schemas')]
+    public function testReconcileAnnotationCreatesRowsForFreshMediaFiles(bool $withAnnId): void
+    {
+        [$repo, $path] = $this->setupRepo($withAnnId);
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2024-01-01 10:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2024-01-02 10:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-2', '2024-01-03 10:00:00');
+        $conn->close();
+
+        $touched = $repo->reconcileAnnotationForMediaFiles('user-1', ['mf-1', 'mf-2']);
+        $this->assertSame(2, $touched);
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        $rows = $conn->fetchAllAssociativeIndexed(
+            "SELECT item_id, play_count, play_date FROM annotation",
+        );
+        $this->assertSame(2, (int) $rows['mf-1']['play_count']);
+        $this->assertSame(1, (int) $rows['mf-2']['play_count']);
+        // play_date is taken from datetime(MAX(submission_time), 'unixepoch').
+        $this->assertSame('2024-01-02 10:00:00', $rows['mf-1']['play_date']);
+        $conn->close();
+    }
+
+    #[DataProvider('schemas')]
+    public function testReconcileAnnotationUpdatesExistingRowsWithoutDuplicating(bool $withAnnId): void
+    {
+        [$repo, $path] = $this->setupRepo($withAnnId);
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        // Pre-existing annotation with a stale play_count — typically what
+        // a wipe-scrobbles left behind (count=0) before re-import.
+        NavidromeFixtureFactory::insertAnnotation($conn, 'user-1', 'mf-1', playCount: 0, playDate: '1970-01-01 00:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2024-06-15 10:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-1', '2024-06-16 10:00:00');
+        $conn->close();
+
+        $repo->reconcileAnnotationForMediaFiles('user-1', ['mf-1']);
+
+        $conn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $path]);
+        $rows = $conn->fetchAllAssociative("SELECT play_count, play_date FROM annotation WHERE item_id = 'mf-1'");
+        $this->assertCount(1, $rows, 'No duplicate annotation row');
+        $this->assertSame(2, (int) $rows[0]['play_count']);
+        $this->assertSame('2024-06-16 10:00:00', $rows[0]['play_date']);
+        $conn->close();
+    }
+
+    public function testReconcileNoopOnEmptyMediaFileList(): void
+    {
+        [$repo, $_] = $this->setupRepo(withAnnId: false);
+        $this->assertSame(0, $repo->reconcileAnnotationForMediaFiles('user-1', []));
+    }
+
+    /**
+     * @return array<string, array{0: bool}>
+     */
+    public static function schemas(): array
+    {
+        return [
+            'older schema with ann_id' => [true],
+            'recent schema without ann_id (fix #184)' => [false],
+        ];
+    }
+}

--- a/tests/Navidrome/NavidromeFixtureFactory.php
+++ b/tests/Navidrome/NavidromeFixtureFactory.php
@@ -10,7 +10,14 @@ use Doctrine\DBAL\DriverManager;
  */
 final class NavidromeFixtureFactory
 {
-    public static function createDatabase(string $path, bool $withScrobbles = true): Connection
+    /**
+     * @param bool $withAnnId  when false, builds the `annotation` table WITHOUT
+     *                         the `ann_id` column — mirroring recent Navidrome
+     *                         (mid-2025+) which dropped it and keys on the
+     *                         UNIQUE (user_id, item_id, item_type) constraint.
+     *                         Used to exercise the schema-agnostic INSERT path.
+     */
+    public static function createDatabase(string $path, bool $withScrobbles = true, bool $withAnnId = true): Connection
     {
         if (file_exists($path)) {
             unlink($path);
@@ -53,19 +60,38 @@ final class NavidromeFixtureFactory
                 mbz_album_artist_id VARCHAR(255) DEFAULT NULL
             )
         SQL);
-        $conn->executeStatement(<<<'SQL'
-            CREATE TABLE annotation (
-                ann_id VARCHAR(255) PRIMARY KEY NOT NULL,
-                user_id VARCHAR(255) DEFAULT '' NOT NULL,
-                item_id VARCHAR(255) DEFAULT '' NOT NULL,
-                item_type VARCHAR(255) DEFAULT '' NOT NULL,
-                play_count INTEGER,
-                play_date DATETIME,
-                rating INTEGER,
-                starred BOOL DEFAULT 0 NOT NULL,
-                starred_at DATETIME
-            )
-        SQL);
+        if ($withAnnId) {
+            $conn->executeStatement(<<<'SQL'
+                CREATE TABLE annotation (
+                    ann_id VARCHAR(255) PRIMARY KEY NOT NULL,
+                    user_id VARCHAR(255) DEFAULT '' NOT NULL,
+                    item_id VARCHAR(255) DEFAULT '' NOT NULL,
+                    item_type VARCHAR(255) DEFAULT '' NOT NULL,
+                    play_count INTEGER,
+                    play_date DATETIME,
+                    rating INTEGER,
+                    starred BOOL DEFAULT 0 NOT NULL,
+                    starred_at DATETIME,
+                    UNIQUE (user_id, item_id, item_type)
+                )
+            SQL);
+        } else {
+            // Recent Navidrome schema: no ann_id, identity = composite UNIQUE.
+            $conn->executeStatement(<<<'SQL'
+                CREATE TABLE annotation (
+                    user_id VARCHAR(255) DEFAULT '' NOT NULL,
+                    item_id VARCHAR(255) DEFAULT '' NOT NULL,
+                    item_type VARCHAR(255) DEFAULT '' NOT NULL,
+                    play_count INTEGER DEFAULT 0,
+                    play_date DATETIME,
+                    rating INTEGER DEFAULT 0,
+                    starred BOOL DEFAULT 0 NOT NULL,
+                    starred_at DATETIME,
+                    rated_at DATETIME,
+                    UNIQUE (user_id, item_id, item_type)
+                )
+            SQL);
+        }
 
         if ($withScrobbles) {
             // Mirror the real Navidrome 0.55+ schema where submission_time is
@@ -126,13 +152,43 @@ final class NavidromeFixtureFactory
         );
     }
 
-    public static function insertAnnotation(Connection $conn, string $userId, string $mediaId, int $playCount, string $playDate): void
-    {
+    /**
+     * Insert an annotation row, adapting to whichever schema the DB was
+     * built with (with / without `ann_id`).
+     */
+    public static function insertAnnotation(
+        Connection $conn,
+        string $userId,
+        string $mediaId,
+        int $playCount,
+        string $playDate,
+        int $starred = 0,
+        ?string $starredAt = null,
+    ): void {
+        if (self::annotationHasAnnId($conn)) {
+            $conn->executeStatement(
+                'INSERT INTO annotation (ann_id, user_id, item_id, item_type, play_count, play_date, starred, starred_at)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+                [bin2hex(random_bytes(8)), $userId, $mediaId, 'media_file', $playCount, $playDate, $starred, $starredAt],
+            );
+            return;
+        }
         $conn->executeStatement(
-            'INSERT INTO annotation (ann_id, user_id, item_id, item_type, play_count, play_date)
-             VALUES (?, ?, ?, ?, ?, ?)',
-            [bin2hex(random_bytes(8)), $userId, $mediaId, 'media_file', $playCount, $playDate],
+            'INSERT INTO annotation (user_id, item_id, item_type, play_count, play_date, starred, starred_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [$userId, $mediaId, 'media_file', $playCount, $playDate, $starred, $starredAt],
         );
+    }
+
+    private static function annotationHasAnnId(Connection $conn): bool
+    {
+        foreach ($conn->fetchAllAssociative('PRAGMA table_info(annotation)') as $col) {
+            if (($col['name'] ?? null) === 'ann_id') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public static function insertScrobble(

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -161,6 +161,52 @@ class NavidromeSyncServiceTest extends TestCase
         $this->assertSame(1, $report->matched);
     }
 
+    public function testSyncReconcilesAnnotationPlayCountInSameTransaction(): void
+    {
+        // Regression: `insertScrobble()` only touches the `scrobbles` table.
+        // Without the reconcile step inside flushBatch, Navidrome's UI keeps
+        // showing 0 plays. Lock in that play_count / play_date are bumped on
+        // `annotation` in the same write transaction as the inserts.
+        $s1 = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $s2 = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-02-15 09:00:00');
+        $sync1 = new ScrobbleSync($s1, ScrobbleSync::TARGET_NAVIDROME);
+        $sync2 = new ScrobbleSync($s2, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(2);
+        $syncRepo->method('streamPending')->willReturnCallback(function () use ($sync1, $sync2): \Generator {
+            yield $sync1;
+            yield $sync2;
+        });
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturn(null);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process();
+
+        $this->assertSame(2, $report->matched);
+
+        $ndConn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->ndDbPath]);
+        $this->assertSame(2, (int) $ndConn->fetchOne("SELECT COUNT(*) FROM scrobbles"));
+        $row = $ndConn->fetchAssociative(
+            "SELECT play_count, play_date FROM annotation WHERE item_id = 'mf-1'",
+        );
+        $this->assertNotFalse($row, 'annotation row must be created by reconcile');
+        $this->assertSame(2, (int) $row['play_count'], 'play_count reflects both scrobbles');
+        $this->assertSame('2024-02-15 09:00:00', $row['play_date'], 'play_date = MAX(submission_time)');
+        $ndConn->close();
+    }
+
     public function testBatchFlushDetachesBothSyncAndScrobble(): void
     {
         // Regression for the OOM on --limit=50000 : the old code detached

--- a/tests/Navidrome/NavidromeTopListsTest.php
+++ b/tests/Navidrome/NavidromeTopListsTest.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Locks in the behaviour of the top-* readers that feed the 6 Top pages:
+ * ranking by play volume, first/last play bounds, and the year/month/day
+ * cascade filter. These are integration tests against a real SQLite
+ * Navidrome fixture — the SQL (GROUP BY + strftime on submission_time
+ * unixepoch) is the part with real bug surface.
+ */
+class NavidromeTopListsTest extends TestCase
+{
+    private string $dbPath;
+
+    protected function setUp(): void
+    {
+        $this->dbPath = sys_get_temp_dir() . '/nd-top-test-' . uniqid() . '.db';
+        $conn = NavidromeFixtureFactory::createDatabase($this->dbPath, withScrobbles: true);
+
+        // Three artists / albums / tracks with distinct play volumes and
+        // spread across two years so the cascade can be exercised.
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a1', 'Around the World', 'Daft Punk', album: 'Homework');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a2', 'Da Funk', 'Daft Punk', album: 'Homework');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b1', 'Hoppipolla', 'Sigur Ros', album: 'Takk');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-c1', 'Svefn', 'Amiina', album: 'Kurr');
+
+        // Daft Punk: 4 plays (3 in 2024-03, 1 in 2025-01) — top artist.
+        self::play($conn, 'mf-a1', '2024-03-01 10:00:00');
+        self::play($conn, 'mf-a1', '2024-03-15 11:00:00');
+        self::play($conn, 'mf-a2', '2024-03-20 12:00:00');
+        self::play($conn, 'mf-a1', '2025-01-05 09:00:00');
+        // Sigur Ros: 2 plays in 2024-03.
+        self::play($conn, 'mf-b1', '2024-03-02 10:00:00');
+        self::play($conn, 'mf-b1', '2024-03-03 10:00:00');
+        // Amiina: 1 play in 2025-02.
+        self::play($conn, 'mf-c1', '2025-02-10 10:00:00');
+
+        $conn->close();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ([$this->dbPath, $this->dbPath . '-wal', $this->dbPath . '-shm'] as $f) {
+            if (file_exists($f)) {
+                unlink($f);
+            }
+        }
+    }
+
+    private static function play(Connection $conn, string $mediaId, string $time): void
+    {
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', $mediaId, $time);
+    }
+
+    private function repo(): NavidromeRepository
+    {
+        return new NavidromeRepository($this->dbPath, 'admin');
+    }
+
+    public function testTopArtistsRankedByPlaysWithFirstLastBounds(): void
+    {
+        $rows = $this->repo()->getTopArtistsWithDates(null, null, null, 10);
+
+        $this->assertSame('Daft Punk', $rows[0]['artist']);
+        $this->assertSame(4, $rows[0]['plays']);
+        $this->assertSame('Sigur Ros', $rows[1]['artist']);
+        $this->assertSame(2, $rows[1]['plays']);
+        // First / last play span the full history for Daft Punk.
+        $this->assertSame('2024-03-01 10:00:00', $rows[0]['first_played_at']);
+        $this->assertSame('2025-01-05 09:00:00', $rows[0]['last_played_at']);
+    }
+
+    public function testTopArtistsYearFilter(): void
+    {
+        $rows = $this->repo()->getTopArtistsWithDates(2025, null, null, 10);
+
+        $byArtist = array_column($rows, 'plays', 'artist');
+        $this->assertSame(1, $byArtist['Daft Punk'] ?? null, '2025 has 1 Daft Punk play');
+        $this->assertSame(1, $byArtist['Amiina'] ?? null);
+        $this->assertArrayNotHasKey('Sigur Ros', $byArtist, 'Sigur Ros never played in 2025');
+    }
+
+    public function testTopArtistsYearMonthFilter(): void
+    {
+        $rows = $this->repo()->getTopArtistsWithDates(2024, 3, null, 10);
+        $byArtist = array_column($rows, 'plays', 'artist');
+
+        $this->assertSame(3, $byArtist['Daft Punk'] ?? null);
+        $this->assertSame(2, $byArtist['Sigur Ros'] ?? null);
+        $this->assertArrayNotHasKey('Amiina', $byArtist);
+    }
+
+    public function testTopArtistsFullDayFilter(): void
+    {
+        $rows = $this->repo()->getTopArtistsWithDates(2024, 3, 1, 10);
+        $byArtist = array_column($rows, 'plays', 'artist');
+
+        $this->assertSame(['Daft Punk' => 1], $byArtist, 'Only mf-a1 on 2024-03-01');
+    }
+
+    public function testTopAlbumsRankedByPlays(): void
+    {
+        $rows = $this->repo()->getTopAlbumsWithDates(null, null, null, 10);
+
+        $this->assertSame('Homework', $rows[0]['album']);
+        $this->assertSame(4, $rows[0]['plays']);
+        $this->assertSame(2, $rows[0]['track_count'], 'Homework has 2 distinct tracks played');
+    }
+
+    public function testTopTracksRankedByPlays(): void
+    {
+        $rows = $this->repo()->getTopTracksWithDates(null, null, null, 10);
+
+        $this->assertSame('mf-a1', $rows[0]['id']);
+        $this->assertSame('Around the World', $rows[0]['title']);
+        $this->assertSame(3, $rows[0]['plays']);
+        $this->assertSame('2024-03-01 10:00:00', $rows[0]['first_played_at']);
+        $this->assertSame('2025-01-05 09:00:00', $rows[0]['last_played_at']);
+    }
+
+    public function testLimitCapsResults(): void
+    {
+        $this->assertCount(1, $this->repo()->getTopArtistsWithDates(null, null, null, 1));
+    }
+
+    public function testEmptyWhenScrobblesTableMissing(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-noscrob-' . uniqid() . '.db';
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+        $this->assertSame([], $repo->getTopArtistsWithDates(null, null, null, 10));
+        $this->assertSame([], $repo->getTopAlbumsWithDates(null, null, null, 10));
+        $this->assertSame([], $repo->getTopTracksWithDates(null, null, null, 10));
+        $this->assertSame([], $repo->getAvailableScrobbleYears());
+
+        unlink($path);
+    }
+
+    public function testAvailableScrobbleYearsDescending(): void
+    {
+        $this->assertSame(['2025', '2024'], $this->repo()->getAvailableScrobbleYears());
+    }
+
+    public function testFirstScrobbleMonth(): void
+    {
+        $this->assertSame('2024-03', $this->repo()->getFirstScrobbleMonth());
+    }
+}


### PR DESCRIPTION
## Summary

PR **2/4** — couvre le code récent posé sans tests, **avant** les refactos plus risquées des PR suivantes. **Aucun changement de logique métier** : ces tests documentent le comportement actuel et serviront de filet pour les PR 3 et 4.

### `NavidromeFixtureFactory` étendu

- `createDatabase(withAnnId: bool)` modélise **les deux schémas** d'`annotation` :
  - ancien : `ann_id` PK + UNIQUE composite,
  - récent : pas de `ann_id`, identité = UNIQUE composite (cf. fix #184).
- `insertAnnotation()` détecte le schéma au runtime et adapte l'INSERT — même contrat que la méthode prod `annotationInsertShape()`.

### `NavidromeTopListsTest` (10 tests)

Verrouille les méthodes top-* qui nourrissent les 6 pages `/top-*` :
- tri par plays, bornes first/last play (`datetime(submission_time, 'unixepoch')`),
- cascade year / year+month / year+month+day,
- limit qui cap, `[]` quand la table `scrobbles` est absente,
- `availableScrobbleYears()` descendant, `getFirstScrobbleMonth()`.

### `NavidromeAnnotationTest` (11 tests, data provider sur 2 schémas)

Verrouille le fix #184 sur **les deux schémas en parallèle** :
- `markStarred()` insère sur fresh row,
- `markStarred()` promote `starred=0 → 1` sans toucher `play_count`,
- `markStarred()` idempotent quand déjà starré (pas de doublon),
- `reconcileAnnotationForMediaFiles()` crée des annotations neuves,
- `reconcileAnnotationForMediaFiles()` met à jour sans dupliquer,
- noop sur liste vide.

### `NavidromeSyncServiceTest` étendu

Nouveau cas bout-en-bout `testSyncReconcilesAnnotationPlayCountInSameTransaction` — 2 scrobbles traités via `process()`. Vérifie que `annotation.play_count = 2` ET `play_date = MAX(submission_time)` après le sync, preuve que le reconcile tourne bien dans la même transaction que les inserts scrobbles (le bug fixé en #182).

## Test plan

- [x] `composer phpcs` → vert
- [x] `composer phpunit` → **135 / 408 verts** (était 113 / 344)
- [x] `composer phpstan` → vert en CI (les 10 erreurs locales sont l'artefact d'environnement déjà constaté en #187)

## Suite

- PR 3 : dédup des 6 controllers top-* + `DateCascadeFilter::toSqlClauses()` (les tests de cette PR protègent le refacto).
- PR 4 : split god object — `NavidromeStringNormalizer` + `NavidromeSchemaIntrospector`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_