### PR TITLE
feat(subsonic): écriture playlists (create/replace/findByName)

### DIFF
--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -7,11 +7,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 /**
  * Minimal read-only client for Navidrome's Subsonic-compatible REST API.
  *
- * Scope of this first slice: just what the /playlists pages need (ping,
- * getPlaylists, getPlaylist). The POC carried 15+ methods (createPlaylist,
- * updatePlaylist, star/unstar, search3, fetchCoverArt, startScan…) but we
- * port them only when the corresponding feature ships, to keep this PR
- * reviewable.
+ * Scope so far: the /playlists pages (ping, getPlaylists, getPlaylist) plus
+ * the write path the playlist generator needs (createPlaylist,
+ * replacePlaylist, findPlaylistByName). The POC carried more (star/unstar,
+ * search3, fetchCoverArt, startScan…) but we port them only when the
+ * corresponding feature ships, to keep each PR reviewable.
  *
  * Auth follows the « salted token » scheme of Subsonic ≥ 1.13.0 :
  * `t = md5(password + salt)` is sent in the URL instead of the raw
@@ -126,11 +126,89 @@ class SubsonicClient
     }
 
     /**
-     * @param array<string, scalar> $params
+     * Create a new playlist from an ordered list of song ids (Navidrome
+     * media_file ids). Returns the id of the created playlist. Subsonic
+     * `createPlaylist.view?name=…&songId=a&songId=b` builds the playlist
+     * in the given order.
+     *
+     * @param list<string> $songIds
+     */
+    public function createPlaylist(string $name, array $songIds): string
+    {
+        if ($name === '') {
+            throw new \RuntimeException('createPlaylist requires a non-empty name.');
+        }
+
+        $data = $this->call('createPlaylist', ['name' => $name], ['songId' => array_values($songIds)]);
+
+        // Navidrome echoes the created playlist node; fall back to a
+        // re-lookup by name if some server variant omits it.
+        $id = (string) ($data['playlist']['id'] ?? '');
+        if ($id !== '') {
+            return $id;
+        }
+        $existing = $this->findPlaylistByName($name);
+
+        return $existing['id'] ?? throw new \RuntimeException(
+            'createPlaylist did not return an id and the playlist could not be found by name: ' . $name,
+        );
+    }
+
+    /**
+     * Overwrite an existing playlist's song list in place (idempotent
+     * regeneration — no duplicate playlist is created). Subsonic
+     * `createPlaylist.view?playlistId=…&songId=…` replaces the whole
+     * contents with the given ordered list. `name` is passed through so a
+     * server that honours it keeps the title in sync.
+     *
+     * @param list<string> $songIds
+     */
+    public function replacePlaylist(string $playlistId, string $name, array $songIds): void
+    {
+        if ($playlistId === '') {
+            throw new \RuntimeException('replacePlaylist requires a non-empty playlistId.');
+        }
+
+        $this->call(
+            'createPlaylist',
+            ['playlistId' => $playlistId, 'name' => $name],
+            ['songId' => array_values($songIds)],
+        );
+    }
+
+    /**
+     * Find one playlist owned by the configured user whose name matches
+     * exactly (case-sensitive, as Navidrome stores it). Returns the
+     * normalized {@see getPlaylists()} row or null. Used by the generator
+     * to decide create-vs-replace.
+     *
+     * @return array{
+     *     id: string, name: string, owner: string,
+     *     songCount: int, duration: int, public: bool,
+     *     created: ?string, changed: ?string, comment: string
+     * }|null
+     */
+    public function findPlaylistByName(string $name): ?array
+    {
+        foreach ($this->getPlaylists() as $p) {
+            if ($p['name'] === $name && $p['owner'] === $this->user) {
+                return $p;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<string, scalar>     $params   single-valued query params
+     * @param array<string, list<string>> $repeated repeated-key params (e.g.
+     *        `['songId' => ['a', 'b']]` → `songId=a&songId=b`). `http_build_query`
+     *        would render these as `songId[0]=…`, which Subsonic rejects, so we
+     *        append them manually.
      *
      * @return array<string, mixed>
      */
-    private function call(string $method, array $params): array
+    private function call(string $method, array $params, array $repeated = []): array
     {
         $salt = bin2hex(random_bytes(8));
         $token = md5($this->password . $salt);
@@ -144,8 +222,14 @@ class SubsonicClient
             'f' => 'json',
         ];
 
-        $url = rtrim($this->baseUrl, '/') . '/rest/' . $method . '.view?'
-            . http_build_query(array_merge($auth, $params));
+        $query = http_build_query(array_merge($auth, $params));
+        foreach ($repeated as $key => $values) {
+            foreach ($values as $value) {
+                $query .= '&' . rawurlencode($key) . '=' . rawurlencode($value);
+            }
+        }
+
+        $url = rtrim($this->baseUrl, '/') . '/rest/' . $method . '.view?' . $query;
 
         try {
             $response = $this->httpClient->request('GET', $url, ['timeout' => 30]);

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -197,6 +197,103 @@ class SubsonicClientTest extends TestCase
         $this->assertStringNotContainsString('//rest/', $captured);
     }
 
+    public function testCreatePlaylistSendsRepeatedSongIdParamsAndReturnsId(): void
+    {
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return new MockResponse($this->envelope([
+                'status' => 'ok',
+                'playlist' => ['id' => 'pl-new', 'name' => 'Retour en arrière'],
+            ]));
+        });
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $id = $client->createPlaylist('Retour en arrière', ['mf-1', 'mf-2', 'mf-3']);
+
+        $this->assertSame('pl-new', $id);
+        $this->assertIsString($captured);
+        // Repeated key form — NOT songId[0]=… which Subsonic rejects.
+        $this->assertStringContainsString('songId=mf-1', $captured);
+        $this->assertStringContainsString('songId=mf-2', $captured);
+        $this->assertStringContainsString('songId=mf-3', $captured);
+        $this->assertStringNotContainsString('songId%5B', $captured); // no songId[0]
+        $this->assertStringContainsString('createPlaylist.view?', $captured);
+    }
+
+    public function testCreatePlaylistRejectsEmptyName(): void
+    {
+        $http = new MockHttpClient([]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('non-empty name');
+        $client->createPlaylist('', ['mf-1']);
+    }
+
+    public function testReplacePlaylistSendsPlaylistIdAndSongs(): void
+    {
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return new MockResponse($this->envelope(['status' => 'ok']));
+        });
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $client->replacePlaylist('pl-1', 'Retour en arrière', ['mf-9', 'mf-8']);
+
+        $this->assertIsString($captured);
+        $this->assertStringContainsString('playlistId=pl-1', $captured);
+        $this->assertStringContainsString('songId=mf-9', $captured);
+        $this->assertStringContainsString('songId=mf-8', $captured);
+    }
+
+    public function testReplacePlaylistRejectsEmptyId(): void
+    {
+        $http = new MockHttpClient([]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('non-empty playlistId');
+        $client->replacePlaylist('', 'X', ['mf-1']);
+    }
+
+    public function testFindPlaylistByNameMatchesNameAndOwner(): void
+    {
+        $payload = $this->envelope([
+            'status' => 'ok',
+            'playlists' => [
+                'playlist' => [
+                    ['id' => 'pl-1', 'name' => 'Retour en arrière', 'owner' => 'someone-else'],
+                    ['id' => 'pl-2', 'name' => 'Retour en arrière', 'owner' => 'admin'],
+                    ['id' => 'pl-3', 'name' => 'Autre', 'owner' => 'admin'],
+                ],
+            ],
+        ]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $found = $client->findPlaylistByName('Retour en arrière');
+
+        $this->assertNotNull($found);
+        // Must pick the one owned by the configured user, not the homonym.
+        $this->assertSame('pl-2', $found['id']);
+    }
+
+    public function testFindPlaylistByNameReturnsNullWhenAbsent(): void
+    {
+        $payload = $this->envelope([
+            'status' => 'ok',
+            'playlists' => ['playlist' => [['id' => 'pl-1', 'name' => 'Autre', 'owner' => 'admin']]],
+        ]);
+        $http = new MockHttpClient([new MockResponse($payload)]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->assertNull($client->findPlaylistByName('Inexistante'));
+    }
+
     /**
      * @param array<string, mixed> $response
      */


### PR DESCRIPTION
## Résumé (PR 1/3 du chantier playlists)

Fondation pour le générateur de playlists « plugin ». Porte du POC les méthodes d'**écriture** Subsonic dont la commande de génération (PR 2) aura besoin. Zéro impact sur les pages `/playlists` existantes (lecture seule inchangée).

## Changements

- `createPlaylist(name, songIds): string` — crée une playlist ordonnée, renvoie son id (fallback re-lookup par nom si le serveur n'écho pas le node créé).
- `replacePlaylist(playlistId, name, songIds)` — réécrit le contenu en place (régénération **idempotente**, pas de doublon).
- `findPlaylistByName(name)` — playlist du même nom appartenant à l'utilisateur configuré (décide create vs replace).

### Détail technique

Subsonic `createPlaylist` attend des `songId` **répétés** (`songId=a&songId=b`). `http_build_query` rendrait `songId[0]=…`, rejeté par Subsonic. `call()` accepte désormais un 3ᵉ param `$repeated` appendé manuellement en clés répétées (`rawurlencode`).

## Tests

- `tests/Subsonic/SubsonicClientTest.php` : +6 cas — `songId` répétés (non bracketed), id retourné, gardes nom/id vides, `findByName` filtre name+owner (ignore l'homonyme d'un autre user), absence → null.
- `composer ci` vert (198/198, phpcs clean, phpstan inchangé).

## Suite

PR 2 = infra plugin + commande (one/all) + UI génération/régénération + « Retour en arrière ». PR 3 = les 4 autres playlists.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_