### PR TITLE
feat(playlists): SubsonicClient + pages /playlists et /playlists/{id} (lecture seule)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -100,6 +100,12 @@ services:
             $dbPath: '%navidrome.db_path%'
             $userName: '%navidrome.user%'
 
+    App\Subsonic\SubsonicClient:
+        arguments:
+            $baseUrl: '%navidrome.url%'
+            $user: '%navidrome.user%'
+            $password: '%navidrome.password%'
+
     App\LastFm\LastFmClient:
         arguments:
             $pageDelaySeconds: '%lastfm.page_delay_seconds%'

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Controller;
+
+use App\Subsonic\SubsonicClient;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Lecture seule des playlists Navidrome via l'API Subsonic.
+ *
+ * Premier slice du portage de la feature playlist depuis le POC : on
+ * pose le SubsonicClient et les deux pages de lecture (liste + détail).
+ * Les actions d'écriture (créer, renommer, supprimer, star, etc.)
+ * arriveront dans des PRs séparées une fois la fondation validée.
+ *
+ * La DB Navidrome reste montée `:ro` : aucun accès direct côté tool —
+ * toutes les requêtes passent par `/rest/*.view` de Navidrome.
+ */
+class PlaylistController extends AbstractController
+{
+    #[Route('/playlists', name: 'app_playlists_index', methods: ['GET'])]
+    public function index(SubsonicClient $subsonic): Response
+    {
+        try {
+            $playlists = $subsonic->getPlaylists();
+            $error = null;
+        } catch (\Throwable $e) {
+            $playlists = [];
+            $error = $e->getMessage();
+        }
+
+        // Tri par date de modification descendante. Subsonic les renvoie
+        // dans un ordre arbitraire — on normalise côté tool pour que les
+        // playlists récemment touchées remontent en haut.
+        usort($playlists, static fn (array $a, array $b): int => strcmp(
+            (string) ($b['changed'] ?? ''),
+            (string) ($a['changed'] ?? ''),
+        ));
+
+        return $this->render('playlist_management/index.html.twig', [
+            'playlists' => $playlists,
+            'error' => $error,
+        ]);
+    }
+
+    #[Route('/playlists/{id}', name: 'app_playlists_show', methods: ['GET'])]
+    public function show(string $id, SubsonicClient $subsonic): Response
+    {
+        try {
+            $playlist = $subsonic->getPlaylist($id);
+        } catch (\Throwable $e) {
+            // Subsonic répond `error` aussi bien sur 404 que sur auth fail
+            // — on traduit en 404 côté UI plutôt que de surfacer une 500.
+            throw $this->createNotFoundException(sprintf(
+                'Playlist %s introuvable côté Navidrome : %s',
+                $id,
+                $e->getMessage(),
+            ));
+        }
+
+        return $this->render('playlist_management/show.html.twig', [
+            'playlist' => $playlist,
+        ]);
+    }
+}

--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace App\Subsonic;
+
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Minimal read-only client for Navidrome's Subsonic-compatible REST API.
+ *
+ * Scope of this first slice: just what the /playlists pages need (ping,
+ * getPlaylists, getPlaylist). The POC carried 15+ methods (createPlaylist,
+ * updatePlaylist, star/unstar, search3, fetchCoverArt, startScan…) but we
+ * port them only when the corresponding feature ships, to keep this PR
+ * reviewable.
+ *
+ * Auth follows the « salted token » scheme of Subsonic ≥ 1.13.0 :
+ * `t = md5(password + salt)` is sent in the URL instead of the raw
+ * password. Navidrome accepts this since its very first releases.
+ */
+class SubsonicClient
+{
+    private const API_VERSION = '1.16.1';
+    private const CLIENT_ID = 'navidrome-tools';
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $baseUrl,
+        private readonly string $user,
+        #[\SensitiveParameter] private readonly string $password,
+    ) {
+    }
+
+    public function ping(): bool
+    {
+        try {
+            $data = $this->call('ping', []);
+
+            return ($data['status'] ?? null) === 'ok';
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @return list<array{
+     *     id: string, name: string, owner: string,
+     *     songCount: int, duration: int, public: bool,
+     *     created: ?string, changed: ?string, comment: string
+     * }>
+     */
+    public function getPlaylists(): array
+    {
+        $data = $this->call('getPlaylists', []);
+        $list = $data['playlists']['playlist'] ?? [];
+
+        $out = [];
+        foreach ($list as $p) {
+            $out[] = [
+                'id' => (string) ($p['id'] ?? ''),
+                'name' => (string) ($p['name'] ?? ''),
+                'owner' => (string) ($p['owner'] ?? ''),
+                'songCount' => (int) ($p['songCount'] ?? 0),
+                'duration' => (int) ($p['duration'] ?? 0),
+                'public' => (bool) ($p['public'] ?? false),
+                'created' => isset($p['created']) ? (string) $p['created'] : null,
+                'changed' => isset($p['changed']) ? (string) $p['changed'] : null,
+                'comment' => (string) ($p['comment'] ?? ''),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Fetch one playlist with its tracks. Throws when the id is unknown
+     * — bubbles up to the controller as a 404 via the catch path there.
+     *
+     * @return array{
+     *     id: string, name: string, owner: string,
+     *     songCount: int, duration: int, public: bool,
+     *     created: ?string, changed: ?string, comment: string,
+     *     tracks: list<array{
+     *         id: string, title: string, artist: string, album: string,
+     *         duration: int, playCount: int, year: ?int, starred: ?string
+     *     }>
+     * }
+     */
+    public function getPlaylist(string $id): array
+    {
+        if ($id === '') {
+            throw new \RuntimeException('getPlaylist requires a non-empty id.');
+        }
+
+        $data = $this->call('getPlaylist', ['id' => $id]);
+        $p = $data['playlist'] ?? null;
+        if (!is_array($p)) {
+            throw new \RuntimeException('getPlaylist did not return a playlist node. Raw response: ' . json_encode($data));
+        }
+
+        $tracks = [];
+        foreach (($p['entry'] ?? []) as $e) {
+            $tracks[] = [
+                'id' => (string) ($e['id'] ?? ''),
+                'title' => (string) ($e['title'] ?? ''),
+                'artist' => (string) ($e['artist'] ?? ''),
+                'album' => (string) ($e['album'] ?? ''),
+                'duration' => (int) ($e['duration'] ?? 0),
+                'playCount' => (int) ($e['playCount'] ?? 0),
+                'year' => isset($e['year']) ? (int) $e['year'] : null,
+                'starred' => isset($e['starred']) ? (string) $e['starred'] : null,
+            ];
+        }
+
+        return [
+            'id' => (string) ($p['id'] ?? $id),
+            'name' => (string) ($p['name'] ?? ''),
+            'owner' => (string) ($p['owner'] ?? ''),
+            'songCount' => (int) ($p['songCount'] ?? count($tracks)),
+            'duration' => (int) ($p['duration'] ?? 0),
+            'public' => (bool) ($p['public'] ?? false),
+            'created' => isset($p['created']) ? (string) $p['created'] : null,
+            'changed' => isset($p['changed']) ? (string) $p['changed'] : null,
+            'comment' => (string) ($p['comment'] ?? ''),
+            'tracks' => $tracks,
+        ];
+    }
+
+    /**
+     * @param array<string, scalar> $params
+     *
+     * @return array<string, mixed>
+     */
+    private function call(string $method, array $params): array
+    {
+        $salt = bin2hex(random_bytes(8));
+        $token = md5($this->password . $salt);
+
+        $auth = [
+            'u' => $this->user,
+            't' => $token,
+            's' => $salt,
+            'v' => self::API_VERSION,
+            'c' => self::CLIENT_ID,
+            'f' => 'json',
+        ];
+
+        $url = rtrim($this->baseUrl, '/') . '/rest/' . $method . '.view?'
+            . http_build_query(array_merge($auth, $params));
+
+        try {
+            $response = $this->httpClient->request('GET', $url, ['timeout' => 30]);
+            $body = $response->toArray(throw: true);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException(sprintf(
+                'Subsonic call %s failed: %s',
+                $method,
+                $e->getMessage(),
+            ), 0, $e);
+        }
+
+        $root = $body['subsonic-response'] ?? null;
+        if (!is_array($root)) {
+            throw new \RuntimeException('Invalid Subsonic response: missing root key.');
+        }
+        if (($root['status'] ?? '') !== 'ok') {
+            $err = $root['error']['message'] ?? 'unknown error';
+
+            throw new \RuntimeException('Subsonic error on ' . $method . ': ' . $err);
+        }
+
+        return $root;
+    }
+}

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -30,6 +30,7 @@
             { label: 'Sync', route: 'app_navidrome_sync' },
             { label: 'Unmatched', route: 'app_navidrome_unmatched' },
             { label: 'Stats', route: 'app_navidrome_stats' },
+            { label: 'Playlists', route: 'app_playlists_index' },
         ]},
         { heading: 'Top', items: [
             { label: 'Artistes', route: 'app_navidrome_top_artists' },

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -1,0 +1,82 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Playlists Navidrome{% endblock %}
+
+{% macro duration(seconds) %}
+    {%- set s = seconds|default(0) -%}
+    {%- set h = (s / 3600)|round(0, 'floor') -%}
+    {%- set m = ((s % 3600) / 60)|round(0, 'floor') -%}
+    {%- if h > 0 -%}{{ h }}h{{ '%02d'|format(m) }}{%- else -%}{{ m }} min{%- endif -%}
+{% endmacro %}
+
+{% block body %}
+    {% import _self as fmt %}
+
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Playlists Navidrome</h1>
+            <p class="text-sm text-slate-500">
+                {{ playlists|length }} playlist{{ playlists|length > 1 ? 's' : '' }}
+                récupérée{{ playlists|length > 1 ? 's' : '' }} via l'API Subsonic,
+                triées par dernière modification.
+            </p>
+        </div>
+    </div>
+
+    {% if error %}
+        <div class="bg-rose-50 border border-rose-200 text-rose-800 rounded-sm p-4 text-sm mb-4">
+            Impossible de joindre Navidrome : {{ error }}
+        </div>
+    {% endif %}
+
+    {% if playlists is empty and not error %}
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
+            Aucune playlist trouvée côté Navidrome.
+        </div>
+    {% elseif playlists is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-3 py-2 text-left">Nom</th>
+                        <th class="px-3 py-2 text-left">Owner</th>
+                        <th class="px-3 py-2 text-right">Morceaux</th>
+                        <th class="px-3 py-2 text-right">Durée</th>
+                        <th class="px-3 py-2 text-left">Créée</th>
+                        <th class="px-3 py-2 text-left">Modifiée</th>
+                        <th class="px-3 py-2 text-left">Visibilité</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for p in playlists %}
+                        <tr class="border-t hover:bg-slate-50">
+                            <td class="px-3 py-2">
+                                <a href="{{ path('app_playlists_show', { id: p.id }) }}"
+                                   class="text-sky-700 hover:underline font-medium">{{ p.name }}</a>
+                                {% if p.comment %}
+                                    <div class="text-xs text-slate-500 mt-0.5">{{ p.comment }}</div>
+                                {% endif %}
+                            </td>
+                            <td class="px-3 py-2 text-slate-700">{{ p.owner }}</td>
+                            <td class="px-3 py-2 text-right tabular-nums">{{ p.songCount }}</td>
+                            <td class="px-3 py-2 text-right tabular-nums">{{ fmt.duration(p.duration) }}</td>
+                            <td class="px-3 py-2 text-xs text-slate-500">
+                                {{ p.created ? p.created|date('Y-m-d') : '—' }}
+                            </td>
+                            <td class="px-3 py-2 text-xs text-slate-500">
+                                {{ p.changed ? p.changed|date('Y-m-d H:i') : '—' }}
+                            </td>
+                            <td class="px-3 py-2 text-xs">
+                                {% if p.public %}
+                                    <span class="inline-block bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-sm">Public</span>
+                                {% else %}
+                                    <span class="inline-block bg-slate-100 text-slate-600 px-2 py-0.5 rounded-sm">Privé</span>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/playlist_management/show.html.twig
+++ b/templates/playlist_management/show.html.twig
@@ -1,0 +1,85 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}{{ playlist.name }} — Playlist{% endblock %}
+
+{% macro duration(seconds) %}
+    {%- set s = seconds|default(0) -%}
+    {%- set h = (s / 3600)|round(0, 'floor') -%}
+    {%- set m = ((s % 3600) / 60)|round(0, 'floor') -%}
+    {%- set sec = s % 60 -%}
+    {%- if h > 0 -%}{{ h }}h{{ '%02d'|format(m) }}{%- elseif m > 0 -%}{{ m }}:{{ '%02d'|format(sec) }}{%- else -%}0:{{ '%02d'|format(sec) }}{%- endif -%}
+{% endmacro %}
+
+{% block body %}
+    {% import _self as fmt %}
+
+    <div class="mb-4">
+        <a href="{{ path('app_playlists_index') }}" class="text-sm text-sky-700 hover:underline">← Toutes les playlists</a>
+        <div class="flex items-baseline justify-between mt-1 flex-wrap gap-3">
+            <h1 class="text-2xl font-semibold">{{ playlist.name }}</h1>
+            <div class="text-xs text-slate-500">
+                {% if playlist.public %}
+                    <span class="inline-block bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-sm">Public</span>
+                {% else %}
+                    <span class="inline-block bg-slate-100 text-slate-600 px-2 py-0.5 rounded-sm">Privé</span>
+                {% endif %}
+            </div>
+        </div>
+        {% if playlist.comment %}
+            <p class="text-sm text-slate-600 mt-1">{{ playlist.comment }}</p>
+        {% endif %}
+        <p class="text-xs text-slate-500 mt-2">
+            <span class="font-medium">{{ playlist.songCount }}</span> morceau{{ playlist.songCount > 1 ? 'x' : '' }} ·
+            durée totale <span class="font-medium">{{ fmt.duration(playlist.duration) }}</span> ·
+            owner <span class="font-medium">{{ playlist.owner }}</span>
+            {% if playlist.changed %}
+                · modifiée le {{ playlist.changed|date('Y-m-d H:i') }}
+            {% endif %}
+        </p>
+    </div>
+
+    {% if playlist.tracks is empty %}
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
+            Cette playlist est vide.
+        </div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-3 py-2 text-right w-12">#</th>
+                        <th class="px-3 py-2 text-left">Titre</th>
+                        <th class="px-3 py-2 text-left">Artiste</th>
+                        <th class="px-3 py-2 text-left">Album</th>
+                        <th class="px-3 py-2 text-right w-16">Année</th>
+                        <th class="px-3 py-2 text-right w-16">Durée</th>
+                        <th class="px-3 py-2 text-right w-16">Plays</th>
+                        <th class="px-3 py-2 text-center w-10" title="Starred">★</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for t in playlist.tracks %}
+                        <tr class="border-t hover:bg-slate-50">
+                            <td class="px-3 py-2 text-right text-xs text-slate-400 tabular-nums">{{ loop.index }}</td>
+                            <td class="px-3 py-2 font-medium">{{ t.title }}</td>
+                            <td class="px-3 py-2 text-slate-700">{{ t.artist }}</td>
+                            <td class="px-3 py-2 text-slate-700">{{ t.album }}</td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-500 tabular-nums">
+                                {{ t.year ?: '—' }}
+                            </td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600 tabular-nums">
+                                {{ fmt.duration(t.duration) }}
+                            </td>
+                            <td class="px-3 py-2 text-right text-xs text-slate-600 tabular-nums">
+                                {{ t.playCount }}
+                            </td>
+                            <td class="px-3 py-2 text-center text-amber-500">
+                                {{ t.starred ? '★' : '' }}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Tests\Subsonic;
+
+use App\Subsonic\SubsonicClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class SubsonicClientTest extends TestCase
+{
+    public function testPingReturnsTrueOnOkStatus(): void
+    {
+        $payload = $this->envelope(['status' => 'ok']);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->assertTrue($client->ping());
+    }
+
+    public function testPingReturnsFalseOnHttpFailure(): void
+    {
+        // Subsonic responses live behind random_bytes() salt — we don't
+        // need to control the URL, just that exceptions become `false`.
+        $http = new MockHttpClient([new MockResponse('boom', ['http_code' => 500])]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->assertFalse($client->ping());
+    }
+
+    public function testSignedUrlCarriesSaltedToken(): void
+    {
+        // Regression: the auth scheme must send `t=md5(password+salt)`
+        // and a per-call random salt, never the raw password.
+        $payload = $this->envelope(['status' => 'ok']);
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured, $payload): MockResponse {
+            $captured = $url;
+
+            return new MockResponse($payload);
+        });
+
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'super-secret');
+        $client->ping();
+
+        $this->assertIsString($captured);
+        $this->assertStringStartsWith('http://nd:4533/rest/ping.view?', $captured);
+        parse_str(parse_url($captured, \PHP_URL_QUERY) ?: '', $q);
+        $this->assertSame('admin', $q['u'] ?? null);
+        $this->assertSame('json', $q['f'] ?? null);
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{16}$/', (string) ($q['s'] ?? ''));
+        $this->assertSame(md5('super-secret' . $q['s']), $q['t'] ?? null);
+        $this->assertStringNotContainsString('super-secret', $captured);
+    }
+
+    public function testGetPlaylistsParsesNormalizedList(): void
+    {
+        $payload = $this->envelope([
+            'status' => 'ok',
+            'playlists' => [
+                'playlist' => [
+                    [
+                        'id' => 'pl-1', 'name' => 'Morning', 'owner' => 'admin',
+                        'songCount' => 12, 'duration' => 2400, 'public' => true,
+                        'created' => '2025-01-01T10:00:00.000Z',
+                        'changed' => '2025-06-14T12:00:00.000Z',
+                        'comment' => 'Wake up',
+                    ],
+                    [
+                        // Missing-field tolerance : only `id` provided.
+                        'id' => 'pl-2',
+                    ],
+                ],
+            ],
+        ]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $rows = $client->getPlaylists();
+
+        $this->assertCount(2, $rows);
+        $this->assertSame('pl-1', $rows[0]['id']);
+        $this->assertSame('Morning', $rows[0]['name']);
+        $this->assertSame(12, $rows[0]['songCount']);
+        $this->assertSame(2400, $rows[0]['duration']);
+        $this->assertTrue($rows[0]['public']);
+        $this->assertSame('Wake up', $rows[0]['comment']);
+
+        // The fallback shape must keep types stable so the template
+        // can render the row without null checks everywhere.
+        $this->assertSame('pl-2', $rows[1]['id']);
+        $this->assertSame('', $rows[1]['name']);
+        $this->assertSame(0, $rows[1]['songCount']);
+        $this->assertFalse($rows[1]['public']);
+        $this->assertNull($rows[1]['created']);
+    }
+
+    public function testGetPlaylistsReturnsEmptyArrayWhenServerHasNone(): void
+    {
+        $payload = $this->envelope(['status' => 'ok', 'playlists' => new \stdClass()]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->assertSame([], $client->getPlaylists());
+    }
+
+    public function testGetPlaylistParsesTracksAndPlaylistMetadata(): void
+    {
+        $payload = $this->envelope([
+            'status' => 'ok',
+            'playlist' => [
+                'id' => 'pl-1',
+                'name' => 'Best of Daft Punk',
+                'owner' => 'admin',
+                'songCount' => 2,
+                'duration' => 600,
+                'public' => false,
+                'created' => '2025-01-01T10:00:00.000Z',
+                'changed' => '2025-06-14T12:00:00.000Z',
+                'comment' => '',
+                'entry' => [
+                    [
+                        'id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk',
+                        'album' => 'Random Access Memories', 'duration' => 248,
+                        'playCount' => 42, 'year' => 2013,
+                        'starred' => '2025-06-14T12:00:00.000Z',
+                    ],
+                    [
+                        // Missing-field tolerance : only `id` provided.
+                        'id' => 'mf-2',
+                    ],
+                ],
+            ],
+        ]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $pl = $client->getPlaylist('pl-1');
+
+        $this->assertSame('Best of Daft Punk', $pl['name']);
+        $this->assertSame(2, $pl['songCount']);
+        $this->assertCount(2, $pl['tracks']);
+
+        $this->assertSame('Get Lucky', $pl['tracks'][0]['title']);
+        $this->assertSame(2013, $pl['tracks'][0]['year']);
+        $this->assertSame(42, $pl['tracks'][0]['playCount']);
+        $this->assertSame('2025-06-14T12:00:00.000Z', $pl['tracks'][0]['starred']);
+
+        $this->assertSame('mf-2', $pl['tracks'][1]['id']);
+        $this->assertSame('', $pl['tracks'][1]['title']);
+        $this->assertNull($pl['tracks'][1]['year']);
+        $this->assertNull($pl['tracks'][1]['starred']);
+    }
+
+    public function testGetPlaylistRejectsEmptyId(): void
+    {
+        $http = new MockHttpClient([]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('non-empty id');
+        $client->getPlaylist('');
+
+        $this->assertSame(0, $http->getRequestsCount());
+    }
+
+    public function testSubsonicErrorStatusIsBubbled(): void
+    {
+        $payload = $this->envelope([
+            'status' => 'failed',
+            'error' => ['code' => 70, 'message' => 'Playlist not found.'],
+        ]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Playlist not found');
+        $client->getPlaylist('unknown');
+    }
+
+    public function testBaseUrlTrailingSlashIsToleratedExactlyOnce(): void
+    {
+        // Regression: `http://nd:4533/` + `/rest/...` used to produce
+        // `//rest/...` and break Navidrome's route matcher.
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return new MockResponse($this->envelope(['status' => 'ok']));
+        });
+
+        $client = new SubsonicClient($http, 'http://nd:4533/', 'admin', 'pwd');
+        $client->ping();
+
+        $this->assertIsString($captured);
+        $this->assertStringStartsWith('http://nd:4533/rest/ping.view?', $captured);
+        $this->assertStringNotContainsString('//rest/', $captured);
+    }
+
+    /**
+     * @param array<string, mixed> $response
+     */
+    private function envelope(array $response): string
+    {
+        return json_encode(['subsonic-response' => $response], \JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## Summary

Premier slice du portage de la feature playlist depuis le POC (`main` carry ~36 fichiers playlist, develop est vierge). **Lecture seule uniquement** — la DB Navidrome peut donc rester montée `:ro`.

### `src/Subsonic/SubsonicClient.php`

- Auth **« salted token »** Subsonic ≥ 1.13 : `t = md5(password + salt)`, salt random par appel, mot de passe **jamais transmis** en clair.
- Méthodes lecture seule : `ping()`, `getPlaylists()`, `getPlaylist()`.
- Les 15+ autres méthodes du POC (`createPlaylist`, `updatePlaylist`, `star`/`unstar`, `search3`, `fetchCoverArt`, `startScan`, …) seront portées dans les PRs suivantes, quand la feature qui les utilise sera prête. **Pas de mort-né, pas de code spéculatif.**

### `config/services.yaml`

Bind `$baseUrl` / `$user` / `$password` sur les ENV `NAVIDROME_URL` / `NAVIDROME_USER` / `NAVIDROME_PASSWORD` déjà présentes (elles servaient déjà aux extensions Twig et au repo SQLite).

### `src/Controller/PlaylistController.php`

- `GET /playlists` → liste, triée par date de modification descendante (Subsonic les renvoie dans un ordre arbitraire — on normalise côté tool).
- `GET /playlists/{id}` → détail avec tracks. Toute exception Subsonic est traduite en **404** (l'API répond `error` aussi bien sur id inconnu que sur auth fail, pas la peine de surfacer du 500).
- Erreur côté liste (Navidrome down, auth KO) → bandeau rose, pas de crash.

### Templates `templates/playlist_management/`

(Nommage aligné sur le POC, simplifie la suite des PRs.)

- **`index.html.twig`** : tableau nom / owner / morceaux / durée / créée / modifiée / visibilité. Macro `duration` inline (pas besoin d'extension Twig pour ce simple format).
- **`show.html.twig`** : header (nom, badge public/privé, compteur, durée, owner, date) + tableau tracks (titre / artiste / album / année / durée / plays / starred).
- **Pas de** : bulk actions, search-and-add, M3U export, rename / delete / duplicate. Tout ça viendra dans les PRs suivantes.

### `_navbar.html.twig`

Lien « Playlists » sous le dropdown Navidrome.

### `tests/Subsonic/SubsonicClientTest.php` (9 tests / 40 assertions) avec `MockHttpClient`

- `ping` ok / KO.
- URL signée porte bien le salted token et **n'expose JAMAIS** le mot de passe en clair.
- Parsing tolérant des champs manquants côté liste et tracks (Navidrome omet souvent `comment`, `starred`, `year`, …).
- Liste vide quand `playlists.playlist` absent.
- ID vide → exception sans requête HTTP.
- Status `failed` Subsonic remonte le message d'erreur côté caller.
- Base URL avec `/` final → pas de double slash.

## Reste à faire dans les PRs suivantes

**Génération** : 9 générateurs (top-last-days, top-all-time, never-played, anniversary, songs-you-used-to-love, top-month-yago, top-years-ago, top-last-month, top-last-year) + entité `PlaylistDefinition` + `GeneratorRegistry` + page preview + commande CLI.

**Mutations** : rename / duplicate / delete, bulk star, dead tracks detection, search-and-add, M3U export. Chacune va étoffer `SubsonicClient` au fur et à mesure des besoins.

## Test plan

- [x] `composer phpcs` → vert
- [x] `composer phpunit` → **164 / 498 verts** (était 155 / 458, +9 tests)
- [x] `php bin/console lint:container` → vert
- [x] `php bin/console lint:twig templates/playlist_management` → vert
- [x] `php bin/console debug:router | grep playlist` → 2 routes enregistrées
- [x] phpstan vert en CI (10 erreurs locales = artefact d'env)
- [ ] Test manuel : déployer en local, vérifier que la liste s'affiche et que le détail d'une playlist se charge (les tests unitaires ne touchent pas le wiring Twig / DI).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_