### PR TITLE
feat(matching): featuring inverse + séparateurs vs/x dans le lead-artist

### DIFF
--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2774,10 +2774,24 @@ class NavidromeRepository
             }
         }
 
+        // Inverse asymmetric featuring : Last.fm scrobbles a CLEAN couple
+        // ("Jay-Z" / "Crazy in Love") with NO featuring marker on either
+        // field, but the library credits a feat. variant in the artist
+        // column ("Jay-Z feat. Beyoncé"). The forward case above is gated
+        // on a featuring marker in the Last.fm *title*; this is the mirror
+        // when neither field carries one. Title stays strict (exact), so a
+        // hit is the same song under a longer artist credit.
+        if (!$titleHadFeaturing) {
+            $id = $this->lookupArtistPrefixFeaturingTitle($artistN, $titleN);
+            if ($id !== null) {
+                return $id;
+            }
+        }
+
         // Last-resort: split lead artist on multi-artist separators
-        // ("&", " - ", " and ", " et ", ","). Conservative: only on the
-        // strict (artist, title) couple AND require album_artist to match
-        // the stripped artist for confidence.
+        // ("&", " - ", " and ", " et ", ",", " vs ", " vs. ", " x ").
+        // Conservative: only on the strict (artist, title) couple AND
+        // require album_artist to match the stripped artist for confidence.
         $leadOnlyN = self::normalize(self::stripLeadArtist($artist));
         if ($leadOnlyN !== '' && $leadOnlyN !== $artistN && $leadOnlyN !== $leadArtistN) {
             return $this->lookupExactArtistTitleRequiringAlbumArtist($leadOnlyN, $titleN);

--- a/src/Navidrome/NavidromeStringNormalizer.php
+++ b/src/Navidrome/NavidromeStringNormalizer.php
@@ -169,13 +169,17 @@ final class NavidromeStringNormalizer
     }
 
     /**
-     * Drop trailing co-artists separated by `,`, ` - `, `&`, ` and `, ` et `
-     * to keep only the lead artist (« Médine & Rounhaa » → « Médine »).
-     * Last-resort fallback when the regular cascade fails.
+     * Drop trailing co-artists separated by `,`, ` - `, `&`, ` and `, ` et `,
+     * ` vs `, ` vs. `, ` x ` to keep only the lead artist
+     * (« Médine & Rounhaa » → « Médine », « Diplo x M.I.A. » → « Diplo »).
+     * The ` vs `/` x ` separators cover EDM / hip-hop collab credits.
+     * Surrounding whitespace is required on the word separators so a name
+     * like « Malcolm X » or « Charli XCX » is never split. Last-resort
+     * fallback when the regular cascade fails.
      */
     public static function stripLeadArtist(string $artist): string
     {
-        if (preg_match('/^(.*?)(?:\s*,\s*|\s+-\s+|\s*&\s*|\s+(?:and|et)\s+)/iu', $artist, $m)) {
+        if (preg_match('/^(.*?)(?:\s*,\s*|\s+-\s+|\s*&\s*|\s+(?:and|et|vs\.?|x)\s+)/iu', $artist, $m)) {
             $lead = trim($m[1]);
             if ($lead !== '' && $lead !== $artist) {
                 return $lead;

--- a/tests/Navidrome/NavidromeCoupleLookupTest.php
+++ b/tests/Navidrome/NavidromeCoupleLookupTest.php
@@ -145,6 +145,40 @@ class NavidromeCoupleLookupTest extends TestCase
         );
     }
 
+    public function testInverseFeaturingCleanScrobbleMatchesFeatVariant(): void
+    {
+        // Last.fm scrobbles a clean couple; the library credits a feat.
+        // variant in the artist column. No featuring marker on either
+        // Last.fm field — the inverse asymmetric step must catch it.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Crazy in Love', 'artist' => 'Beyoncé feat. Jay-Z'],
+        ]);
+
+        $this->assertSame('mf-1', $repo->findMediaFileByArtistTitle('Beyoncé', 'Crazy in Love'));
+    }
+
+    public function testInverseFeaturingDoesNotMatchDifferentTitle(): void
+    {
+        // Title stays strict — a feat. artist prefix is not enough on its own.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Crazy in Love', 'artist' => 'Beyoncé feat. Jay-Z'],
+        ]);
+
+        $this->assertNull($repo->findMediaFileByArtistTitle('Beyoncé', 'Halo'));
+    }
+
+    public function testLeadArtistSplitOnXSeparatorRequiresAlbumArtist(): void
+    {
+        // "Diplo x M.I.A." scrobble; library track credited to "Diplo"
+        // with album_artist "Diplo" → the conservative lead-split path
+        // (requires album_artist) resolves it.
+        $repo = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Paper Planes', 'artist' => 'Diplo', 'album_artist' => 'Diplo'],
+        ]);
+
+        $this->assertSame('mf-1', $repo->findMediaFileByArtistTitle('Diplo x M.I.A.', 'Paper Planes'));
+    }
+
     /**
      * @param list<array{id: string, title: string, artist: string, album_artist?: string, album?: string}> $tracks
      */

--- a/tests/Navidrome/NavidromeStringNormalizerTest.php
+++ b/tests/Navidrome/NavidromeStringNormalizerTest.php
@@ -124,6 +124,17 @@ class NavidromeStringNormalizerTest extends TestCase
         $this->assertSame('Lone Artist', NavidromeStringNormalizer::stripLeadArtist('Lone Artist'));
     }
 
+    public function testStripLeadArtistCoversVsAndXSeparators(): void
+    {
+        $this->assertSame('Diplo', NavidromeStringNormalizer::stripLeadArtist('Diplo x M.I.A.'));
+        $this->assertSame('Eminem', NavidromeStringNormalizer::stripLeadArtist('Eminem vs. D12'));
+        $this->assertSame('Blur', NavidromeStringNormalizer::stripLeadArtist('Blur vs Oasis'));
+        // The single-letter `x` separator must not eat names where x is
+        // part of the word, not a delimiter surrounded by spaces.
+        $this->assertSame('Malcolm X', NavidromeStringNormalizer::stripLeadArtist('Malcolm X'));
+        $this->assertSame('Charli XCX', NavidromeStringNormalizer::stripLeadArtist('Charli XCX'));
+    }
+
     public function testTitleHasFeaturingMarkerCoversClosedAndTruncatedForms(): void
     {
         $this->assertTrue(NavidromeStringNormalizer::titleHasFeaturingMarker('Crazy in Love (feat. Jay-Z)'));


### PR DESCRIPTION
## Résumé (PR D du plan matching)

Deux trous symétriques au cas featuring déjà couvert.

### 1. Featuring inverse

Last.fm scrobble un couple **propre** (« Beyoncé » / « Crazy in Love », aucun marqueur feat.) mais la bibliothèque crédite une variante feat. dans la colonne `artist` (« Beyoncé feat. Jay-Z »). Le cas *forward* existant est gated sur un marqueur feat. dans le **titre** Last.fm ; ici aucun champ n'en porte. On réutilise `lookupArtistPrefixFeaturingTitle` sur le titre **exact** (titre strict → même morceau sous un crédit artiste plus long).

### 2. Séparateurs lead-artist élargis

`vs`, `vs.`, `x` ajoutés (collabs EDM / hip-hop : « Diplo x M.I.A. »). Espaces requis autour des séparateurs-mots → **« Malcolm X » et « Charli XCX » jamais coupés**. Le chemin lead-split reste conservateur (exige `album_artist`).

## Fichiers

- `src/Navidrome/NavidromeRepository.php` : étape featuring inverse avant le last-resort lead-split.
- `src/Navidrome/NavidromeStringNormalizer.php` : `stripLeadArtist` élargi.
- `tests/` : 5 cas (vs/x + garde Malcolm X/Charli XCX, featuring inverse match + titre strict, lead-split x avec album_artist).

## Test plan

- [x] `composer ci` vert (188/188 + phpcs clean)
- [ ] Rematch → collabs feat. inverses et « X vs Y » / « X x Y » se résolvent

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_