### PR TITLE
feat(matching): fold album_artist dans le lookup couple primaire

### DIFF
--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2387,7 +2387,9 @@ class NavidromeRepository
      * similar tagging quirk) confuses the cascade.
      *
      * Used by {@see \App\Service\UnmatchedDiagnoser} to surface the
-     * `MATCHER_GAP` category : « track présente, cascade KO ».
+     * `MATCHER_GAP` category, AND by the couple cascade itself (see
+     * {@see findMediaFileByArtistTitle()}) which now folds the
+     * album_artist column into its primary exact lookup.
      */
     public function findMediaFileByArtistOrAlbumArtistAndTitle(string $artist, string $title): ?string
     {
@@ -2397,16 +2399,7 @@ class NavidromeRepository
             return null;
         }
 
-        $id = $this->connection()->fetchOne(
-            'SELECT id FROM media_file
-             WHERE np_normalize(title) = :t
-               AND (np_normalize(artist) = :a OR np_normalize(album_artist) = :a)
-             ORDER BY (np_normalize(artist) = :a) DESC, id ASC
-             LIMIT 1',
-            ['a' => $artistN, 't' => $titleN],
-        );
-
-        return is_string($id) && $id !== '' ? $id : null;
+        return $this->lookupExactArtistOrAlbumArtistTitle($artistN, $titleN);
     }
 
     /**
@@ -2692,7 +2685,10 @@ class NavidromeRepository
             return null;
         }
 
-        $id = $this->lookupExactArtistTitle($artistN, $titleN);
+        // Primary exact step folds the album_artist column in (collabs /
+        // compilations where Last.fm scrobbles the lead artist but the
+        // track row credits a feat. variant). Title stays strict.
+        $id = $this->lookupExactArtistOrAlbumArtistTitle($artistN, $titleN);
         if ($id !== null) {
             return $id;
         }
@@ -2760,6 +2756,36 @@ class NavidromeRepository
                 WHERE np_normalize(artist) = :a
                   AND np_normalize(title) = :t
                 ORDER BY (np_normalize(album_artist) = :a) DESC, id ASC
+                LIMIT 1';
+        $id = $this->connection()->fetchOne($sql, ['a' => $artistNormalized, 't' => $titleNormalized]);
+
+        return is_string($id) && $id !== '' ? $id : null;
+    }
+
+    /**
+     * Like {@see lookupExactArtistTitle()} but the artist may live in
+     * either the `artist` column OR the `album_artist` column. Catches
+     * collabs and compilations where Last.fm scrobbles the lead /
+     * album artist ("Orelsan") while the track row credits a feat.
+     * variant ("Orelsan feat. Skread") but the album is credited to the
+     * lead artist. Title stays strict, so precision is still anchored on
+     * an exact (normalized) title match. Results prefer a hit on the
+     * primary `artist` column when both exist.
+     *
+     * Only used as the PRIMARY exact step — the stripped-form retries
+     * deliberately keep the narrower `artist`-only lookup to avoid
+     * compounding two fuzzy widenings at once.
+     */
+    private function lookupExactArtistOrAlbumArtistTitle(string $artistNormalized, string $titleNormalized): ?string
+    {
+        if ($artistNormalized === '' || $titleNormalized === '') {
+            return null;
+        }
+
+        $sql = 'SELECT id FROM media_file
+                WHERE np_normalize(title) = :t
+                  AND (np_normalize(artist) = :a OR np_normalize(album_artist) = :a)
+                ORDER BY (np_normalize(artist) = :a) DESC, id ASC
                 LIMIT 1';
         $id = $this->connection()->fetchOne($sql, ['a' => $artistNormalized, 't' => $titleNormalized]);
 

--- a/tests/Navidrome/NavidromeCoupleLookupTest.php
+++ b/tests/Navidrome/NavidromeCoupleLookupTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Direct coverage of the couple cascade
+ * ({@see NavidromeRepository::findMediaFileByArtistTitle()}) against a
+ * real SQLite media_file table. Focused on the album_artist widening
+ * (PR B) and on guarding the false-positive boundaries.
+ */
+class NavidromeCoupleLookupTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testExactArtistTitleMatches(): void
+    {
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk'],
+        ]);
+
+        $this->assertSame('mf-1', $repo->findMediaFileByArtistTitle('Daft Punk', 'Get Lucky'));
+    }
+
+    public function testCollabResolvedViaAlbumArtistColumn(): void
+    {
+        // Last.fm scrobbles "Orelsan"; the track is credited to
+        // "Orelsan feat. Skread" but the album_artist is "Orelsan".
+        // The artist-only step misses it — the album_artist widening
+        // catches it.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Ensemble', 'artist' => 'OrelSan feat. Skread', 'album_artist' => 'Orelsan'],
+        ]);
+
+        $this->assertSame('mf-1', $repo->findMediaFileByArtistTitle('Orelsan', 'Ensemble'));
+    }
+
+    public function testPrimaryArtistColumnPreferredOverAlbumArtist(): void
+    {
+        // Two tracks share the title; one matches on artist, the other
+        // only on album_artist. The artist-column hit must win.
+        $repo = $this->seed([
+            ['id' => 'mf-album', 'title' => 'Intro', 'artist' => 'Someone Else', 'album_artist' => 'Dr Dre'],
+            ['id' => 'mf-artist', 'title' => 'Intro', 'artist' => 'Dr Dre', 'album_artist' => 'Dr Dre'],
+        ]);
+
+        $this->assertSame('mf-artist', $repo->findMediaFileByArtistTitle('Dr Dre', 'Intro'));
+    }
+
+    public function testNoMatchWhenNeitherColumnMatches(): void
+    {
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album_artist' => 'Daft Punk'],
+        ]);
+
+        $this->assertNull($repo->findMediaFileByArtistTitle('Justice', 'Get Lucky'));
+    }
+
+    public function testTitleStaysStrictUnderAlbumArtistWidening(): void
+    {
+        // album_artist matches but the title doesn't — must NOT match,
+        // proving the widening is on the artist axis only.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Civilisation', 'artist' => 'Orelsan', 'album_artist' => 'Orelsan'],
+        ]);
+
+        $this->assertNull($repo->findMediaFileByArtistTitle('Orelsan', 'Totally Other Title'));
+    }
+
+    /**
+     * @param list<array{id: string, title: string, artist: string, album_artist?: string}> $tracks
+     */
+    private function seed(array $tracks): NavidromeRepository
+    {
+        $path = sys_get_temp_dir() . '/nd-couple-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        foreach ($tracks as $t) {
+            NavidromeFixtureFactory::insertTrack(
+                $conn,
+                $t['id'],
+                $t['title'],
+                $t['artist'],
+                albumArtist: $t['album_artist'] ?? null,
+            );
+        }
+        $conn->close();
+
+        return new NavidromeRepository($path, 'admin');
+    }
+}


### PR DESCRIPTION
## Résumé (PR B du plan matching)

La cascade couple ne cherchait l'artiste que sur `media_file.artist`. Les **collabs et compilations** où Last.fm scrobble l'artiste lead/album mais où la track est créditée à une variante feat. (`artist="Orelsan feat. Skread"`, `album_artist="Orelsan"`) tombaient en `unmatched` — exactement les cas que le badge **MATCHER_GAP** révélait.

## Changement

Le premier lookup exact élargit l'axe artiste à `(artist OR album_artist)`, **titre toujours strict**, avec un `ORDER BY` qui privilégie un hit sur la colonne `artist` quand les deux existent. Les retries sur formes strippées gardent volontairement le lookup `artist`-only pour ne pas cumuler deux élargissements flous d'un coup.

- `src/Navidrome/NavidromeRepository.php` : `lookupExactArtistOrAlbumArtistTitle()` (core normalisé, partagé avec `findMediaFileByArtistOrAlbumArtistAndTitle` du diagnoser) câblé en étape 1 de `findMediaFileByArtistTitle()`.
- `tests/Navidrome/NavidromeCoupleLookupTest.php` : 5 cas — exact, collab via album_artist, priorité colonne artist, no-match, titre strict sous widening.

## Précision

Le seul faux-positif théorique ajouté : un album dont l'`album_artist` = artiste scrobblé contenant une track au titre exact mais créditée à un autre artiste. En pratique `album_artist` ≠ un artiste réellement scrobblé sauf si c'est bien son album → match correct. Net win sur les MATCHER_GAP.

## Test plan

- [x] `composer ci` vert (177/177 + phpcs clean)
- [ ] Rematch → les MATCHER_GAP collabs/compilations passent en `matched`

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_