### PR TITLE
fix(rematch): purge le cache négatif des couples retentés + catégorie MATCHER_GAP

### DIFF
--- a/src/MessageHandler/RematchMessageHandler.php
+++ b/src/MessageHandler/RematchMessageHandler.php
@@ -8,6 +8,7 @@ use App\Entity\ScrobbleSync;
 use App\Message\RematchMessage;
 use App\Navidrome\NavidromeSyncReport;
 use App\Navidrome\NavidromeSyncService;
+use App\Repository\LastFmMatchCacheRepository;
 use App\Repository\ScrobbleSyncRepository;
 use App\Service\RunHistoryRecorder;
 use App\Strawberry\StrawberrySyncReport;
@@ -23,6 +24,7 @@ class RematchMessageHandler
         private readonly StrawberrySyncService $strawberrySync,
         private readonly RunHistoryRecorder $recorder,
         private readonly NavidromeContainerManager $container,
+        private readonly LastFmMatchCacheRepository $matchCache,
     ) {
     }
 
@@ -37,6 +39,14 @@ class RematchMessageHandler
             reference: 'unmatched',
             label: sprintf('%s rematch%s', $message->target, $message->dryRun ? ' [dry-run]' : ''),
             action: function (RunHistory $entry) use ($message): NavidromeSyncReport|StrawberrySyncReport {
+                // Bust the LastFm match cache for couples we're about to
+                // retry. Otherwise the matcher hits its own fresh negative
+                // entry (TTL 30j by default) for the very couples the user
+                // is asking to rematch, and the run is a no-op. Positives
+                // are preserved — those are still valid resolutions.
+                if ($message->target === ScrobbleSync::TARGET_NAVIDROME) {
+                    $this->matchCache->purgeUnmatchedNegatives($message->target);
+                }
                 $this->syncRepo->resetUnmatchedToPending($message->target);
                 if ($message->target === ScrobbleSync::TARGET_NAVIDROME) {
                     return $this->navidromeSync->process(limit: $message->limit, dryRun: $message->dryRun, run: $entry);

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2378,6 +2378,38 @@ class NavidromeRepository
     }
 
     /**
+     * Find one media_file matching `(artist, title)` strictly on `title`
+     * but tolerating the artist living in either the `artist` column or
+     * the `album_artist` column. This is what the matching cascade's
+     * couple step deliberately does NOT do — it sticks to the `artist`
+     * column to keep false-positives down — so a hit here typically
+     * means the user owns the track but a feat-artist asymmetry (or
+     * similar tagging quirk) confuses the cascade.
+     *
+     * Used by {@see \App\Service\UnmatchedDiagnoser} to surface the
+     * `MATCHER_GAP` category : « track présente, cascade KO ».
+     */
+    public function findMediaFileByArtistOrAlbumArtistAndTitle(string $artist, string $title): ?string
+    {
+        $artistN = self::normalize($artist);
+        $titleN = self::normalize($title);
+        if ($artistN === '' || $titleN === '') {
+            return null;
+        }
+
+        $id = $this->connection()->fetchOne(
+            'SELECT id FROM media_file
+             WHERE np_normalize(title) = :t
+               AND (np_normalize(artist) = :a OR np_normalize(album_artist) = :a)
+             ORDER BY (np_normalize(artist) = :a) DESC, id ASC
+             LIMIT 1',
+            ['a' => $artistN, 't' => $titleN],
+        );
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
      * Returns up to `$limit` library artist names within Levenshtein
      * distance `$maxDistance` of `$artist` (normalized comparison), ordered
      * by ascending distance. The candidate pool is restricted to artists

--- a/src/Repository/LastFmMatchCacheRepository.php
+++ b/src/Repository/LastFmMatchCacheRepository.php
@@ -172,6 +172,76 @@ class LastFmMatchCacheRepository extends ServiceEntityRepository
     }
 
     /**
+     * Drop every NEGATIVE cache row whose `(source_artist_norm,
+     * source_title_norm)` couple is referenced by at least one
+     * `scrobble_sync` row currently in `unmatched` status for `$target`.
+     *
+     * Called by {@see \App\MessageHandler\RematchMessageHandler} before
+     * resetting the sync rows to `pending`: without this, the matcher's
+     * cache lookup short-circuits on the same negative entry that
+     * produced the unmatched in the first place, and the rematch is a
+     * no-op for every couple whose negative cache is still within
+     * `$cacheTtlDays`. Positives are kept — those are still valid
+     * resolutions; the user can wipe them via {@see purgeAll()} if
+     * they really mean it.
+     *
+     * Returns the number of rows deleted.
+     */
+    public function purgeUnmatchedNegatives(string $target): int
+    {
+        // Two-step rather than a JOINed DELETE: the `np_normalize` UDF
+        // is registered on the Navidrome connection, not the app ORM
+        // connection that hosts both tables. We fetch raw couples,
+        // normalize in PHP (same canonical form as the cache columns),
+        // then delete in a single statement.
+        $couples = $this->connection()->fetchAllAssociative(
+            'SELECT DISTINCT s.artist, s.title
+             FROM scrobble_sync ss
+             INNER JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE ss.target = :target AND ss.status = :status',
+            ['target' => $target, 'status' => 'unmatched'],
+        );
+
+        $tuples = [];
+        $params = [];
+        $i = 0;
+        foreach ($couples as $row) {
+            $a = NavidromeRepository::normalize((string) ($row['artist'] ?? ''));
+            $t = NavidromeRepository::normalize((string) ($row['title'] ?? ''));
+            if ($a === '' || $t === '') {
+                continue;
+            }
+            $tuples[] = sprintf('(:a%d, :t%d)', $i, $i);
+            $params['a' . $i] = $a;
+            $params['t' . $i] = $t;
+            $i++;
+        }
+        if ($tuples === []) {
+            return 0;
+        }
+
+        // SQLite caps prepared-statement params at 999. Chunk the IN list
+        // so we never trip that limit on libraries with thousands of
+        // distinct unmatched couples.
+        $deleted = 0;
+        foreach (array_chunk($tuples, 400, preserve_keys: true) as $chunk) {
+            $chunkParams = [];
+            foreach (array_keys($chunk) as $idx) {
+                $chunkParams['a' . $idx] = $params['a' . $idx];
+                $chunkParams['t' . $idx] = $params['t' . $idx];
+            }
+            $deleted += (int) $this->connection()->executeStatement(
+                'DELETE FROM lastfm_match_cache
+                 WHERE target_media_file_id IS NULL
+                   AND (source_artist_norm, source_title_norm) IN (' . implode(',', $chunk) . ')',
+                $chunkParams,
+            );
+        }
+
+        return $deleted;
+    }
+
+    /**
      * Drop every negative cache row older than `$ttlDays`. Called once at
      * the start of each import / rematch run. `$ttlDays <= 0` means
      * « never expire », so it's a no-op.

--- a/src/Service/UnmatchedDiagnoser.php
+++ b/src/Service/UnmatchedDiagnoser.php
@@ -23,6 +23,7 @@ class UnmatchedDiagnoser
 {
     public const REASON_ARTIST_UNKNOWN = 'artist_unknown';
     public const REASON_ARTIST_NEAR_MATCH = 'artist_near_match';
+    public const REASON_MATCHER_GAP = 'matcher_gap';
     public const REASON_TITLE_NEAR_MATCH = 'title_near_match';
     public const REASON_TRACK_MISSING = 'track_missing';
     public const REASON_UNKNOWN = 'unknown';
@@ -39,6 +40,7 @@ class UnmatchedDiagnoser
      *     reason: string,
      *     artist_suggestions?: list<array{name: string, distance: int}>,
      *     title_suggestions?: list<array{title: string, distance: int}>,
+     *     target_media_file_id?: string,
      * }
      */
     public function diagnose(string $artist, string $title): array
@@ -60,6 +62,20 @@ class UnmatchedDiagnoser
             }
 
             return ['reason' => self::REASON_ARTIST_UNKNOWN];
+        }
+
+        // Exact title for this artist (artist OR album_artist) BEFORE the
+        // fuzzy-title step. A hit here means the track is actually owned
+        // — the cascade just missed it (typically a stale negative cache
+        // entry, or a tagging asymmetry the cascade is too strict to
+        // bridge). Most actionable category : the user just needs to
+        // rematch (cache now busted) or, worst case, create a direct alias.
+        $mfid = $this->navidrome->findMediaFileByArtistOrAlbumArtistAndTitle($artist, $title);
+        if ($mfid !== null) {
+            return [
+                'reason' => self::REASON_MATCHER_GAP,
+                'target_media_file_id' => $mfid,
+            ];
         }
 
         $titleSuggestions = $this->navidrome->findNearestTitlesForArtist(

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -67,6 +67,11 @@
                         {% set d = row.diagnosis %}
                         {% if d.reason == 'artist_unknown' %}
                             <span class="inline-block px-2 py-0.5 rounded-sm bg-rose-100 text-rose-800" title="Aucun artiste comparable dans la bibliothèque Navidrome.">Artiste inconnu</span>
+                        {% elseif d.reason == 'matcher_gap' %}
+                            <span class="inline-block px-2 py-0.5 rounded-sm bg-violet-100 text-violet-800"
+                                  title="Track présente en bibliothèque mais la cascade matcher l'a ratée. Un rematch (cache négatif purgé) devrait la résoudre.">
+                                Présente — cascade KO
+                            </span>
                         {% elseif d.reason == 'artist_near_match' %}
                             <span class="inline-block px-2 py-0.5 rounded-sm bg-amber-100 text-amber-800"
                                   title="Suggestions : {{ d.artist_suggestions|map(s => s.name ~ ' (' ~ s.distance ~ ')')|join(', ') }}">

--- a/tests/Service/UnmatchedDiagnoserTest.php
+++ b/tests/Service/UnmatchedDiagnoserTest.php
@@ -68,6 +68,36 @@ class UnmatchedDiagnoserTest extends TestCase
         $this->assertSame('Around the World', $result['title_suggestions'][0]['title']);
     }
 
+    public function testMatcherGapWhenExactTrackPresent(): void
+    {
+        // Exact (artist, title) couple owned in the library — but the
+        // unmatched row is still here (e.g. stale negative cache). The
+        // diagnoser must surface this as the most actionable category.
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-1', 'title' => 'Monument', 'artist' => 'Soleil Noir'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Soleil Noir', 'Monument');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_MATCHER_GAP, $result['reason']);
+        $this->assertSame('mf-1', $result['target_media_file_id']);
+    }
+
+    public function testMatcherGapAcceptsAlbumArtistColumnAsTheArtistMatch(): void
+    {
+        // artist="X feat. Y" + album_artist="X" — the matching cascade
+        // misses it (couple step keys on `artist` only) but we own the
+        // track. Must classify as MATCHER_GAP, not TRACK_MISSING.
+        $repo = $this->seedLibrary([
+            ['id' => 'mf-2', 'title' => 'Ensemble', 'artist' => 'OrelSan feat. Skread', 'album_artist' => 'Orelsan'],
+        ]);
+
+        $result = (new UnmatchedDiagnoser($repo))->diagnose('Orelsan', 'Ensemble');
+
+        $this->assertSame(UnmatchedDiagnoser::REASON_MATCHER_GAP, $result['reason']);
+        $this->assertSame('mf-2', $result['target_media_file_id']);
+    }
+
     public function testTrackMissingWhenArtistOwnedButNoNearTitle(): void
     {
         $repo = $this->seedLibrary([


### PR DESCRIPTION
## Résumé

Sans cette purge, **« Rematcher tous » est un no-op** pour toute couple dont la cache négative LastFm (TTL 30j) est encore chaude : le matcher court-circuite sur l'entrée négative et reclasse `unmatched`. Bug constaté sur l'album *Jour de Nuit* / Soleil Noir — tracks présentes en bibliothèque, artiste et titre identiques entre Last.fm et Navidrome, pourtant en `unmatched` permanent.

## Fix #1 — Cache négatif

`RematchMessageHandler` appelle désormais `LastFmMatchCacheRepository::purgeUnmatchedNegatives(target)` AVANT `resetUnmatchedToPending`. Scope :

- Cible **Navidrome uniquement** (Strawberry n'utilise pas la cache LastFm)
- Joint `scrobble_sync.unmatched ⇒ scrobbles`, normalise en PHP (le UDF `np_normalize` n'est registered que sur la connexion Navidrome)
- Chunke l'IN-list à 400 placeholders pour rester sous le cap SQLite de 999
- **Préserve les positifs** — un rematch ne casse pas les résolutions valides

## Fix #2 — Catégorie MATCHER_GAP

Le diagnoser distingue désormais « track présente, cascade KO » de « track absente ». La cascade matcher cherche sur `media_file.artist` uniquement ; le diagnoser sonde aussi `album_artist` (méthode `findMediaFileByArtistOrAlbumArtistAndTitle`), ce qui révèle :

- Les asymétries `feat.` (artist=« X feat. Y », album_artist=« X »)
- Les cas où la cache négative seule bloque le match
- D'autres trous de cascade futurs sans changer la classification

Badge violet « Présente — cascade KO ». Une fois la PR mergée, ces lignes se résoudront sur le prochain rematch.

## Test plan

- [ ] `composer ci` vert localement (172/172 tests, phpcs clean, phpstan baseline inchangé)
- [ ] Lancer un rematch Navidrome → vérifier que les *Soleil Noir / Jour de Nuit* passent en `matched`
- [ ] Vérifier qu'aucun positif valide n'est purgé (`SELECT COUNT(*) FROM lastfm_match_cache WHERE target_media_file_id IS NOT NULL` avant/après)
- [ ] Visiter `/navidrome/unmatched` post-rematch — les MATCHER_GAP devraient avoir disparu, restent les vrais artiste/track manquants

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_