### PR TITLE
feat(matching): track.getCorrection en sonde légère avant track.getInfo

### DIFF
--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -207,6 +207,23 @@ class LastFmClient
         return $this->lookup('track.getInfo', $apiKey, $artist, $title, 'track');
     }
 
+    /**
+     * Lighter sibling of {@see trackGetInfo()} : `track.getCorrection`
+     * returns only Last.fm's autocorrected spelling of the (artist,
+     * title) pair — no listener stats, no wiki, no tags — so it's the
+     * cheaper first probe when all the matcher needs is the canonical
+     * spelling. The MBID is usually absent from this endpoint, so callers
+     * that need it must still fall back to {@see trackGetInfo()}.
+     *
+     * Response shape: `corrections.correction.track.{name, artist.name,
+     * mbid?}`. The `lookup()` helper walks a dotted body key, so we point
+     * it at that nested node.
+     */
+    public function trackGetCorrection(string $apiKey, string $artist, string $title): LastFmTrackInfo
+    {
+        return $this->lookup('track.getCorrection', $apiKey, $artist, $title, 'corrections.correction.track');
+    }
+
     /** @return list<array{name: string, mbid: ?string, match: float, url: string}> */
     public function artistGetSimilar(string $apiKey, string $artist, int $limit = 10): array
     {

--- a/src/LastFm/ScrobbleMatcher.php
+++ b/src/LastFm/ScrobbleMatcher.php
@@ -24,9 +24,11 @@ use App\Repository\LastFmMatchCacheRepository;
  *   4. MBID                     → STATUS_MATCHED
  *   5. Triplet (artist, title, album) when album is non-empty → STATUS_MATCHED
  *   6. Couple (artist, title) with strip-feat / strip-version-markers / etc.
- *   7. Last.fm `track.getInfo`  → recovers a missing MBID or applies the
- *                                 « autocorrect » spelling (re-runs steps
- *                                 4-6 against the corrected names)
+ *   7. Last.fm correction      → `track.getCorrection` first (light:
+ *                                 autocorrect spelling only), then
+ *                                 `track.getInfo` as a fallback for the
+ *                                 MBID path. Re-runs steps 4-6 against the
+ *                                 corrected names.
  *   8. Fuzzy Levenshtein (opt-in via fuzzyMaxDistance > 0)
  *   → STATUS_UNMATCHED if everything fails. Both successes and failures are
  *   memoized in the cache so subsequent runs short-circuit at step 3.
@@ -130,21 +132,40 @@ class ScrobbleMatcher
             return $result;
         }
 
-        // Last.fm `track.getInfo` step : recovers scrobbles with no MBID
-        // (or a wrong text spelling) by asking Last.fm for the canonical
-        // form. Wrapped in an opt-in guard so test harnesses that don't
-        // configure the client don't make HTTP calls. Negative results
-        // get cached (in the caller) so we don't re-query on every
+        // Last.fm correction step : recovers scrobbles with a wrong text
+        // spelling (or a missing/wrong MBID) by asking Last.fm for the
+        // canonical form. Wrapped in an opt-in guard so test harnesses
+        // that don't configure the client don't make HTTP calls. Negative
+        // results get cached (in the caller) so we don't re-query on every
         // rematch run — that's what makes #17 scale beyond the rate limit.
         if ($this->lastFmClient !== null && $this->lastFmApiKey !== null && $this->lastFmApiKey !== '') {
+            // (1) Light first probe : `track.getCorrection` returns ONLY
+            //     the autocorrected spelling — a much smaller payload than
+            //     `track.getInfo`. Most step-7 recoveries are spelling
+            //     corrections, so this resolves the common case without
+            //     ever paying for the heavy call.
+            $correction = $this->lastFmClient->trackGetCorrection(
+                $this->lastFmApiKey,
+                $scrobble->artist,
+                $scrobble->title,
+            );
+            if ($correction->hasCorrection()) {
+                $result = $this->runCorrectedDbCascade($scrobble, $correction);
+                if ($result[0] !== null) {
+                    return $result;
+                }
+            }
+
+            // (2) Fallback : `track.getInfo` for the MBID path that
+            //     getCorrection cannot provide (Last.fm sometimes maps the
+            //     scrobble's recording-MBID to the canonical track-MBID),
+            //     plus its own correction in the rarer case getInfo's
+            //     autocorrect succeeds where getCorrection returned nothing.
             $info = $this->lastFmClient->trackGetInfo(
                 $this->lastFmApiKey,
                 $scrobble->artist,
                 $scrobble->title,
             );
-            // (a) Try the official MBID Last.fm gave us, even when the
-            //     scrobble already had one — Last.fm sometimes maps the
-            //     scrobble's recording-MBID to the canonical track-MBID.
             if ($info->hasMbid()) {
                 /** @var string $mbid (hasMbid() guards against null/empty) */
                 $mbid = $info->mbid;
@@ -153,22 +174,10 @@ class ScrobbleMatcher
                     return [$mfid, LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION];
                 }
             }
-            // (b) Try the autocorrected spelling. We re-run the local
-            //     DB cascade — but NOT the getInfo step itself, which
-            //     would loop. The artist alias was already applied
-            //     upstream, so the corrected names go straight to MBID
-            //     / triplet / couple lookups.
             if ($info->hasCorrection()) {
-                $corrected = new LastFmScrobble(
-                    artist: $info->correctedArtist ?? $scrobble->artist,
-                    title: $info->correctedTitle ?? $scrobble->title,
-                    album: $scrobble->album,
-                    mbid: $info->mbid ?? $scrobble->mbid,
-                    playedAt: $scrobble->playedAt,
-                );
-                $result = $this->runDbCascade($corrected);
+                $result = $this->runCorrectedDbCascade($scrobble, $info);
                 if ($result[0] !== null) {
-                    return [$result[0], LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION];
+                    return $result;
                 }
             }
         }
@@ -189,8 +198,36 @@ class ScrobbleMatcher
     }
 
     /**
+     * Re-run the local DB cascade against a scrobble rewritten with
+     * Last.fm's corrected spelling (and MBID when present). We re-run the
+     * DB-only sub-cascade — never the correction step itself, which would
+     * loop. The artist alias was already applied upstream, so the
+     * corrected names go straight to MBID / triplet / couple lookups. On a
+     * hit the strategy is tagged as a Last.fm correction regardless of
+     * which sub-step matched.
+     *
+     * @return array{0: ?string, 1: ?string}
+     */
+    private function runCorrectedDbCascade(LastFmScrobble $scrobble, LastFmTrackInfo $info): array
+    {
+        $corrected = new LastFmScrobble(
+            artist: $info->correctedArtist ?? $scrobble->artist,
+            title: $info->correctedTitle ?? $scrobble->title,
+            album: $scrobble->album,
+            mbid: $info->mbid ?? $scrobble->mbid,
+            playedAt: $scrobble->playedAt,
+        );
+        $result = $this->runDbCascade($corrected);
+        if ($result[0] !== null) {
+            return [$result[0], LastFmMatchCacheEntry::STRATEGY_LASTFM_CORRECTION];
+        }
+
+        return [null, null];
+    }
+
+    /**
      * Local-only sub-cascade : MBID → triplet → couple. Used both by the
-     * primary cascade and by the `track.getInfo` step (re-running on the
+     * primary cascade and by the correction step (re-running on the
      * autocorrected scrobble).
      *
      * @return array{0: ?string, 1: ?string}

--- a/tests/LastFm/ScrobbleMatcherCorrectionTest.php
+++ b/tests/LastFm/ScrobbleMatcherCorrectionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Tests\LastFm;
+
+use App\LastFm\LastFmClient;
+use App\LastFm\LastFmScrobble;
+use App\LastFm\LastFmTrackInfo;
+use App\LastFm\MatchResult;
+use App\LastFm\ScrobbleMatcher;
+use App\Navidrome\NavidromeRepository;
+use App\Tests\Navidrome\NavidromeFixtureFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the step-7 lightening (PR F): `track.getCorrection` is tried
+ * first and, when it resolves the match, `track.getInfo` is never called.
+ * getInfo stays as the MBID fallback when the correction doesn't resolve.
+ */
+class ScrobbleMatcherCorrectionTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testGetCorrectionResolvesWithoutCallingGetInfo(): void
+    {
+        // Library owns "Daft Punk / Get Lucky"; the scrobble is misspelled
+        // "Daft Pnk / Get Lucky". getCorrection fixes the artist.
+        $navidrome = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk'],
+        ]);
+
+        $client = $this->createMock(LastFmClient::class);
+        $client->expects($this->once())
+            ->method('trackGetCorrection')
+            ->willReturn(new LastFmTrackInfo(mbid: null, correctedArtist: 'Daft Punk', correctedTitle: null));
+        $client->expects($this->never())->method('trackGetInfo');
+
+        $matcher = new ScrobbleMatcher(
+            navidrome: $navidrome,
+            lastFmClient: $client,
+            lastFmApiKey: 'k',
+        );
+
+        $result = $matcher->match($this->scrobble('Daft Pnk', 'Get Lucky'));
+
+        $this->assertSame(MatchResult::STATUS_MATCHED, $result->status);
+        $this->assertSame('mf-1', $result->mediaFileId);
+    }
+
+    public function testFallsBackToGetInfoMbidWhenCorrectionDoesNotResolve(): void
+    {
+        // getCorrection returns nothing useful; getInfo supplies an MBID
+        // that the library owns.
+        $navidrome = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Some Track', 'artist' => 'Some Artist', 'mbz_track_id' => 'mbid-xyz'],
+        ]);
+
+        $client = $this->createMock(LastFmClient::class);
+        $client->expects($this->once())
+            ->method('trackGetCorrection')
+            ->willReturn(LastFmTrackInfo::empty());
+        $client->expects($this->once())
+            ->method('trackGetInfo')
+            ->willReturn(new LastFmTrackInfo(mbid: 'mbid-xyz', correctedArtist: null, correctedTitle: null));
+
+        $matcher = new ScrobbleMatcher(
+            navidrome: $navidrome,
+            lastFmClient: $client,
+            lastFmApiKey: 'k',
+        );
+
+        $result = $matcher->match($this->scrobble('Wrong Name', 'Other Title'));
+
+        $this->assertSame(MatchResult::STATUS_MATCHED, $result->status);
+        $this->assertSame('mf-1', $result->mediaFileId);
+    }
+
+    public function testUnmatchedCallsBothEndpointsThenGivesUp(): void
+    {
+        $navidrome = $this->seed([
+            ['id' => 'mf-1', 'title' => 'Get Lucky', 'artist' => 'Daft Punk'],
+        ]);
+
+        $client = $this->createMock(LastFmClient::class);
+        $client->expects($this->once())->method('trackGetCorrection')->willReturn(LastFmTrackInfo::empty());
+        $client->expects($this->once())->method('trackGetInfo')->willReturn(LastFmTrackInfo::empty());
+
+        $matcher = new ScrobbleMatcher(
+            navidrome: $navidrome,
+            lastFmClient: $client,
+            lastFmApiKey: 'k',
+        );
+
+        $result = $matcher->match($this->scrobble('Nobody', 'Nothing'));
+
+        $this->assertSame(MatchResult::STATUS_UNMATCHED, $result->status);
+    }
+
+    private function scrobble(string $artist, string $title): LastFmScrobble
+    {
+        return new LastFmScrobble(
+            artist: $artist,
+            title: $title,
+            album: '',
+            mbid: null,
+            playedAt: new \DateTimeImmutable('2024-01-01T00:00:00Z'),
+        );
+    }
+
+    /**
+     * @param list<array{id: string, title: string, artist: string, mbz_track_id?: string}> $tracks
+     */
+    private function seed(array $tracks): NavidromeRepository
+    {
+        $path = sys_get_temp_dir() . '/nd-matcher-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        foreach ($tracks as $t) {
+            NavidromeFixtureFactory::insertTrack(
+                $conn,
+                $t['id'],
+                $t['title'],
+                $t['artist'],
+                mbzTrackId: $t['mbz_track_id'] ?? null,
+            );
+        }
+        $conn->close();
+
+        return new NavidromeRepository($path, 'admin');
+    }
+}


### PR DESCRIPTION
## Résumé (PR F du plan matching)

L'étape 7 appelait systématiquement `track.getInfo` (payload lourd : stats d'écoute, wiki, tags) juste pour récupérer l'autocorrect du spelling. Or la plupart des récupérations de l'étape 7 sont des **corrections de spelling**, pas des recouvrements de MBID.

## Changement

On sonde désormais `track.getCorrection` d'abord (payload minimal : uniquement l'orthographe corrigée). Si la correction résout le match via la cascade DB locale, `track.getInfo` **n'est jamais appelé** — économie de l'appel lourd sur le cas commun. `getInfo` reste en fallback pour :
- le chemin **MBID** (que getCorrection ne fournit pas)
- le cas rare où son autocorrect réussit là où getCorrection n'a rien renvoyé

- `src/LastFm/LastFmClient.php` : `trackGetCorrection()` réutilise `lookup()` avec la body-key imbriquée `corrections.correction.track`.
- `src/LastFm/ScrobbleMatcher.php` : étape 7 réordonnée (getCorrection → getInfo), helper `runCorrectedDbCascade` extrait pour partager la ré-exécution de la cascade entre les deux sources.
- `tests/LastFm/ScrobbleMatcherCorrectionTest.php` : 3 cas — getCorrection résout sans getInfo, fallback MBID via getInfo, unmatched appelle les deux puis abandonne.

## Test plan

- [x] `composer ci` vert (191/191 + phpcs clean)
- [ ] Observer en prod : sur un rematch, le volume d'appels `track.getInfo` doit chuter (les corrections passent par le endpoint léger)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_