### PR TITLE
feat(matching): triplet tolérant aux décorations d'édition d'album

### DIFF
--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2670,11 +2670,47 @@ class NavidromeRepository
             ['a' => $artistN, 't' => $titleN, 'al' => $albumN],
         );
 
-        if (count($rows) !== 1) {
+        if (count($rows) === 1) {
+            return (string) $rows[0]['id'];
+        }
+        if (count($rows) > 1) {
+            // Exact album is ambiguous (same track title on two rows with
+            // the identical normalized album) — bail rather than guess.
             return null;
         }
 
-        return (string) $rows[0]['id'];
+        // No exact album hit. Edition/reissue decorations diverge between
+        // Last.fm and the library more often than not ("Random Access
+        // Memories" vs "Random Access Memories (Deluxe Edition)"). Retry
+        // on the (artist, title) rows, comparing albums with the
+        // decoration suffix stripped on BOTH sides. Disambiguation is
+        // kept strict: only return when exactly one row survives.
+        $strippedAlbumN = self::normalize(self::stripAlbumDecorations($album));
+        if ($strippedAlbumN === '') {
+            return null;
+        }
+
+        $candidates = $this->connection()->fetchAllAssociative(
+            'SELECT id, album FROM media_file
+             WHERE np_normalize(artist) = :a AND np_normalize(title) = :t',
+            ['a' => $artistN, 't' => $titleN],
+        );
+
+        $matchId = null;
+        foreach ($candidates as $row) {
+            $candAlbumN = self::normalize(self::stripAlbumDecorations((string) ($row['album'] ?? '')));
+            if ($candAlbumN !== $strippedAlbumN) {
+                continue;
+            }
+            if ($matchId !== null) {
+                // More than one album collapses to the same stripped form
+                // — ambiguous, don't guess.
+                return null;
+            }
+            $matchId = (string) $row['id'];
+        }
+
+        return $matchId;
     }
 
     public function findMediaFileByArtistTitle(string $artist, string $title): ?string
@@ -2891,6 +2927,11 @@ class NavidromeRepository
     private static function stripVersionMarkers(string $title): string
     {
         return NavidromeStringNormalizer::stripVersionMarkers($title);
+    }
+
+    private static function stripAlbumDecorations(string $album): string
+    {
+        return NavidromeStringNormalizer::stripAlbumDecorations($album);
     }
 
     /**

--- a/src/Navidrome/NavidromeStringNormalizer.php
+++ b/src/Navidrome/NavidromeStringNormalizer.php
@@ -95,6 +95,40 @@ final class NavidromeStringNormalizer
     }
 
     /**
+     * Drop a trailing edition / reissue decoration from a raw album title
+     * — « (Deluxe Edition) », « [Remastered] », « (Bonus Track Edition) »,
+     * « (2011 Remaster) », « - Anniversary Edition », « (Explicit) »…
+     * Symmetric to {@see stripVersionMarkers()} but tuned for album-level
+     * suffixes, so a scrobble album « Random Access Memories » still
+     * matches a library album « Random Access Memories (Deluxe Edition) »
+     * after both are stripped. Only the *delimited* trailing form is
+     * touched — a bare « Deluxe » album name is left intact.
+     */
+    public static function stripAlbumDecorations(string $album): string
+    {
+        $markers = '(?:'
+            . 'deluxe(?:\s+(?:edition|version))?'
+            . '|expanded(?:\s+edition)?'
+            . '|special(?:\s+edition)?'
+            . '|anniversary(?:\s+edition)?'
+            . '|collector\'?s?(?:\s+edition)?'
+            . '|limited(?:\s+edition)?'
+            . '|bonus(?:\s+track)?s?(?:\s+(?:edition|version))?'
+            . '|remastered \d{4}|remaster \d{4}|\d{4} remastered|\d{4} remaster'
+            . '|remastered|remaster'
+            . '|reissue'
+            . '|explicit(?:\s+(?:version|content))?'
+            . '|clean(?:\s+version)?'
+            . ')';
+
+        $stripped = preg_replace('/\s*\(' . $markers . '\)\s*$/iu', '', $album) ?? $album;
+        $stripped = preg_replace('/\s*\[' . $markers . '\]\s*$/iu', '', $stripped) ?? $stripped;
+        $stripped = preg_replace('/\s+[\-\x{2013}\x{2014}]\s+' . $markers . '\s*$/iu', '', $stripped) ?? $stripped;
+
+        return trim($stripped);
+    }
+
+    /**
      * Drop a parenthesized/bracketed featuring-with suffix from a title.
      * Only the delimited form — never « X feat. Y » without parens, too
      * risky on real titles.

--- a/tests/Navidrome/NavidromeCoupleLookupTest.php
+++ b/tests/Navidrome/NavidromeCoupleLookupTest.php
@@ -81,8 +81,72 @@ class NavidromeCoupleLookupTest extends TestCase
         $this->assertNull($repo->findMediaFileByArtistTitle('Orelsan', 'Totally Other Title'));
     }
 
+    public function testTripletExactAlbumMatches(): void
+    {
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories'],
+        ]);
+
+        $this->assertSame(
+            'mf-1',
+            $repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'Get Lucky', 'Random Access Memories'),
+        );
+    }
+
+    public function testTripletFallsBackOnStrippedAlbumDecoration(): void
+    {
+        // Library album carries "(Deluxe Edition)"; Last.fm scrobble has
+        // the plain name. Exact triplet misses, stripped retry catches it.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories (Deluxe Edition)'],
+        ]);
+
+        $this->assertSame(
+            'mf-1',
+            $repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'Get Lucky', 'Random Access Memories'),
+        );
+    }
+
+    public function testTripletStrippedFallbackIsSymmetric(): void
+    {
+        // Reverse: library plain, scrobble decorated.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories'],
+        ]);
+
+        $this->assertSame(
+            'mf-1',
+            $repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'Get Lucky', 'Random Access Memories [Remastered]'),
+        );
+    }
+
+    public function testTripletStrippedFallbackBailsWhenAmbiguous(): void
+    {
+        // Two different albums collapse to the same stripped form — don't
+        // guess which pressing the user played.
+        $repo = $this->seed([
+            ['id' => 'mf-a', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories (Deluxe Edition)'],
+            ['id' => 'mf-b', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories [Remastered]'],
+        ]);
+
+        $this->assertNull(
+            $repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'Get Lucky', 'Random Access Memories'),
+        );
+    }
+
+    public function testTripletNoMatchWhenAlbumGenuinelyDiffers(): void
+    {
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk', 'album' => 'Random Access Memories'],
+        ]);
+
+        $this->assertNull(
+            $repo->findMediaFileByArtistTitleAlbum('Daft Punk', 'Get Lucky', 'Discovery'),
+        );
+    }
+
     /**
-     * @param list<array{id: string, title: string, artist: string, album_artist?: string}> $tracks
+     * @param list<array{id: string, title: string, artist: string, album_artist?: string, album?: string}> $tracks
      */
     private function seed(array $tracks): NavidromeRepository
     {
@@ -95,6 +159,7 @@ class NavidromeCoupleLookupTest extends TestCase
                 $t['id'],
                 $t['title'],
                 $t['artist'],
+                album: $t['album'] ?? 'Album',
                 albumArtist: $t['album_artist'] ?? null,
             );
         }

--- a/tests/Navidrome/NavidromeStringNormalizerTest.php
+++ b/tests/Navidrome/NavidromeStringNormalizerTest.php
@@ -66,6 +66,25 @@ class NavidromeStringNormalizerTest extends TestCase
         $this->assertSame('Around the World (Daft Punk Remix)', NavidromeStringNormalizer::stripVersionMarkers('Around the World (Daft Punk Remix)'));
     }
 
+    public function testStripAlbumDecorationsRemovesEditionSuffixes(): void
+    {
+        $this->assertSame('Random Access Memories', NavidromeStringNormalizer::stripAlbumDecorations('Random Access Memories (Deluxe Edition)'));
+        $this->assertSame('Discovery', NavidromeStringNormalizer::stripAlbumDecorations('Discovery [Remastered]'));
+        $this->assertSame('Nevermind', NavidromeStringNormalizer::stripAlbumDecorations('Nevermind (Bonus Track Edition)'));
+        $this->assertSame('OK Computer', NavidromeStringNormalizer::stripAlbumDecorations('OK Computer - Anniversary Edition'));
+        $this->assertSame('The Eminem Show', NavidromeStringNormalizer::stripAlbumDecorations('The Eminem Show (Explicit)'));
+        $this->assertSame('Thriller', NavidromeStringNormalizer::stripAlbumDecorations('Thriller (2001 Remaster)'));
+    }
+
+    public function testStripAlbumDecorationsLeavesBareNamesIntact(): void
+    {
+        // No delimited suffix → unchanged. A legit album literally named
+        // "Deluxe" must survive.
+        $this->assertSame('Deluxe', NavidromeStringNormalizer::stripAlbumDecorations('Deluxe'));
+        $this->assertSame('Special', NavidromeStringNormalizer::stripAlbumDecorations('Special'));
+        $this->assertSame('Remastered Hits', NavidromeStringNormalizer::stripAlbumDecorations('Remastered Hits'));
+    }
+
     public function testStripFeaturingFromTitleOnlyDelimited(): void
     {
         $this->assertSame('Crazy in Love', NavidromeStringNormalizer::stripFeaturingFromTitle('Crazy in Love (feat. Jay-Z)'));


### PR DESCRIPTION
## Résumé (PR C du plan matching)

Le triplet exigeait l'album **exact** normalisé. « Random Access Memories » (Last.fm) ≠ « Random Access Memories (Deluxe Edition) » (bibliothèque) → fall-through vers le couple seul, parfois ambigu sur les rééditions.

## Changement

Quand le triplet exact échoue, on retente sur les lignes `(artiste, titre)` en comparant les albums **décoration-strippée des DEUX côtés** : `(Deluxe Edition)`, `[Remastered]`, `(Bonus Track Edition)`, `- Anniversary Edition`, `(Explicit)`, `(2011 Remaster)`… Symétrique à `stripVersionMarkers` côté titre.

Désambiguïsation stricte : retourne uniquement si **exactement une** ligne survit, sinon `null` — pas de devinette sur le pressing joué.

- `src/Navidrome/NavidromeStringNormalizer.php` : `stripAlbumDecorations()`, ne touche que la forme suffixe **délimitée** (un album littéralement nommé « Deluxe » reste intact).
- `src/Navidrome/NavidromeRepository.php` : fallback strippé dans `findMediaFileByArtistTitleAlbum()`.
- `tests/` : 6 cas normalizer + 5 cas triplet (exact, fallback deluxe, symétrie, ambigu→null, album distinct→null).

## Test plan

- [x] `composer ci` vert (184/184 + phpcs clean)
- [ ] Rematch → les tracks de rééditions/deluxe se matchent enfin via le triplet plutôt que de retomber sur le couple

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_