### PR TITLE
feat(unmatched): bouton « Suggérer des alias » MusicBrainz async

### DIFF
--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -16,3 +16,4 @@ framework:
             'App\Message\SyncNavidromeMessage': async
             'App\Message\SyncStrawberryMessage': async
             'App\Message\RematchMessage': async
+            'App\Message\SuggestAliasesMusicBrainzMessage': async

--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -4,6 +4,7 @@ namespace App\Controller;
 
 use App\Entity\ScrobbleSync;
 use App\Message\RematchMessage;
+use App\Message\SuggestAliasesMusicBrainzMessage;
 use App\Message\SyncNavidromeMessage;
 use App\Repository\ScrobbleSyncRepository;
 use App\Service\UnmatchedDiagnoser;
@@ -72,6 +73,31 @@ class NavidromeSyncController extends AbstractController
         ));
 
         $this->addFlash('success', 'Rematch Navidrome lancé en arrière-plan.');
+        return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/navidrome/suggest-aliases', name: 'app_navidrome_suggest_aliases', methods: ['POST'])]
+    public function suggestAliases(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('navidrome_suggest_aliases', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        // Default floor of 3 unmatched scrobbles per artist: only spend
+        // (rate-limited) MusicBrainz calls on artists that actually move
+        // the unmatched needle, per the issue's ≥3 threshold.
+        $bus->dispatch(new SuggestAliasesMusicBrainzMessage(
+            target: ScrobbleSync::TARGET_NAVIDROME,
+            dryRun: (bool) $request->request->get('dry_run'),
+            limit: max(0, (int) $request->request->get('limit', 0)),
+            minPlays: max(1, (int) $request->request->get('min_plays', 3)),
+        ));
+
+        $this->addFlash(
+            'success',
+            'Suggestion d’alias MusicBrainz lancée en arrière-plan (throttle ~1 req/s). '
+            . 'Les alias uniques haute-confiance sont appliqués automatiquement ; relancez un rematch ensuite.',
+        );
         return $this->redirectToRoute('app_history');
     }
 

--- a/src/Message/SuggestAliasesMusicBrainzMessage.php
+++ b/src/Message/SuggestAliasesMusicBrainzMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Async request to query MusicBrainz for artist aliases bridging unmatched
+ * scrobbles to library artists. Handled out-of-band by the Messenger
+ * worker because MusicBrainz rate-limits at ~1 req/s — running it inline
+ * in the web request would block for seconds-to-minutes.
+ *
+ * Mirrors the `app:aliases:musicbrainz` CLI in non-interactive mode:
+ * unique-library-match aliases are applied automatically, ambiguous ones
+ * are skipped. `minPlays` filters out long-tail artists so we only spend
+ * MB calls on the source artists that actually move the unmatched needle.
+ */
+final class SuggestAliasesMusicBrainzMessage
+{
+    public function __construct(
+        public readonly string $target,
+        public readonly bool $dryRun = false,
+        public readonly int $limit = 0,
+        public readonly int $minPlays = 0,
+    ) {
+    }
+}

--- a/src/MessageHandler/SuggestAliasesMusicBrainzMessageHandler.php
+++ b/src/MessageHandler/SuggestAliasesMusicBrainzMessageHandler.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\SuggestAliasesMusicBrainzMessage;
+use App\Service\MusicBrainzAliasReport;
+use App\Service\MusicBrainzAliasSuggester;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Worker-side handler for {@see SuggestAliasesMusicBrainzMessage}. Runs the
+ * same non-interactive flow as the `app:aliases:musicbrainz` CLI: it
+ * throttles MusicBrainz requests (~1 req/s) via the suggester's
+ * `beforeQuery` hook, applies unique-library-match aliases, skips
+ * ambiguous ones, and records a RunHistory entry so the result shows up
+ * on the history page — exactly like Sync / Rematch jobs.
+ */
+#[AsMessageHandler]
+class SuggestAliasesMusicBrainzMessageHandler
+{
+    /** MB asks 1 req/s per UA. 1100 ms keeps a small safety margin. */
+    private const RATE_LIMIT_MS = 1100;
+
+    public function __construct(
+        private readonly MusicBrainzAliasSuggester $suggester,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function __invoke(SuggestAliasesMusicBrainzMessage $message): void
+    {
+        $beforeQuery = static function (string $artist): void {
+            usleep(self::RATE_LIMIT_MS * 1000);
+        };
+
+        $label = sprintf(
+            'MusicBrainz alias suggest [%s%s]',
+            $message->target,
+            $message->dryRun ? ' dry-run' : '',
+        );
+
+        $this->recorder->record(
+            type: RunHistory::TYPE_NAVIDROME_ALIAS_MUSICBRAINZ,
+            reference: $message->target,
+            label: $label,
+            action: fn (): MusicBrainzAliasReport => $this->suggester->suggest(
+                target: $message->target,
+                dryRun: $message->dryRun,
+                limit: $message->limit,
+                beforeQuery: $beforeQuery,
+                confirm: null,
+                minPlays: $message->minPlays,
+            ),
+            extractMetrics: static fn (MusicBrainzAliasReport $r): array => [
+                'queried' => $r->artistsQueried,
+                'created' => $r->aliasesCreated,
+                'ambiguous' => $r->ambiguous,
+                'no_match' => $r->noMatch,
+                'mb_errors' => $r->mbErrors,
+                'plays_covered' => $r->playsCovered,
+            ],
+        );
+    }
+}

--- a/src/Service/MusicBrainzAliasSuggester.php
+++ b/src/Service/MusicBrainzAliasSuggester.php
@@ -71,6 +71,7 @@ class MusicBrainzAliasSuggester
         int $limit,
         ?callable $beforeQuery = null,
         ?callable $confirm = null,
+        int $minPlays = 0,
     ): MusicBrainzAliasReport {
         $report = new MusicBrainzAliasReport();
         $report->dryRun = $dryRun;
@@ -92,6 +93,14 @@ class MusicBrainzAliasSuggester
 
             $source = (string) $row['artist'];
             $plays = (int) $row['plays'];
+
+            // `unmatchedArtistsWithPlays` is ordered by descending plays, so
+            // once we drop below the floor every remaining artist is too —
+            // stop scanning rather than spending MB calls on the long tail.
+            if ($minPlays > 0 && $plays < $minPlays) {
+                break;
+            }
+
             $sourceNorm = NavidromeRepository::normalize($source);
 
             $report->artistsConsidered++;

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -7,16 +7,27 @@
             <h1 class="text-2xl font-semibold mt-1">Scrobbles non matchés — Navidrome</h1>
             <p class="text-sm text-slate-500">{{ total }} groupe{{ total != 1 ? 's' : '' }} (artiste, titre, album)</p>
         </div>
-        <form method="post" action="{{ path('app_navidrome_rematch') }}" class="flex gap-2 items-center">
-            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_rematch') }}">
-            <label class="flex items-center gap-1 text-xs text-slate-500">
-                <input type="checkbox" name="auto_stop" value="1"> auto-stop
-            </label>
-            <button type="submit"
-                    class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
-                ↺ Rematcher tous
-            </button>
-        </form>
+        <div class="flex gap-2 items-center flex-wrap">
+            <form method="post" action="{{ path('app_navidrome_suggest_aliases') }}" class="flex gap-2 items-center"
+                  onsubmit="return confirm('Interroger MusicBrainz pour les artistes ayant ≥3 scrobbles non matchés ? Throttle ~1 req/s, les alias uniques sont appliqués automatiquement.');">
+                <input type="hidden" name="_token" value="{{ csrf_token('navidrome_suggest_aliases') }}">
+                <button type="submit"
+                        class="bg-emerald-700 hover:bg-emerald-800 text-white px-4 py-1.5 rounded-sm text-sm font-medium"
+                        title="Interroge MusicBrainz et crée les alias artiste uniques haute-confiance (≥3 scrobbles)">
+                    🎯 Suggérer des alias
+                </button>
+            </form>
+            <form method="post" action="{{ path('app_navidrome_rematch') }}" class="flex gap-2 items-center">
+                <input type="hidden" name="_token" value="{{ csrf_token('navidrome_rematch') }}">
+                <label class="flex items-center gap-1 text-xs text-slate-500">
+                    <input type="checkbox" name="auto_stop" value="1"> auto-stop
+                </label>
+                <button type="submit"
+                        class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                    ↺ Rematcher tous
+                </button>
+            </form>
+        </div>
     </div>
 
     <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap gap-3 items-end">

--- a/tests/Service/MusicBrainzAliasSuggesterTest.php
+++ b/tests/Service/MusicBrainzAliasSuggesterTest.php
@@ -204,6 +204,29 @@ class MusicBrainzAliasSuggesterTest extends TestCase
         $this->assertSame(1, $report->noMatch);
     }
 
+    public function testMinPlaysStopsScanningBelowTheFloor(): void
+    {
+        // Rows are ordered by descending plays. With minPlays=3 the second
+        // artist (1 play) is below the floor → the loop breaks and never
+        // queries MB for it, so it's never even counted as considered.
+        $suggester = $this->makeSuggester(
+            mbResponse: [
+                new MusicBrainzArtistCandidate('mbid-beatles', 'The Beatles', 100, ['Beatles, The']),
+            ],
+            unmatched: [
+                ['artist' => 'Beatles, The', 'plays' => 9],
+                ['artist' => 'Long Tail Act', 'plays' => 1],
+            ],
+            libArtists: ['The Beatles'],
+        );
+
+        $report = $suggester->suggest('navidrome', dryRun: false, limit: 0, minPlays: 3);
+
+        // Only the high-volume artist is considered + aliased.
+        $this->assertSame(1, $report->artistsConsidered);
+        $this->assertSame(1, $report->aliasesCreated);
+    }
+
     public function testSourceAlreadyAliasedIsSkipped(): void
     {
         $suggester = $this->makeSuggester(


### PR DESCRIPTION
Closes #200 (volet async auto-apply).

## Résumé

Branche le `MusicBrainzAliasSuggester` **existant** sur la page `/navidrome/unmatched`. Un bouton dispatch un message Messenger traité par le worker — MusicBrainz throttle à ~1 req/s, donc interdit en synchrone dans la requête HTTP.

Flux **non-interactif** identique au CLI `app:aliases:musicbrainz` : les alias artiste à match-bibliothèque **unique** sont appliqués automatiquement, le cache négatif de l'artiste est purgé, les ambigus sont skippés. Le rapport atterrit dans l'historique comme Sync/Rematch.

Scope au seuil **≥3 scrobbles non matchés par artiste** pour ne dépenser des appels MB (rate-limités) que sur les artistes à fort volume.

## Changements

- `src/Message/SuggestAliasesMusicBrainzMessage.php` + `MessageHandler/…Handler.php` (worker), **routé async** dans `messenger.yaml`.
- `src/Service/MusicBrainzAliasSuggester.php` : param `minPlays` (défaut 0, rétro-compatible) ; `break` dès qu'on passe sous le plancher (rows triées par plays décroissants → la queue est forcément sous le seuil aussi).
- `src/Controller/NavidromeSyncController.php` : route POST CSRF-protégée, redirige vers l'historique.
- `templates/navidrome/unmatched.html.twig` : bouton 🎯 avec `confirm` JS.
- `tests/` : `minPlays` stoppe le scan sous le plancher.

## Hors scope (suivi possible)

L'écran de revue humaine des candidats **ambigus** (option B de la question) n'est pas inclus — les ambigus restent skippés comme le CLI. À ouvrir en suivi si besoin.

## Test plan

- [x] `composer ci` vert (192/192 + phpcs clean, phpstan inchangé)
- [ ] Cliquer le bouton → job en historique, throttle respecté, alias uniques créés
- [ ] Rematch ensuite → les scrobbles des artistes aliasés passent en `matched`

> Note env : `bin/console` ne boote pas dans ce conteneur (`vendor/autoload_runtime.php` non généré, composer-as-root) — artefact d'environnement préexistant, sans rapport avec le diff ; le kernel de test boote et les 192 tests passent.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_