### PR TITLE
refactor(controllers): AbstractTopListController + DateCascadeFilter::toSqlClause (3/4)

### DIFF
--- a/src/Controller/LastFmTopAlbumsController.php
+++ b/src/Controller/LastFmTopAlbumsController.php
@@ -2,68 +2,60 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Repository\ScrobbleRepository;
 use App\Service\LastFmStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class LastFmTopAlbumsController extends AbstractController
+class LastFmTopAlbumsController extends AbstractTopListController
 {
-    private const TOP_N = 100;
-
     public function __construct(
+        private readonly LastFmStatsService $stats,
+        private readonly ScrobbleRepository $scrobbles,
         private readonly string $defaultUser,
     ) {
     }
 
     #[Route('/lastfm/top-albums', name: 'app_lastfm_top_albums', methods: ['GET'])]
-    public function index(
-        Request $request,
-        LastFmStatsService $stats,
-        ScrobbleRepository $scrobbles,
-    ): Response {
-        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
+    public function index(Request $request): Response
+    {
+        return $this->renderTopList($request);
+    }
 
-        $source = 'live';
-        $computedAt = null;
-        if ($c['year'] !== null) {
-            $rows = $stats->topAlbumsWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get($user);
-            $cached = is_array($snapshot) && isset($snapshot['top_albums_alltime']) && is_array($snapshot['top_albums_alltime'])
-                ? $snapshot['top_albums_alltime']
-                : null;
-            if ($cached !== null) {
-                /** @var list<array{artist: string, album: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
-                $rows = $cached;
-                $source = 'snapshot';
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $stats->topAlbumsWithDates($user, null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    private function user(): ?string
+    {
+        return $this->defaultUser !== '' ? $this->defaultUser : null;
+    }
 
-        return $this->render('lastfm/top_albums.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $scrobbles->availableYears($user),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:lastfm:stats:compute',
-        ]);
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->stats->topAlbumsWithDates($this->user(), $year, $month, $day, $limit);
+    }
+
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get($this->user());
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_albums_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->scrobbles->availableYears($this->user());
+    }
+
+    protected function templateName(): string
+    {
+        return 'lastfm/top_albums.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:lastfm:stats:compute';
     }
 }

--- a/src/Controller/LastFmTopArtistsController.php
+++ b/src/Controller/LastFmTopArtistsController.php
@@ -2,74 +2,60 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Repository\ScrobbleRepository;
 use App\Service\LastFmStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-/**
- * Top artistes Last.fm. Sans filtre → lecture instantanée depuis
- * `top_artists_alltime` du snapshot stats. Avec filtre date → requête
- * live (la fenêtre réduit la volumétrie). Snapshot manquant → fallback
- * live + bandeau ambre invitant à lancer `app:lastfm:stats:compute`.
- */
-class LastFmTopArtistsController extends AbstractController
+class LastFmTopArtistsController extends AbstractTopListController
 {
-    private const TOP_N = 100;
-
     public function __construct(
+        private readonly LastFmStatsService $stats,
+        private readonly ScrobbleRepository $scrobbles,
         private readonly string $defaultUser,
     ) {
     }
 
     #[Route('/lastfm/top-artists', name: 'app_lastfm_top_artists', methods: ['GET'])]
-    public function index(
-        Request $request,
-        LastFmStatsService $stats,
-        ScrobbleRepository $scrobbles,
-    ): Response {
-        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
+    public function index(Request $request): Response
+    {
+        return $this->renderTopList($request);
+    }
 
-        $source = 'live';
-        $computedAt = null;
-        if ($c['year'] !== null) {
-            $rows = $stats->topArtistsWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get($user);
-            $cached = is_array($snapshot) && isset($snapshot['top_artists_alltime']) && is_array($snapshot['top_artists_alltime'])
-                ? $snapshot['top_artists_alltime']
-                : null;
-            if ($cached !== null) {
-                /** @var list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
-                $rows = $cached;
-                $source = 'snapshot';
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $stats->topArtistsWithDates($user, null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    private function user(): ?string
+    {
+        return $this->defaultUser !== '' ? $this->defaultUser : null;
+    }
 
-        return $this->render('lastfm/top_artists.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $scrobbles->availableYears($user),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:lastfm:stats:compute',
-        ]);
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->stats->topArtistsWithDates($this->user(), $year, $month, $day, $limit);
+    }
+
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get($this->user());
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_artists_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->scrobbles->availableYears($this->user());
+    }
+
+    protected function templateName(): string
+    {
+        return 'lastfm/top_artists.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:lastfm:stats:compute';
     }
 }

--- a/src/Controller/LastFmTopTracksController.php
+++ b/src/Controller/LastFmTopTracksController.php
@@ -2,82 +2,60 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Repository\ScrobbleRepository;
 use App\Service\LastFmStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-/**
- * Top morceaux Last.fm. Deux chemins selon que l'utilisateur a posé
- * un filtre date ou pas :
- *
- *  - **Aucun filtre** → lecture depuis `top_tracks_alltime` du
- *    snapshot persisté par `LastFmStatsService::compute()` (commande
- *    `app:lastfm:stats:compute`). C'est la vue par défaut et la plus
- *    lourde à calculer ; on l'amortit une fois pour toutes au
- *    recompute. Si le snapshot manque (jamais calculé), on tombe sur
- *    un fallback live et on signale l'utilisateur dans le bandeau.
- *  - **Filtre posé** (`year` / `month` / `day`) → requête live. Le
- *    filtre réduit la volumétrie donc la requête est rapide même
- *    sur les grosses bases.
- */
-class LastFmTopTracksController extends AbstractController
+class LastFmTopTracksController extends AbstractTopListController
 {
-    private const TOP_N = 100;
-
     public function __construct(
+        private readonly LastFmStatsService $stats,
+        private readonly ScrobbleRepository $scrobbles,
         private readonly string $defaultUser,
     ) {
     }
 
     #[Route('/lastfm/top-tracks', name: 'app_lastfm_top_tracks', methods: ['GET'])]
-    public function index(
-        Request $request,
-        LastFmStatsService $stats,
-        ScrobbleRepository $scrobbles,
-    ): Response {
-        $user = $this->defaultUser !== '' ? $this->defaultUser : null;
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
-        $hasFilter = $c['year'] !== null;
+    public function index(Request $request): Response
+    {
+        return $this->renderTopList($request);
+    }
 
-        $source = $hasFilter ? 'live' : 'snapshot';
-        $computedAt = null;
-        if ($hasFilter) {
-            $rows = $stats->topTracksWithDates($user, $c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get($user);
-            /** @var list<array{artist: string, title: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}>|null $cached */
-            $cached = is_array($snapshot) && isset($snapshot['top_tracks_alltime']) && is_array($snapshot['top_tracks_alltime'])
-                ? $snapshot['top_tracks_alltime']
-                : null;
-            if ($cached !== null) {
-                $rows = $cached;
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $stats->topTracksWithDates($user, null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    private function user(): ?string
+    {
+        return $this->defaultUser !== '' ? $this->defaultUser : null;
+    }
 
-        return $this->render('lastfm/top_tracks.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $scrobbles->availableYears($user),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:lastfm:stats:compute',
-        ]);
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->stats->topTracksWithDates($this->user(), $year, $month, $day, $limit);
+    }
+
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get($this->user());
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_tracks_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->scrobbles->availableYears($this->user());
+    }
+
+    protected function templateName(): string
+    {
+        return 'lastfm/top_tracks.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:lastfm:stats:compute';
     }
 }

--- a/src/Controller/NavidromeTopAlbumsController.php
+++ b/src/Controller/NavidromeTopAlbumsController.php
@@ -2,59 +2,54 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Navidrome\NavidromeRepository;
 use App\Service\NavidromeStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class NavidromeTopAlbumsController extends AbstractController
+class NavidromeTopAlbumsController extends AbstractTopListController
 {
-    private const TOP_N = 100;
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly NavidromeStatsService $stats,
+    ) {
+    }
 
     #[Route('/navidrome/top-albums', name: 'app_navidrome_top_albums', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
+    public function index(Request $request): Response
     {
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
+        return $this->renderTopList($request);
+    }
 
-        $source = 'live';
-        $computedAt = null;
-        if ($c['year'] !== null) {
-            $rows = $navidrome->getTopAlbumsWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get();
-            $cached = is_array($snapshot) && isset($snapshot['top_albums_alltime']) && is_array($snapshot['top_albums_alltime'])
-                ? $snapshot['top_albums_alltime']
-                : null;
-            if ($cached !== null) {
-                /** @var list<array{album_id: string, album: string, artist: string, plays: int, track_count: int, first_played_at: string, last_played_at: string}> $rows */
-                $rows = $cached;
-                $source = 'snapshot';
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $navidrome->getTopAlbumsWithDates(null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->navidrome->getTopAlbumsWithDates($year, $month, $day, $limit);
+    }
 
-        return $this->render('navidrome/top_albums.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $navidrome->getAvailableScrobbleYears(),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:navidrome:stats:compute',
-        ]);
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get();
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_albums_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->navidrome->getAvailableScrobbleYears();
+    }
+
+    protected function templateName(): string
+    {
+        return 'navidrome/top_albums.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:navidrome:stats:compute';
     }
 }

--- a/src/Controller/NavidromeTopArtistsController.php
+++ b/src/Controller/NavidromeTopArtistsController.php
@@ -2,59 +2,54 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Navidrome\NavidromeRepository;
 use App\Service\NavidromeStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class NavidromeTopArtistsController extends AbstractController
+class NavidromeTopArtistsController extends AbstractTopListController
 {
-    private const TOP_N = 100;
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly NavidromeStatsService $stats,
+    ) {
+    }
 
     #[Route('/navidrome/top-artists', name: 'app_navidrome_top_artists', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
+    public function index(Request $request): Response
     {
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
+        return $this->renderTopList($request);
+    }
 
-        $source = 'live';
-        $computedAt = null;
-        if ($c['year'] !== null) {
-            $rows = $navidrome->getTopArtistsWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get();
-            $cached = is_array($snapshot) && isset($snapshot['top_artists_alltime']) && is_array($snapshot['top_artists_alltime'])
-                ? $snapshot['top_artists_alltime']
-                : null;
-            if ($cached !== null) {
-                /** @var list<array{artist: string, plays: int, first_played_at: string, last_played_at: string}> $rows */
-                $rows = $cached;
-                $source = 'snapshot';
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $navidrome->getTopArtistsWithDates(null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->navidrome->getTopArtistsWithDates($year, $month, $day, $limit);
+    }
 
-        return $this->render('navidrome/top_artists.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $navidrome->getAvailableScrobbleYears(),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:navidrome:stats:compute',
-        ]);
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get();
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_artists_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->navidrome->getAvailableScrobbleYears();
+    }
+
+    protected function templateName(): string
+    {
+        return 'navidrome/top_artists.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:navidrome:stats:compute';
     }
 }

--- a/src/Controller/NavidromeTopTracksController.php
+++ b/src/Controller/NavidromeTopTracksController.php
@@ -2,59 +2,54 @@
 
 namespace App\Controller;
 
-use App\Filter\DateCascadeFilter;
+use App\Controller\TopList\AbstractTopListController;
 use App\Navidrome\NavidromeRepository;
 use App\Service\NavidromeStatsService;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-class NavidromeTopTracksController extends AbstractController
+class NavidromeTopTracksController extends AbstractTopListController
 {
-    private const TOP_N = 100;
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly NavidromeStatsService $stats,
+    ) {
+    }
 
     #[Route('/navidrome/top-tracks', name: 'app_navidrome_top_tracks', methods: ['GET'])]
-    public function index(Request $request, NavidromeRepository $navidrome, NavidromeStatsService $stats): Response
+    public function index(Request $request): Response
     {
-        $c = DateCascadeFilter::parse(
-            $request->query->get('year'),
-            $request->query->get('month'),
-            $request->query->get('day'),
-        );
+        return $this->renderTopList($request);
+    }
 
-        $source = 'live';
-        $computedAt = null;
-        if ($c['year'] !== null) {
-            $rows = $navidrome->getTopTracksWithDates($c['year'], $c['month'], $c['day'], self::TOP_N);
-        } else {
-            $snapshot = $stats->get();
-            $cached = is_array($snapshot) && isset($snapshot['top_tracks_alltime']) && is_array($snapshot['top_tracks_alltime'])
-                ? $snapshot['top_tracks_alltime']
-                : null;
-            if ($cached !== null) {
-                /** @var list<array{id: string, title: string, artist: string, album: ?string, plays: int, first_played_at: string, last_played_at: string}> $rows */
-                $rows = $cached;
-                $source = 'snapshot';
-                $computedAt = is_string($snapshot['computed_at'] ?? null) ? $snapshot['computed_at'] : null;
-            } else {
-                $rows = $navidrome->getTopTracksWithDates(null, null, null, self::TOP_N);
-                $source = 'live_fallback';
-            }
-        }
+    protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array
+    {
+        return $this->navidrome->getTopTracksWithDates($year, $month, $day, $limit);
+    }
 
-        return $this->render('navidrome/top_tracks.html.twig', [
-            'rows' => $rows,
-            'top_n' => self::TOP_N,
-            'available_years' => $navidrome->getAvailableScrobbleYears(),
-            'filters' => [
-                'year' => $c['year'] !== null ? (string) $c['year'] : '',
-                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
-                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
-            ],
-            'source' => $source,
-            'computed_at' => $computedAt,
-            'compute_command' => 'app:navidrome:stats:compute',
-        ]);
+    protected function fetchSnapshot(): ?array
+    {
+        return $this->stats->get();
+    }
+
+    protected function snapshotKey(): string
+    {
+        return 'top_tracks_alltime';
+    }
+
+    protected function availableYears(): array
+    {
+        return $this->navidrome->getAvailableScrobbleYears();
+    }
+
+    protected function templateName(): string
+    {
+        return 'navidrome/top_tracks.html.twig';
+    }
+
+    protected function computeCommand(): string
+    {
+        return 'app:navidrome:stats:compute';
     }
 }

--- a/src/Controller/TopList/AbstractTopListController.php
+++ b/src/Controller/TopList/AbstractTopListController.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Controller\TopList;
+
+use App\Filter\DateCascadeFilter;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Cœur partagé des six pages /(lastfm|navidrome)/top-(artists|albums|tracks).
+ *
+ * Décide entre trois sources de données selon la présence d'un filtre date :
+ *  - **filtre posé** (`year` / `month` / `day`) → requête live, le filtre
+ *    réduit la volumétrie donc c'est rapide même sur les grosses bases.
+ *  - **aucun filtre, snapshot disponible** → lecture instantanée du
+ *    pré-calcul stocké par la commande `*:stats:compute`.
+ *  - **aucun filtre, pas de snapshot** → fallback live + bandeau ambre
+ *    qui invite à lancer la commande.
+ *
+ * Les classes filles fournissent les six briques différenciantes
+ * (fetchLive / fetchSnapshot / snapshotKey / availableYears / template /
+ * computeCommand) et exposent leur propre route.
+ */
+abstract class AbstractTopListController extends AbstractController
+{
+    protected const TOP_N = 100;
+
+    /**
+     * Requête live (avec ou sans filtre date — les classes filles n'ont
+     * pas à différencier).
+     *
+     * @return list<array<string, mixed>>
+     */
+    abstract protected function fetchLive(?int $year, ?int $month, ?int $day, int $limit): array;
+
+    /**
+     * Snapshot stats persisté côté Last.fm ou Navidrome — renvoie null
+     * quand il n'a jamais été calculé.
+     *
+     * @return array<string, mixed>|null
+     */
+    abstract protected function fetchSnapshot(): ?array;
+
+    /** Ex. `top_tracks_alltime`, `top_albums_alltime`, `top_artists_alltime`. */
+    abstract protected function snapshotKey(): string;
+
+    /** @return list<string> */
+    abstract protected function availableYears(): array;
+
+    abstract protected function templateName(): string;
+
+    /** Affichée dans le bandeau ambre quand le snapshot manque. */
+    abstract protected function computeCommand(): string;
+
+    protected function renderTopList(Request $request): Response
+    {
+        $c = DateCascadeFilter::parse(
+            $request->query->get('year'),
+            $request->query->get('month'),
+            $request->query->get('day'),
+        );
+        $hasFilter = $c['year'] !== null;
+
+        $source = $hasFilter ? 'live' : 'snapshot';
+        $computedAt = null;
+        if ($hasFilter) {
+            $rows = $this->fetchLive($c['year'], $c['month'], $c['day'], static::TOP_N);
+        } else {
+            $snapshot = $this->fetchSnapshot();
+            $key = $this->snapshotKey();
+            $cached = is_array($snapshot) && isset($snapshot[$key]) && is_array($snapshot[$key])
+                ? $snapshot[$key]
+                : null;
+            if ($cached !== null) {
+                /** @var list<array<string, mixed>> $rows */
+                $rows = $cached;
+                $computedAt = is_array($snapshot) && is_string($snapshot['computed_at'] ?? null)
+                    ? $snapshot['computed_at']
+                    : null;
+            } else {
+                $rows = $this->fetchLive(null, null, null, static::TOP_N);
+                $source = 'live_fallback';
+            }
+        }
+
+        return $this->render($this->templateName(), [
+            'rows' => $rows,
+            'top_n' => static::TOP_N,
+            'available_years' => $this->availableYears(),
+            'filters' => [
+                'year' => $c['year'] !== null ? (string) $c['year'] : '',
+                'month' => $c['month'] !== null ? sprintf('%02d', $c['month']) : '',
+                'day' => $c['day'] !== null ? sprintf('%02d', $c['day']) : '',
+            ],
+            'source' => $source,
+            'computed_at' => $computedAt,
+            'compute_command' => $this->computeCommand(),
+        ]);
+    }
+}

--- a/src/Filter/DateCascadeFilter.php
+++ b/src/Filter/DateCascadeFilter.php
@@ -25,6 +25,61 @@ final class DateCascadeFilter
         return ['year' => $y, 'month' => $m, 'day' => $d];
     }
 
+    /**
+     * Produces the SQLite `WHERE` fragment that applies the year / month /
+     * day cascade to a timestamp column. Source of truth shared by
+     * `LastFmStatsService::topXWithDates()` and
+     * `NavidromeRepository::getTopXWithDates()` — both produced the same
+     * three-branch code by hand (year → `strftime('%Y', col)`, +month →
+     * `strftime('%Y-%m', col)`, +day → `strftime('%Y-%m-%d', col)`).
+     *
+     * Two SQLite quirks accommodated :
+     *  - When the column is a unix epoch (Navidrome `submission_time` is
+     *    INTEGER from 0.55+), pass `$unixepoch = true` to interpose the
+     *    `'unixepoch'` modifier expected by `strftime`.
+     *  - Named params with a prefix avoid collisions with surrounding
+     *    `:user` / `:uid` clauses both call sites already carry.
+     *
+     * Returns `null` (no clause to add) when `$year` is null.
+     *
+     * @return array{clause: string, paramName: string, paramValue: string}|null
+     */
+    public static function toSqlClause(
+        ?int $year,
+        ?int $month,
+        ?int $day,
+        string $column,
+        bool $unixepoch = false,
+        string $paramPrefix = 'dc_',
+    ): ?array {
+        if ($year === null) {
+            return null;
+        }
+
+        $strftimeArgs = $unixepoch ? sprintf("%s, 'unixepoch'", $column) : $column;
+
+        if ($day !== null && $month !== null) {
+            return [
+                'clause' => sprintf("strftime('%%Y-%%m-%%d', %s) = :%symd", $strftimeArgs, $paramPrefix),
+                'paramName' => $paramPrefix . 'ymd',
+                'paramValue' => sprintf('%04d-%02d-%02d', $year, $month, $day),
+            ];
+        }
+        if ($month !== null) {
+            return [
+                'clause' => sprintf("strftime('%%Y-%%m', %s) = :%sym", $strftimeArgs, $paramPrefix),
+                'paramName' => $paramPrefix . 'ym',
+                'paramValue' => sprintf('%04d-%02d', $year, $month),
+            ];
+        }
+
+        return [
+            'clause' => sprintf("strftime('%%Y', %s) = :%sy", $strftimeArgs, $paramPrefix),
+            'paramName' => $paramPrefix . 'y',
+            'paramValue' => (string) $year,
+        ];
+    }
+
     private static function asYear(mixed $v): ?int
     {
         if (!is_string($v) || !preg_match('/^\d{4}$/', $v)) {

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -979,19 +979,18 @@ class NavidromeRepository
      */
     private static function applyNavidromeCascadeClause(string &$sql, array &$params, ?int $year, ?int $month, ?int $day): void
     {
-        if ($year === null) {
+        $c = \App\Filter\DateCascadeFilter::toSqlClause(
+            $year,
+            $month,
+            $day,
+            's.submission_time',
+            unixepoch: true,
+        );
+        if ($c === null) {
             return;
         }
-        if ($day !== null && $month !== null) {
-            $sql .= " AND strftime('%Y-%m-%d', s.submission_time, 'unixepoch') = :ymd";
-            $params['ymd'] = sprintf('%04d-%02d-%02d', $year, $month, $day);
-        } elseif ($month !== null) {
-            $sql .= " AND strftime('%Y-%m', s.submission_time, 'unixepoch') = :ym";
-            $params['ym'] = sprintf('%04d-%02d', $year, $month);
-        } else {
-            $sql .= " AND strftime('%Y', s.submission_time, 'unixepoch') = :y";
-            $params['y'] = (string) $year;
-        }
+        $sql .= ' AND ' . $c['clause'];
+        $params[$c['paramName']] = $c['paramValue'];
     }
 
     /**

--- a/src/Service/LastFmStatsService.php
+++ b/src/Service/LastFmStatsService.php
@@ -3,6 +3,7 @@
 namespace App\Service;
 
 use App\Entity\StatsSnapshot;
+use App\Filter\DateCascadeFilter;
 use App\Repository\StatsSnapshotRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
@@ -565,29 +566,21 @@ class LastFmStatsService
     }
 
     /**
-     * Adds the appropriate `strftime` clause for the cascade (year /
-     * year-month / year-month-day) to the given clauses + params arrays.
-     * Mutates the references in place to mirror the {@see buildWhere()}
-     * pattern callers already use.
+     * Adds the cascade clause from {@see DateCascadeFilter::toSqlClause()}
+     * to the given clauses + params arrays, mirroring the {@see buildWhere()}
+     * mutate-in-place pattern. No-op when `$year` is null.
      *
      * @param list<string> $clauses
      * @param array<string, mixed> $params
      */
     private static function applyDateCascade(array &$clauses, array &$params, ?int $year, ?int $month, ?int $day): void
     {
-        if ($year === null) {
+        $c = DateCascadeFilter::toSqlClause($year, $month, $day, 'played_at');
+        if ($c === null) {
             return;
         }
-        if ($day !== null && $month !== null) {
-            $clauses[] = "strftime('%Y-%m-%d', played_at) = :ymd";
-            $params['ymd'] = sprintf('%04d-%02d-%02d', $year, $month, $day);
-        } elseif ($month !== null) {
-            $clauses[] = "strftime('%Y-%m', played_at) = :ym";
-            $params['ym'] = sprintf('%04d-%02d', $year, $month);
-        } else {
-            $clauses[] = "strftime('%Y', played_at) = :y";
-            $params['y'] = (string) $year;
-        }
+        $clauses[] = $c['clause'];
+        $params[$c['paramName']] = $c['paramValue'];
     }
 
     /**

--- a/tests/Filter/DateCascadeFilterTest.php
+++ b/tests/Filter/DateCascadeFilterTest.php
@@ -70,4 +70,51 @@ class DateCascadeFilterTest extends TestCase
             DateCascadeFilter::parse(2024, 6, 15),
         );
     }
+
+    public function testToSqlClauseNullWhenYearMissing(): void
+    {
+        $this->assertNull(DateCascadeFilter::toSqlClause(null, 6, 15, 'played_at'));
+    }
+
+    public function testToSqlClauseYearOnly(): void
+    {
+        $c = DateCascadeFilter::toSqlClause(2024, null, null, 'played_at');
+
+        $this->assertSame("strftime('%Y', played_at) = :dc_y", $c['clause']);
+        $this->assertSame('dc_y', $c['paramName']);
+        $this->assertSame('2024', $c['paramValue']);
+    }
+
+    public function testToSqlClauseYearMonth(): void
+    {
+        $c = DateCascadeFilter::toSqlClause(2024, 6, null, 's.played_at');
+
+        $this->assertSame("strftime('%Y-%m', s.played_at) = :dc_ym", $c['clause']);
+        $this->assertSame('2024-06', $c['paramValue']);
+    }
+
+    public function testToSqlClauseFullDate(): void
+    {
+        $c = DateCascadeFilter::toSqlClause(2024, 6, 5, 'played_at');
+
+        $this->assertSame("strftime('%Y-%m-%d', played_at) = :dc_ymd", $c['clause']);
+        $this->assertSame('2024-06-05', $c['paramValue']);
+    }
+
+    public function testToSqlClauseUnixepochWrapsModifier(): void
+    {
+        $c = DateCascadeFilter::toSqlClause(2024, null, null, 's.submission_time', unixepoch: true);
+
+        $this->assertSame("strftime('%Y', s.submission_time, 'unixepoch') = :dc_y", $c['clause']);
+    }
+
+    public function testToSqlClauseCustomPrefixAvoidsParamCollision(): void
+    {
+        // Both call sites carry surrounding `:user` / `:uid` clauses ; the
+        // helper supports a custom prefix to keep param names unique.
+        $c = DateCascadeFilter::toSqlClause(2024, null, null, 'played_at', paramPrefix: 'top_');
+
+        $this->assertSame("strftime('%Y', played_at) = :top_y", $c['clause']);
+        $this->assertSame('top_y', $c['paramName']);
+    }
 }


### PR DESCRIPTION
## Summary

PR **3/4** — déduplique le code récent des 6 pages top-* maintenant qu'on a un filet de tests posé en PR #188 (`NavidromeTopListsTest`, `DateCascadeFilterTest`). **Aucun changement de comportement** : les tests existants protègent l'invariant.

### `DateCascadeFilter::toSqlClause()` (nouvelle méthode statique)

Source de vérité unique pour la cascade `year` → `year-month` → `year-month-day`. Produit le tuple `[clause SQL, paramName, paramValue]`.

- Supporte les deux variantes existantes : colonne brute (Last.fm `played_at`) et unix epoch (Navidrome `submission_time, 'unixepoch'`).
- Préfixe de param configurable pour ne pas entrer en collision avec les `:user` / `:uid` déjà portés par les call sites.
- **6 nouveaux tests** sur `DateCascadeFilterTest` (null sur year manquant, year-only, year+month, full date, unixepoch wrap, prefix custom).

Les deux implémentations existantes deviennent des **wrappers minces** :

| Méthode | Avant | Après |
|---|---|---|
| `LastFmStatsService::applyDateCascade()` | 22 lignes | 7 lignes |
| `NavidromeRepository::applyNavidromeCascadeClause()` | 16 lignes | 10 lignes |

(`ScrobbleRepository::buildFilterClauses()` utilise des params positionnels et fait plus que la cascade — laissé tel quel.)

### `AbstractTopListController`

Nouveau fichier `src/Controller/TopList/AbstractTopListController.php` qui centralise le flux :

```
parse cascade → snapshot (si pas de filtre) → live (si filtre) → live_fallback (snapshot absent) → render
```

~100 lignes au total dans **une** classe, au lieu d'être répétées dans les 6 controllers. Six méthodes abstraites pour les briques différenciantes :

- `fetchLive(?int $year, ?int $month, ?int $day, int $limit): array`
- `fetchSnapshot(): ?array`
- `snapshotKey(): string` (`top_tracks_alltime`, `top_albums_alltime`, `top_artists_alltime`)
- `availableYears(): list<string>`
- `templateName(): string`
- `computeCommand(): string`

Les 6 controllers concrets (LastFm + Navidrome × artists/albums/tracks) deviennent des **shims de ~55-60 lignes** : DI + route + 6 overrides courts.

## Test plan

- [x] `composer phpcs` → vert
- [x] `composer phpunit` → **141 / 419 verts** (+6 sur `DateCascadeFilterTest`)
- [x] `php bin/console lint:container` → vert
- [x] `php bin/console debug:router | grep top-` → 6 routes intactes
- [x] phpstan vert en CI (les 10 erreurs locales sont l'artefact d'env constaté en #187)

## Suite

PR 4 : split `NavidromeRepository` (3192 lignes) — extractions sûres uniquement (`NavidromeStringNormalizer` + `NavidromeSchemaIntrospector`).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_