### PR TITLE
feat(unmatched): diagnostic « pourquoi unmatched » sur /navidrome/unmatched

### DIFF
--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -6,6 +6,7 @@ use App\Entity\ScrobbleSync;
 use App\Message\RematchMessage;
 use App\Message\SyncNavidromeMessage;
 use App\Repository\ScrobbleSyncRepository;
+use App\Service\UnmatchedDiagnoser;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -75,8 +76,11 @@ class NavidromeSyncController extends AbstractController
     }
 
     #[Route('/navidrome/unmatched', name: 'app_navidrome_unmatched', methods: ['GET'])]
-    public function unmatched(Request $request, ScrobbleSyncRepository $syncRepo): Response
-    {
+    public function unmatched(
+        Request $request,
+        ScrobbleSyncRepository $syncRepo,
+        UnmatchedDiagnoser $diagnoser,
+    ): Response {
         $page = max(1, (int) $request->query->get('page', 1));
         $perPage = 50;
         $filterArtist = trim((string) $request->query->get('artist', ''));
@@ -89,6 +93,17 @@ class NavidromeSyncController extends AbstractController
             filterArtist: $filterArtist !== '' ? $filterArtist : null,
             filterTitle: $filterTitle !== '' ? $filterTitle : null,
         );
+        // Per-row diagnosis is scoped to the current page (worst case 50
+        // groups → a handful of cheap SQLite probes each). Cached in
+        // {@see UnmatchedDiagnoser} would be premature: a user paginating
+        // hits each row at most once per visit.
+        foreach ($rows as &$row) {
+            $row['diagnosis'] = $diagnoser->diagnose(
+                (string) ($row['artist'] ?? ''),
+                (string) ($row['title'] ?? ''),
+            );
+        }
+        unset($row);
         $total = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
 
         return $this->render('navidrome/unmatched.html.twig', [

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2352,6 +2352,143 @@ class NavidromeRepository
     }
 
     /**
+     * True when at least one media_file row has the given artist (matched
+     * on either `artist` or `album_artist`, normalized). Cheaper than
+     * {@see findArtistIdByName()} when the caller only needs a boolean —
+     * skips the `artist` table probe and stops at the first row found.
+     *
+     * Used by the unmatched diagnoser to distinguish "artist absent from
+     * library" from "artist present but track/album missing".
+     */
+    public function hasArtistInLibrary(string $artist): bool
+    {
+        $artistN = self::normalize($artist);
+        if ($artistN === '') {
+            return false;
+        }
+
+        $row = $this->connection()->fetchOne(
+            'SELECT 1 FROM media_file
+             WHERE np_normalize(artist) = :a OR np_normalize(album_artist) = :a
+             LIMIT 1',
+            ['a' => $artistN],
+        );
+
+        return $row !== false;
+    }
+
+    /**
+     * Returns up to `$limit` library artist names within Levenshtein
+     * distance `$maxDistance` of `$artist` (normalized comparison), ordered
+     * by ascending distance. The candidate pool is restricted to artists
+     * sharing the first character of the normalized query — same pruning
+     * trick as {@see findMediaFileFuzzy()} to keep the scan bounded.
+     *
+     * Used by the unmatched diagnoser to suggest probable artist aliases.
+     *
+     * @return list<array{name: string, distance: int}>
+     */
+    public function findNearestArtistNames(string $artist, int $maxDistance, int $limit = 3): array
+    {
+        if ($maxDistance <= 0 || $limit <= 0) {
+            return [];
+        }
+
+        $artistN = self::normalize($artist);
+        if ($artistN === '' || strlen($artistN) > 255) {
+            return [];
+        }
+
+        $prefix = mb_substr($artistN, 0, 1);
+        if ($prefix === '') {
+            return [];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT artist FROM media_file
+             WHERE artist != '' AND substr(np_normalize(artist), 1, 1) = :p",
+            ['p' => $prefix],
+        );
+
+        $seen = [];
+        $matches = [];
+        foreach ($rows as $row) {
+            $name = (string) ($row['artist'] ?? '');
+            if ($name === '' || isset($seen[$name])) {
+                continue;
+            }
+            $seen[$name] = true;
+
+            $candN = self::normalize($name);
+            if ($candN === '' || $candN === $artistN || strlen($candN) > 255) {
+                continue;
+            }
+
+            $score = levenshtein($candN, $artistN);
+            if ($score > $maxDistance) {
+                continue;
+            }
+            $matches[] = ['name' => $name, 'distance' => $score];
+        }
+
+        usort($matches, static fn (array $a, array $b) => $a['distance'] <=> $b['distance']);
+
+        return array_slice($matches, 0, $limit);
+    }
+
+    /**
+     * Returns up to `$limit` titles for `$artist` whose normalized form
+     * is within Levenshtein distance `$maxDistance` of `$title`, ordered
+     * by ascending distance. Distinct on the raw title (multiple albums
+     * share the same track title — we only want one suggestion per name).
+     *
+     * Used by the unmatched diagnoser to flag scrobbles whose title likely
+     * differs by a typo / re-release marker from a track the user owns.
+     *
+     * @return list<array{title: string, distance: int}>
+     */
+    public function findNearestTitlesForArtist(string $artist, string $title, int $maxDistance, int $limit = 3): array
+    {
+        if ($maxDistance <= 0 || $limit <= 0) {
+            return [];
+        }
+
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        if ($artistN === '' || $titleN === '' || strlen($titleN) > 255) {
+            return [];
+        }
+
+        $rows = $this->connection()->fetchAllAssociative(
+            "SELECT DISTINCT title FROM media_file
+             WHERE title != ''
+               AND (np_normalize(artist) = :a OR np_normalize(album_artist) = :a)",
+            ['a' => $artistN],
+        );
+
+        $matches = [];
+        foreach ($rows as $row) {
+            $name = (string) ($row['title'] ?? '');
+            if ($name === '') {
+                continue;
+            }
+            $candN = self::normalize($name);
+            if ($candN === '' || $candN === $titleN || strlen($candN) > 255) {
+                continue;
+            }
+            $score = levenshtein($candN, $titleN);
+            if ($score > $maxDistance) {
+                continue;
+            }
+            $matches[] = ['title' => $name, 'distance' => $score];
+        }
+
+        usort($matches, static fn (array $a, array $b) => $a['distance'] <=> $b['distance']);
+
+        return array_slice($matches, 0, $limit);
+    }
+
+    /**
      * Bulk map: normalized artist name → that artist's media_files as
      * `['id' => …, 'title_norm' => …]`. One full table scan with the
      * `np_normalize` UDF applied server-side, grouped in PHP. Lets a caller

--- a/src/Service/UnmatchedDiagnoser.php
+++ b/src/Service/UnmatchedDiagnoser.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Service;
+
+use App\Navidrome\NavidromeRepository;
+
+/**
+ * Classifies why a scrobble (or unmatched group) failed the matching
+ * cascade, by re-running cheap read-only probes against the Navidrome DB.
+ *
+ * Read-only by design: this service does NOT mutate the cache, the alias
+ * tables or anything else. Wired from the `/navidrome/unmatched` page so
+ * users can see, per row, the likely category of failure (artist
+ * unknown, near-match alias candidate, track missing from the library)
+ * and act on it without guessing.
+ *
+ * The classification is intentionally heuristic and best-effort: it
+ * mirrors the cascade's local-only steps (MBID excluded, since the
+ * scrobble at this point already failed the full cascade including
+ * `track.getInfo`).
+ */
+class UnmatchedDiagnoser
+{
+    public const REASON_ARTIST_UNKNOWN = 'artist_unknown';
+    public const REASON_ARTIST_NEAR_MATCH = 'artist_near_match';
+    public const REASON_TITLE_NEAR_MATCH = 'title_near_match';
+    public const REASON_TRACK_MISSING = 'track_missing';
+    public const REASON_UNKNOWN = 'unknown';
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $artistMaxDistance = 2,
+        private readonly int $titleMaxDistance = 3,
+    ) {
+    }
+
+    /**
+     * @return array{
+     *     reason: string,
+     *     artist_suggestions?: list<array{name: string, distance: int}>,
+     *     title_suggestions?: list<array{title: string, distance: int}>,
+     * }
+     */
+    public function diagnose(string $artist, string $title): array
+    {
+        if (trim($artist) === '' || trim($title) === '') {
+            return ['reason' => self::REASON_UNKNOWN];
+        }
+
+        if (!$this->navidrome->hasArtistInLibrary($artist)) {
+            $artistSuggestions = $this->navidrome->findNearestArtistNames(
+                $artist,
+                $this->artistMaxDistance,
+            );
+            if ($artistSuggestions !== []) {
+                return [
+                    'reason' => self::REASON_ARTIST_NEAR_MATCH,
+                    'artist_suggestions' => $artistSuggestions,
+                ];
+            }
+
+            return ['reason' => self::REASON_ARTIST_UNKNOWN];
+        }
+
+        $titleSuggestions = $this->navidrome->findNearestTitlesForArtist(
+            $artist,
+            $title,
+            $this->titleMaxDistance,
+        );
+        if ($titleSuggestions !== []) {
+            return [
+                'reason' => self::REASON_TITLE_NEAR_MATCH,
+                'title_suggestions' => $titleSuggestions,
+            ];
+        }
+
+        return ['reason' => self::REASON_TRACK_MISSING];
+    }
+}

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -50,6 +50,7 @@
                     <th class="px-3 py-2 text-left">Artiste</th>
                     <th class="px-3 py-2 text-left">Titre</th>
                     <th class="px-3 py-2 text-left">Album</th>
+                    <th class="px-3 py-2 text-left">Diagnostic</th>
                     <th class="px-3 py-2 text-right">Scrobbles</th>
                     <th class="px-3 py-2 text-right">Dernier joué</th>
                     <th class="px-3 py-2 text-right">Actions</th>
@@ -62,6 +63,26 @@
                     <td class="px-3 py-1.5">{{ row.artist }}</td>
                     <td class="px-3 py-1.5">{{ row.title }}</td>
                     <td class="px-3 py-1.5 text-slate-400 text-xs">{{ row.album ?? '—' }}</td>
+                    <td class="px-3 py-1.5 text-xs">
+                        {% set d = row.diagnosis %}
+                        {% if d.reason == 'artist_unknown' %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-rose-100 text-rose-800" title="Aucun artiste comparable dans la bibliothèque Navidrome.">Artiste inconnu</span>
+                        {% elseif d.reason == 'artist_near_match' %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-amber-100 text-amber-800"
+                                  title="Suggestions : {{ d.artist_suggestions|map(s => s.name ~ ' (' ~ s.distance ~ ')')|join(', ') }}">
+                                Artiste ≈ {{ d.artist_suggestions[0].name }}
+                            </span>
+                        {% elseif d.reason == 'title_near_match' %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-sky-100 text-sky-800"
+                                  title="Suggestions : {{ d.title_suggestions|map(s => s.title ~ ' (' ~ s.distance ~ ')')|join(', ') }}">
+                                Titre ≈ {{ d.title_suggestions[0].title }}
+                            </span>
+                        {% elseif d.reason == 'track_missing' %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-slate-100 text-slate-700" title="L'artiste existe mais ce titre est introuvable dans la bibliothèque.">Track absente</span>
+                        {% else %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-slate-100 text-slate-500">—</span>
+                        {% endif %}
+                    </td>
                     <td class="px-3 py-1.5 text-right font-mono">{{ row.count }}</td>
                     <td class="px-3 py-1.5 text-right text-xs text-slate-500">{{ row.last_played_at|date('d/m/Y') }}</td>
                     <td class="px-3 py-1.5 text-right whitespace-nowrap">

--- a/tests/Service/UnmatchedDiagnoserTest.php
+++ b/tests/Service/UnmatchedDiagnoserTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Navidrome\NavidromeRepository;
+use App\Service\UnmatchedDiagnoser;
+use App\Tests\Navidrome\NavidromeFixtureFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the heuristic classification of unmatched scrobbles. The
+ * underlying SQL probes live on {@see NavidromeRepository}; this test
+ * pins the routing logic + the suggestion shapes.
+ */
+class UnmatchedDiagnoserTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testArtistUnknownWhenLibraryHasNothingComparable(): void
+    {
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Zzz Unknown Band', 'Whatever');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_ARTIST_UNKNOWN, $result['reason']);
+        $this->assertArrayNotHasKey('artist_suggestions', $result);
+    }
+
+    public function testArtistNearMatchSurfacesSuggestion(): void
+    {
+        // Library has "Daft Punk". Scrobble says "Daft Pumk" (typo).
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Daft Pumk', 'Get Lucky');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_ARTIST_NEAR_MATCH, $result['reason']);
+        $this->assertNotEmpty($result['artist_suggestions']);
+        $this->assertSame('Daft Punk', $result['artist_suggestions'][0]['name']);
+        $this->assertSame(1, $result['artist_suggestions'][0]['distance']);
+    }
+
+    public function testTitleNearMatchWhenArtistOwnedButTitleDiffers(): void
+    {
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Around the World', 'artist' => 'Daft Punk'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Daft Punk', 'Around the Word');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_TITLE_NEAR_MATCH, $result['reason']);
+        $this->assertNotEmpty($result['title_suggestions']);
+        $this->assertSame('Around the World', $result['title_suggestions'][0]['title']);
+    }
+
+    public function testTrackMissingWhenArtistOwnedButNoNearTitle(): void
+    {
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Around the World', 'artist' => 'Daft Punk'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Daft Punk', 'Something Completely Different');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_TRACK_MISSING, $result['reason']);
+    }
+
+    public function testEmptyInputsReturnUnknown(): void
+    {
+        $repo = $this->seedLibrary([]);
+        $diag = new UnmatchedDiagnoser($repo);
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_UNKNOWN, $diag->diagnose('', 'Title')['reason']);
+        $this->assertSame(UnmatchedDiagnoser::REASON_UNKNOWN, $diag->diagnose('Artist', '   ')['reason']);
+    }
+
+    public function testArtistMatchedViaAlbumArtistColumnSkipsArtistUnknown(): void
+    {
+        // The library has a feat. variant on `artist` but the canonical name
+        // sits in `album_artist`. The diagnoser must reuse that column too.
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Ensemble', 'artist' => 'OrelSan feat. Skread', 'album_artist' => 'Orelsan'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Orelsan', 'Nowhere Track');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_TRACK_MISSING, $result['reason']);
+    }
+
+    /**
+     * @param list<array{id: string, title: string, artist: string, album_artist?: string}> $tracks
+     */
+    private function seedLibrary(array $tracks): NavidromeRepository
+    {
+        $path = sys_get_temp_dir() . '/nd-diag-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        foreach ($tracks as $t) {
+            NavidromeFixtureFactory::insertTrack(
+                $conn,
+                $t['id'],
+                $t['title'],
+                $t['artist'],
+                albumArtist: $t['album_artist'] ?? null,
+            );
+        }
+        $conn->close();
+
+        return new NavidromeRepository($path, 'admin');
+    }
+}


### PR DESCRIPTION
## Résumé

Classifieur read-only des scrobbles non matchés affiché par ligne sur `/navidrome/unmatched`. Permet de prioriser les actions (alias vs import) sans deviner la cause du miss.

## Catégories

- **Artiste inconnu** — aucune trace de l'artiste dans `media_file.artist` ni `album_artist`
- **Artiste ≈ X** — pas d'exact mais Levenshtein ≤ 2 vs un artiste de la bibliothèque (suggestion en tooltip)
- **Titre ≈ X** — l'artiste existe, un de ses titres est à Levenshtein ≤ 3
- **Track absente** — artiste owned, aucun titre proche (→ Lidarr)
- **—** (unknown) — fallback

## Changements

- `src/Service/UnmatchedDiagnoser.php` : cascade `hasArtistInLibrary → findNearestArtistNames → findNearestTitlesForArtist`, MBID exclu (déjà retenté en amont).
- `src/Navidrome/NavidromeRepository.php` : 3 sondes SQL read-only, pruning par préfixe + Levenshtein PHP (même pattern que `findMediaFileFuzzy`).
- `src/Controller/NavidromeSyncController.php` : diagnose par ligne, scopée à la page courante (50 max).
- `templates/navidrome/unmatched.html.twig` : colonne badge colorée, suggestions en tooltip.
- `tests/Service/UnmatchedDiagnoserTest.php` : 6 cas (SQLite mémoire) — chaque catégorie + fallback `album_artist` + entrées vides.

## Test plan

- [ ] Visiter `/navidrome/unmatched`, vérifier qu'une distribution des badges apparaît
- [ ] Vérifier qu'un tooltip s'affiche au survol d'un badge `≈`
- [ ] Confirmer qu'aucune mutation n'a lieu sur le cache / les alias (read-only)
- [ ] `composer ci` reste vert localement

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_