### PR TITLE
refactor(navidrome): extrait NavidromeStringNormalizer du god object (4/4)

### DIFF
--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2646,23 +2646,7 @@ class NavidromeRepository
      */
     private static function titleHasFeaturingMarker(string $title): bool
     {
-        // Closed paren / bracket form.
-        if (preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+[^)]+\)/iu', $title)) {
-            return true;
-        }
-        if (preg_match('/\[(?:feat\.?|ft\.?|featuring|with)\s+[^\]]+\]/iu', $title)) {
-            return true;
-        }
-
-        // Truncated open paren (no closing paren in the whole title).
-        if (
-            !preg_match('/\([^)]*\)/u', $title)
-            && preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+/iu', $title)
-        ) {
-            return true;
-        }
-
-        return false;
+        return NavidromeStringNormalizer::titleHasFeaturingMarker($title);
     }
 
     /**
@@ -2693,12 +2677,7 @@ class NavidromeRepository
      */
     private static function stripFeaturedArtists(string $artist): string
     {
-        // 1. Strip parenthesized suffix: "(feat. …)" / "(ft. …)" / "(featuring …)".
-        $stripped = preg_replace('/\s*\((?:feat\.?|ft\.?|featuring)\s+[^)]*\)\s*/iu', '', $artist) ?? $artist;
-        // 2. Strip trailing form: " feat. …" / " ft. …" / " featuring …" until end.
-        $stripped = preg_replace('/\s+(?:feat\.?|ft\.?|featuring)\s+.*$/iu', '', $stripped) ?? $stripped;
-
-        return trim($stripped);
+        return NavidromeStringNormalizer::stripFeaturedArtists($artist);
     }
 
     /**
@@ -2716,34 +2695,7 @@ class NavidromeRepository
      */
     private static function stripVersionMarkers(string $title): string
     {
-        // Order matters: longer alternatives must come first so "remastered 2011"
-        // is captured by the year-aware pattern instead of just "remastered".
-        // Contextual markers (live/acoustic/…) accept an optional trailing
-        // qualifier so "Live at Reading 1992" / "Acoustic Version" / "Deluxe
-        // Edition" all match.
-        $markers = '(?:'
-            . 'remastered \d{4}|remaster \d{4}|\d{4} remastered|\d{4} remaster'
-            . '|radio edit|radio mix|radio version'
-            . '|album version|album mix|album edit'
-            . '|single version|single edit|single mix'
-            . '|extended version|extended mix|extended edit'
-            . '|mono version|stereo version'
-            . '|remastered|remaster'
-            . '|live(?:\s[^)\]]+)?'
-            . '|acoustic(?:\s+(?:version|mix))?'
-            . '|instrumental(?:\s+version)?'
-            . '|demo(?:\s+version)?'
-            . '|deluxe(?:\s+(?:edition|version))?'
-            . ')';
-
-        // Parenthesized form: " (Radio Edit)".
-        $stripped = preg_replace('/\s*\(' . $markers . '\)\s*$/iu', '', $title) ?? $title;
-        // Bracketed form: " [Radio Edit]".
-        $stripped = preg_replace('/\s*\[' . $markers . '\]\s*$/iu', '', $stripped) ?? $stripped;
-        // Dash-separated form: " - Radio Edit" (ASCII -, en dash, em dash).
-        $stripped = preg_replace('/\s+[\-\x{2013}\x{2014}]\s+' . $markers . '\s*$/iu', '', $stripped) ?? $stripped;
-
-        return trim($stripped);
+        return NavidromeStringNormalizer::stripVersionMarkers($title);
     }
 
     /**
@@ -2756,11 +2708,7 @@ class NavidromeRepository
      */
     private static function stripFeaturingFromTitle(string $title): string
     {
-        $pattern = '(?:feat\.?|ft\.?|featuring|with)\s+[^)\]]+';
-        $stripped = preg_replace('/\s*\(' . $pattern . '\)\s*$/iu', '', $title) ?? $title;
-        $stripped = preg_replace('/\s*\[' . $pattern . '\]\s*$/iu', '', $stripped) ?? $stripped;
-
-        return trim($stripped);
+        return NavidromeStringNormalizer::stripFeaturingFromTitle($title);
     }
 
     /**
@@ -2772,7 +2720,7 @@ class NavidromeRepository
      */
     private static function stripTrackNumberPrefix(string $title): string
     {
-        return trim(preg_replace('/^\d{1,3}[_\-.\s]+(?=\S)/u', '', $title) ?? $title);
+        return NavidromeStringNormalizer::stripTrackNumberPrefix($title);
     }
 
     /**
@@ -2785,12 +2733,7 @@ class NavidromeRepository
      */
     private static function stripTruncatedParen(string $title): string
     {
-        if (preg_match('/\([^)]*\)/u', $title)) {
-            return $title;
-        }
-        $markers = '(?:feat\.?|ft\.?|featuring|with|live|acoustic|remastered|remaster|deluxe|extended|radio|album|single|mono|stereo|instrumental|demo)';
-
-        return trim(preg_replace('/\s*\(' . $markers . '[^)]*$/iu', '', $title) ?? $title);
+        return NavidromeStringNormalizer::stripTruncatedParen($title);
     }
 
     /**
@@ -2802,14 +2745,7 @@ class NavidromeRepository
      */
     private static function stripLeadArtist(string $artist): string
     {
-        if (preg_match('/^(.*?)(?:\s*,\s*|\s+-\s+|\s*&\s*|\s+(?:and|et)\s+)/iu', $artist, $m)) {
-            $lead = trim($m[1]);
-            if ($lead !== '' && $lead !== $artist) {
-                return $lead;
-            }
-        }
-
-        return $artist;
+        return NavidromeStringNormalizer::stripLeadArtist($artist);
     }
 
     /**
@@ -3115,17 +3051,7 @@ class NavidromeRepository
      */
     public static function normalize(string $s): string
     {
-        $s = mb_strtolower(trim($s));
-        $decomposed = \Normalizer::normalize($s, \Normalizer::FORM_KD);
-        if ($decomposed === false) {
-            // Input was not valid UTF-8 — fall back to the lowercased form.
-            return $s;
-        }
-        $stripped = (string) preg_replace('/\p{Mn}+/u', '', $decomposed);
-        // Drop punctuation/symbols (keep letters, digits, whitespace).
-        $cleaned = (string) preg_replace('/[^\p{L}\p{N}\s]+/u', '', $stripped);
-
-        return trim((string) preg_replace('/\s+/u', ' ', $cleaned));
+        return NavidromeStringNormalizer::normalize($s);
     }
 
     /**

--- a/src/Navidrome/NavidromeStringNormalizer.php
+++ b/src/Navidrome/NavidromeStringNormalizer.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Navidrome;
+
+/**
+ * Pure string helpers used by the matching cascade (Last.fm scrobble →
+ * Navidrome media_file) and by every code path that normalizes artist /
+ * title before comparison. Extracted from {@see NavidromeRepository} so
+ * the SQL repo stops being a god object — these are stateless functions
+ * that don't need a DB connection.
+ *
+ * `normalize()` is also exposed to SQLite as the UDF `np_normalize()` by
+ * {@see NavidromeRepository::connection()} so the same transformation is
+ * applied server-side on indexed columns. Callers that already write
+ * `NavidromeRepository::normalize(...)` continue to work via a thin
+ * delegation kept on the repo for backward compatibility.
+ */
+final class NavidromeStringNormalizer
+{
+    /**
+     * Canonical comparison form for an artist / album / title :
+     *  - lowercase, trim
+     *  - NFKD decomposition + drop combining marks (accents)
+     *  - drop punctuation / symbols (keep letters, digits, whitespace)
+     *  - collapse internal whitespace to a single space.
+     *
+     * `Beyoncé` → `beyonce`, `AC/DC` → `acdc`, `Sigur Rós` → `sigur ros`,
+     * `Get Lucky (feat. Pharrell Williams)` → `get lucky feat pharrell williams`.
+     *
+     * Falls back to the lowercased input when NFKD fails (e.g. input
+     * isn't valid UTF-8).
+     */
+    public static function normalize(string $s): string
+    {
+        $s = mb_strtolower(trim($s));
+        $decomposed = \Normalizer::normalize($s, \Normalizer::FORM_KD);
+        if ($decomposed === false) {
+            return $s;
+        }
+        $stripped = (string) preg_replace('/\p{Mn}+/u', '', $decomposed);
+        // Drop punctuation/symbols (keep letters, digits, whitespace).
+        $cleaned = (string) preg_replace('/[^\p{L}\p{N}\s]+/u', '', $stripped);
+
+        return trim((string) preg_replace('/\s+/u', ' ', $cleaned));
+    }
+
+    /**
+     * Drop `feat. …` / `ft. …` / `featuring …` from a raw artist string,
+     * both the parenthesized form and the trailing « X feat. Y » form
+     * (which we never strip from a title — too risky on legit lyrics).
+     * Returns the input unchanged when no marker is present. Works on
+     * the raw input because {@see self::normalize()} would strip parens
+     * and dots, defeating the patterns below.
+     */
+    public static function stripFeaturedArtists(string $artist): string
+    {
+        // 1. Strip parenthesized suffix: "(feat. …)" / "(ft. …)" / "(featuring …)".
+        $stripped = preg_replace('/\s*\((?:feat\.?|ft\.?|featuring)\s+[^)]*\)\s*/iu', '', $artist) ?? $artist;
+        // 2. Strip trailing form: " feat. …" / " ft. …" / " featuring …" until end.
+        $stripped = preg_replace('/\s+(?:feat\.?|ft\.?|featuring)\s+.*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a trailing version-marker suffix (Radio Edit, Remastered 2011,
+     * Live, Acoustic, Deluxe Edition…) from a raw title. Handles
+     * parenthesized, bracketed, and dash-separated forms (ASCII -, en
+     * dash, em dash). Live/acoustic/etc. is only stripped when *delimited*
+     * — « Live and Let Die » remains intact. Remix is intentionally NOT
+     * stripped (DJ remixes are usually distinct recordings).
+     */
+    public static function stripVersionMarkers(string $title): string
+    {
+        $markers = '(?:'
+            . 'remastered \d{4}|remaster \d{4}|\d{4} remastered|\d{4} remaster'
+            . '|radio edit|radio mix|radio version'
+            . '|album version|album mix|album edit'
+            . '|single version|single edit|single mix'
+            . '|extended version|extended mix|extended edit'
+            . '|mono version|stereo version'
+            . '|remastered|remaster'
+            . '|live(?:\s[^)\]]+)?'
+            . '|acoustic(?:\s+(?:version|mix))?'
+            . '|instrumental(?:\s+version)?'
+            . '|demo(?:\s+version)?'
+            . '|deluxe(?:\s+(?:edition|version))?'
+            . ')';
+
+        $stripped = preg_replace('/\s*\(' . $markers . '\)\s*$/iu', '', $title) ?? $title;
+        $stripped = preg_replace('/\s*\[' . $markers . '\]\s*$/iu', '', $stripped) ?? $stripped;
+        $stripped = preg_replace('/\s+[\-\x{2013}\x{2014}]\s+' . $markers . '\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a parenthesized/bracketed featuring-with suffix from a title.
+     * Only the delimited form — never « X feat. Y » without parens, too
+     * risky on real titles.
+     */
+    public static function stripFeaturingFromTitle(string $title): string
+    {
+        $pattern = '(?:feat\.?|ft\.?|featuring|with)\s+[^)\]]+';
+        $stripped = preg_replace('/\s*\(' . $pattern . '\)\s*$/iu', '', $title) ?? $title;
+        $stripped = preg_replace('/\s*\[' . $pattern . '\]\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
+     * Drop a leading track-number prefix like « 01 - », « 02_ », « 12- »,
+     * « 100. ». Requires a delimiter and a non-blank character behind so
+     * standalone numeric titles (« 1979 », « 5/4 ») are not eaten.
+     */
+    public static function stripTrackNumberPrefix(string $title): string
+    {
+        return trim(preg_replace('/^\d{1,3}[_\-.\s]+(?=\S)/u', '', $title) ?? $title);
+    }
+
+    /**
+     * Drop a trailing OPEN parenthesis block when its content starts with
+     * a known marker keyword — Last.fm truncates titles around 64 chars
+     * and leaves unbalanced parens. Abstains if the title already contains
+     * a closed `(...)` group.
+     */
+    public static function stripTruncatedParen(string $title): string
+    {
+        if (preg_match('/\([^)]*\)/u', $title)) {
+            return $title;
+        }
+        $markers = '(?:feat\.?|ft\.?|featuring|with|live|acoustic|remastered|remaster|deluxe|extended|radio|album|single|mono|stereo|instrumental|demo)';
+
+        return trim(preg_replace('/\s*\(' . $markers . '[^)]*$/iu', '', $title) ?? $title);
+    }
+
+    /**
+     * Drop trailing co-artists separated by `,`, ` - `, `&`, ` and `, ` et `
+     * to keep only the lead artist (« Médine & Rounhaa » → « Médine »).
+     * Last-resort fallback when the regular cascade fails.
+     */
+    public static function stripLeadArtist(string $artist): string
+    {
+        if (preg_match('/^(.*?)(?:\s*,\s*|\s+-\s+|\s*&\s*|\s+(?:and|et)\s+)/iu', $artist, $m)) {
+            $lead = trim($m[1]);
+            if ($lead !== '' && $lead !== $artist) {
+                return $lead;
+            }
+        }
+
+        return $artist;
+    }
+
+    /**
+     * True when the title carries a `(feat. …)` / `[ft. …]` / `(with …)`
+     * marker (closed or truncated open-paren). Gates the « move the
+     * featuring into the artist column » heuristic in the matcher.
+     */
+    public static function titleHasFeaturingMarker(string $title): bool
+    {
+        if (preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+[^)]+\)/iu', $title)) {
+            return true;
+        }
+        if (preg_match('/\[(?:feat\.?|ft\.?|featuring|with)\s+[^\]]+\]/iu', $title)) {
+            return true;
+        }
+
+        return !preg_match('/\([^)]*\)/u', $title)
+            && (bool) preg_match('/\((?:feat\.?|ft\.?|featuring|with)\s+/iu', $title);
+    }
+}

--- a/tests/Navidrome/NavidromeStringNormalizerTest.php
+++ b/tests/Navidrome/NavidromeStringNormalizerTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeStringNormalizer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Lock the canonical forms produced by the string normalizer (extracted
+ * from NavidromeRepository). Behaviour is preserved bit-for-bit by the
+ * extraction — these tests will catch any future drift on the
+ * normalization rules that the matching cascade and 31+ external callers
+ * depend on.
+ */
+class NavidromeStringNormalizerTest extends TestCase
+{
+    public function testNormalizeLowercasesAndStripsAccents(): void
+    {
+        $this->assertSame('beyonce', NavidromeStringNormalizer::normalize('Beyoncé'));
+        $this->assertSame('sigur ros', NavidromeStringNormalizer::normalize('Sigur Rós'));
+    }
+
+    public function testNormalizeStripsPunctuationButKeepsLettersDigitsSpace(): void
+    {
+        // Punctuation is dropped without inserting whitespace — that's the
+        // contract that keeps `np_normalize('AC/DC')` and `np_normalize('ACDC')`
+        // collide on the same key in SQLite-side joins.
+        $this->assertSame('acdc', NavidromeStringNormalizer::normalize('AC/DC'));
+        $this->assertSame('54', NavidromeStringNormalizer::normalize('5/4'));
+        $this->assertSame('get lucky feat pharrell williams', NavidromeStringNormalizer::normalize('Get Lucky (feat. Pharrell Williams)'));
+    }
+
+    public function testNormalizeCollapsesInternalWhitespaceAndTrims(): void
+    {
+        $this->assertSame('the trimmed', NavidromeStringNormalizer::normalize('  The   trimmed  '));
+        $this->assertSame('the trimmed', NavidromeStringNormalizer::normalize("  The\t  trimmed\n  "));
+    }
+
+    public function testStripFeaturedArtistsHandlesBothParenAndTrailingForms(): void
+    {
+        $this->assertSame('Daft Punk', NavidromeStringNormalizer::stripFeaturedArtists('Daft Punk (feat. Pharrell)'));
+        $this->assertSame('Daft Punk', NavidromeStringNormalizer::stripFeaturedArtists('Daft Punk ft. Pharrell'));
+        $this->assertSame('Daft Punk', NavidromeStringNormalizer::stripFeaturedArtists('Daft Punk featuring Pharrell'));
+        $this->assertSame('Daft Punk', NavidromeStringNormalizer::stripFeaturedArtists('Daft Punk'));
+    }
+
+    public function testStripVersionMarkersHandlesParenBracketAndDashForms(): void
+    {
+        $this->assertSame('Bohemian Rhapsody', NavidromeStringNormalizer::stripVersionMarkers('Bohemian Rhapsody (Remastered 2011)'));
+        $this->assertSame('Bohemian Rhapsody', NavidromeStringNormalizer::stripVersionMarkers('Bohemian Rhapsody [Remastered]'));
+        $this->assertSame('Bohemian Rhapsody', NavidromeStringNormalizer::stripVersionMarkers('Bohemian Rhapsody - Remastered 2011'));
+        $this->assertSame('Around the World', NavidromeStringNormalizer::stripVersionMarkers('Around the World (Radio Edit)'));
+    }
+
+    public function testStripVersionMarkersLeavesDelimitedLiveAloneInTitleBody(): void
+    {
+        // "Live and Let Die" must not lose its first word — the « live »
+        // marker is only stripped when it's a *trailing* delimited suffix.
+        $this->assertSame('Live and Let Die', NavidromeStringNormalizer::stripVersionMarkers('Live and Let Die'));
+        $this->assertSame('Live and Let Die', NavidromeStringNormalizer::stripVersionMarkers('Live and Let Die (Remastered)'));
+    }
+
+    public function testStripVersionMarkersDoesNotStripRemix(): void
+    {
+        // DJ remixes are usually distinct recordings — must NOT be stripped.
+        $this->assertSame('Around the World (Daft Punk Remix)', NavidromeStringNormalizer::stripVersionMarkers('Around the World (Daft Punk Remix)'));
+    }
+
+    public function testStripFeaturingFromTitleOnlyDelimited(): void
+    {
+        $this->assertSame('Crazy in Love', NavidromeStringNormalizer::stripFeaturingFromTitle('Crazy in Love (feat. Jay-Z)'));
+        $this->assertSame('Bad Guy', NavidromeStringNormalizer::stripFeaturingFromTitle('Bad Guy [with Justin Bieber]'));
+        // No parens → never stripped.
+        $this->assertSame('Some Track feat. X', NavidromeStringNormalizer::stripFeaturingFromTitle('Some Track feat. X'));
+    }
+
+    public function testStripTrackNumberPrefixDropsLeadingDigits(): void
+    {
+        $this->assertSame('Around the World', NavidromeStringNormalizer::stripTrackNumberPrefix('01 - Around the World'));
+        $this->assertSame('Around the World', NavidromeStringNormalizer::stripTrackNumberPrefix('02_Around the World'));
+        $this->assertSame('Around the World', NavidromeStringNormalizer::stripTrackNumberPrefix('100. Around the World'));
+    }
+
+    public function testStripTrackNumberPrefixLeavesStandaloneNumericTitlesAlone(): void
+    {
+        $this->assertSame('1979', NavidromeStringNormalizer::stripTrackNumberPrefix('1979'));
+        $this->assertSame('5/4', NavidromeStringNormalizer::stripTrackNumberPrefix('5/4'));
+    }
+
+    public function testStripTruncatedParenOnlyWhenUnbalancedAndMarkerKnown(): void
+    {
+        $this->assertSame('Crazy in Love', NavidromeStringNormalizer::stripTruncatedParen('Crazy in Love (feat. Jay'));
+        // Closed paren → never stripped, even with marker.
+        $this->assertSame('Crazy in Love (feat. Jay-Z)', NavidromeStringNormalizer::stripTruncatedParen('Crazy in Love (feat. Jay-Z)'));
+        // Unbalanced but unknown marker → kept (conservative).
+        $this->assertSame('Foo (something', NavidromeStringNormalizer::stripTruncatedParen('Foo (something'));
+    }
+
+    public function testStripLeadArtistKeepsOnlyTheLeadOnRecognizedSeparators(): void
+    {
+        $this->assertSame('Médine', NavidromeStringNormalizer::stripLeadArtist('Médine & Rounhaa'));
+        $this->assertSame('Foo', NavidromeStringNormalizer::stripLeadArtist('Foo, Bar'));
+        $this->assertSame('Foo', NavidromeStringNormalizer::stripLeadArtist('Foo and Bar'));
+        // No separator → unchanged.
+        $this->assertSame('Lone Artist', NavidromeStringNormalizer::stripLeadArtist('Lone Artist'));
+    }
+
+    public function testTitleHasFeaturingMarkerCoversClosedAndTruncatedForms(): void
+    {
+        $this->assertTrue(NavidromeStringNormalizer::titleHasFeaturingMarker('Crazy in Love (feat. Jay-Z)'));
+        $this->assertTrue(NavidromeStringNormalizer::titleHasFeaturingMarker('Bad Guy [with Justin Bieber]'));
+        $this->assertTrue(NavidromeStringNormalizer::titleHasFeaturingMarker('Crazy in Love (feat. Jay')); // truncated
+        $this->assertFalse(NavidromeStringNormalizer::titleHasFeaturingMarker('Crazy in Love'));
+        // Closed but unrelated paren content → not a featuring marker.
+        $this->assertFalse(NavidromeStringNormalizer::titleHasFeaturingMarker('Around the World (Radio Edit)'));
+    }
+
+    public function testNavidromeRepositoryShimStillWorks(): void
+    {
+        // Backward compat: NavidromeRepository::normalize() must keep
+        // returning the same value as the new class, so the 31 external
+        // callers don't need to migrate atomically.
+        $this->assertSame(
+            NavidromeStringNormalizer::normalize('Sigur Rós'),
+            \App\Navidrome\NavidromeRepository::normalize('Sigur Rós'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

PR **4/4** — première extraction prudente du god object `NavidromeRepository` (3192 lignes, 72 méthodes publiques). **Étape volontairement limitée** à l'extraction de plus bas risque : sept fonctions **pures** (zéro état, zéro DB).

### Nouveau `NavidromeStringNormalizer`

`src/Navidrome/NavidromeStringNormalizer.php` (~170 lignes) porte `normalize()` + les six `strip*()` + `titleHasFeaturingMarker()`. Toutes statiques, pas d'instance, pas de connexion DB → déplaçables sans risque.

### Backward-compat totale

- **`NavidromeRepository::normalize()` conservée** comme délégation mince → les 31 callers externes du repo (`StrawberryRepository`, `AliasGenerator`, `MusicBrainzAliasSuggester`, `LastFmAlias*Repository`, `LastFmMatchCacheRepository`, …) continuent à fonctionner sans migration atomique.
- Les méthodes privées `strip*` / `titleHasFeaturingMarker` conservées comme délégations minces → les ~20 `self::` callers internes au repo restent intacts.
- **L'UDF SQLite `np_normalize()`** reste enregistrée depuis `connection()` (point d'attention CRITIQUE — c'est ce qui aligne la normalisation PHP-side et SQL-side sur les colonnes indexées).

### Mesure

- `NavidromeRepository` : **3192 → 3117 lignes** (-74).
- Pas spectaculaire en volume, mais les 170 lignes extraites deviennent testables sans construire une DB Navidrome.

### `NavidromeStringNormalizerTest`

14 tests / 39 assertions qui verrouillent les règles canoniques :
- `normalize` : accents → ASCII, `AC/DC` → `acdc`, `5/4` → `54`, whitespace collapse + trim (l'UDF SQL `np_normalize()` applique la **même** règle server-side, tout changement casserait des joints).
- `strip*` : version markers (parens / brackets / dashes), featuring (délimité only), track number prefix, truncated paren, lead artist separator (`&` / `,` / `and` / `et`).
- `titleHasFeaturingMarker` : formes fermées + tronquées.
- Régression test : `NavidromeRepository::normalize()` retourne bien le même résultat que la nouvelle classe.

### Pourquoi pas aussi `NavidromeSchemaIntrospector` ?

Reporté en suivi. Le couplage avec `connection()` lazy + les caches (`scrobbleColumnsCache`, `annotationColumnsCache`, `userIdCache`, `hasScrobblesCache`) + la résolution implicite de `userName` est plus complexe que prévu — risque non négligeable pour les 40+ callers de `resolveUserId()` et `hasScrobblesTable()`. Mieux vaut un PR séparé bien scopé qu'un mélange risqué dans celui-ci.

## Test plan

- [x] `composer phpcs` → vert
- [x] `composer phpunit` → **155 / 458 verts** (était 141 / 419, +14 tests)
- [x] phpstan vert en CI (10 erreurs locales = artefact d'env)
- [x] Toutes les méthodes `NavidromeRepository::self::strip*` et `self::normalize` callers internes continuent de tourner via les délégations
- [ ] Smoke sync local : la matching cascade doit produire les mêmes résultats qu'avant (les callers de `normalize` côté `ScrobbleMatcher` et `AliasGenerator` n'ont rien changé)

## Bilan série amélioration base code (4 PRs)

| PR | Objet | Bénéfice |
|---|---|---|
| #187 (1/4) | bind global `$defaultUser` | −47 lignes de config dupliquée |
| #188 (2/4) | tests top-* / annotation #184 / sync+reconcile | filet de sécurité pour les refactos suivantes |
| #189 (3/4) | `AbstractTopListController` + `DateCascadeFilter::toSqlClause()` | dédup 6 controllers + 3 → 1 impl SQL cascade |
| #190 (4/4) | `NavidromeStringNormalizer` extrait | premier coup de hache propre dans le god object |

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_