### PR TITLE
feat(playlists): génération « plugin » + commande/UI + Retour en arrière

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -76,6 +76,21 @@ RUN_HISTORY_RETENTION_DAYS=90
 HELP_COMPOSE_SERVICE=navidrome-tools-web
 ###< Help page ###
 
+###> Playlists ###
+# Comma-separated slugs of playlist definitions to (re)generate when
+# running « tout générer » (CLI --all / UI button). Empty = none auto-run;
+# any definition can still be generated on demand by slug.
+# Available slugs: retour-en-arriere
+PLAYLISTS_ENABLED=
+# Default track cap for definitions that don't override it.
+PLAYLIST_DEFAULT_LIMIT=50
+# « Retour en arrière » — max years back, window length (days) ending at
+# today's anniversary each year, and tracks kept per year.
+PLAYLIST_RETOUR_MAX_YEARS=10
+PLAYLIST_RETOUR_WINDOW_DAYS=15
+PLAYLIST_RETOUR_PER_YEAR=10
+###< Playlists ###
+
 ###> Notifications ###
 NOTIFY_DRIVERS=
 NOTIFY_ON=error

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -17,3 +17,4 @@ framework:
             'App\Message\SyncStrawberryMessage': async
             'App\Message\RematchMessage': async
             'App\Message\SuggestAliasesMusicBrainzMessage': async
+            'App\Message\GeneratePlaylistsMessage': async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,11 @@ parameters:
     lidarr.url: '%env(default::LIDARR_URL)%'
     help.compose_service: '%env(default::HELP_COMPOSE_SERVICE)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
+    playlists.enabled: '%env(PLAYLISTS_ENABLED)%'
+    playlists.default_limit: '%env(int:PLAYLIST_DEFAULT_LIMIT)%'
+    playlist.retour.max_years: '%env(int:PLAYLIST_RETOUR_MAX_YEARS)%'
+    playlist.retour.window_days: '%env(int:PLAYLIST_RETOUR_WINDOW_DAYS)%'
+    playlist.retour.per_year: '%env(int:PLAYLIST_RETOUR_PER_YEAR)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -45,6 +50,8 @@ services:
     _instanceof:
         App\Notifier\NotifierDriverInterface:
             tags: ['app.notifier_driver']
+        App\Playlist\PlaylistDefinitionInterface:
+            tags: ['app.playlist_definition']
 
     App\:
         resource: '../src/'
@@ -61,6 +68,18 @@ services:
     App\Doctrine\SqliteBusyTimeoutMiddleware:
         tags:
             - { name: doctrine.middleware }
+
+    App\Playlist\PlaylistGenerator:
+        arguments:
+            $definitions: !tagged_iterator app.playlist_definition
+            $enabledCsv: '%playlists.enabled%'
+            $defaultLimit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\RetourEnArriereDefinition:
+        arguments:
+            $maxYears: '%playlist.retour.max_years%'
+            $windowDays: '%playlist.retour.window_days%'
+            $perYear: '%playlist.retour.per_year%'
 
     App\Service\BackupService:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,6 +42,11 @@
         <env name="NOTIFY_DISCORD_WEBHOOK_URL" value=""/>
         <env name="NOTIFY_PUSHOVER_TOKEN" value=""/>
         <env name="NOTIFY_PUSHOVER_USER" value=""/>
+        <env name="PLAYLISTS_ENABLED" value=""/>
+        <env name="PLAYLIST_DEFAULT_LIMIT" value="50"/>
+        <env name="PLAYLIST_RETOUR_MAX_YEARS" value="10"/>
+        <env name="PLAYLIST_RETOUR_WINDOW_DAYS" value="15"/>
+        <env name="PLAYLIST_RETOUR_PER_YEAR" value="10"/>
     </php>
 
     <testsuites>

--- a/src/Command/GeneratePlaylistsCommand.php
+++ b/src/Command/GeneratePlaylistsCommand.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistGenerator;
+use App\Playlist\PlaylistRunResult;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Generate (or refresh) the algorithmic playlists in Navidrome.
+ *
+ *   app:playlists:generate --list                 # show available definitions
+ *   app:playlists:generate --slug=retour-en-arriere [--dry-run]
+ *   app:playlists:generate --all [--dry-run]
+ *
+ * `--slug` generates exactly one definition (regardless of PLAYLISTS_ENABLED);
+ * `--all` generates every enabled one. `--dry-run` resolves and prints the
+ * track list without writing anything to Navidrome.
+ */
+#[AsCommand(
+    name: 'app:playlists:generate',
+    description: 'Generate algorithmic playlists in Navidrome (one via --slug, or all enabled via --all).',
+)]
+class GeneratePlaylistsCommand extends Command
+{
+    public function __construct(
+        private readonly PlaylistGenerator $generator,
+        private readonly NavidromeRepository $navidrome,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('slug', null, InputOption::VALUE_REQUIRED, 'Generate only this playlist definition.')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Generate every enabled playlist definition.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Resolve and print tracks without writing to Navidrome.')
+            ->addOption('list', null, InputOption::VALUE_NONE, 'List available playlist definitions and exit.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ((bool) $input->getOption('list')) {
+            return $this->printList($io);
+        }
+
+        $slug = $input->getOption('slug');
+        $slug = is_string($slug) && $slug !== '' ? $slug : null;
+        $all = (bool) $input->getOption('all');
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        if ($slug === null && !$all) {
+            $io->error('Précisez --slug=<slug> pour une playlist, ou --all pour toutes les playlists activées. (--list pour la liste.)');
+            return Command::INVALID;
+        }
+        if ($slug !== null && $all) {
+            $io->error('Options --slug et --all mutuellement exclusives.');
+            return Command::INVALID;
+        }
+
+        $io->title($dryRun ? 'Génération playlists [dry-run]' : 'Génération playlists');
+
+        try {
+            /** @var list<PlaylistRunResult> $results */
+            $results = $this->recorder->record(
+                type: RunHistory::TYPE_PLAYLIST_GENERATE,
+                reference: $slug ?? 'all',
+                label: sprintf('Génération playlists [%s%s]', $slug ?? 'toutes', $dryRun ? ' dry-run' : ''),
+                action: fn (): array => $this->generator->generate($slug, $dryRun),
+                extractMetrics: static fn (array $r): array => ['playlists' => count($r)],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->printResults($io, $results, $dryRun);
+
+        return Command::SUCCESS;
+    }
+
+    private function printList(SymfonyStyle $io): int
+    {
+        $rows = [];
+        foreach ($this->generator->listDefinitions() as $d) {
+            $rows[] = [$d['slug'], $d['name'], $d['enabled'] ? '✓' : '—', $d['description']];
+        }
+        $io->table(['slug', 'nom', 'activé', 'description'], $rows);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<PlaylistRunResult> $results
+     */
+    private function printResults(SymfonyStyle $io, array $results, bool $dryRun): void
+    {
+        if ($results === []) {
+            $io->warning('Aucune playlist générée (aucune définition activée ? voir PLAYLISTS_ENABLED).');
+            return;
+        }
+
+        if ($dryRun) {
+            foreach ($results as $r) {
+                $io->section(sprintf('%s — %d morceaux', $r->name, $r->trackCount()));
+                if ($r->action === PlaylistRunResult::ACTION_ERROR) {
+                    $io->error($r->error ?? 'erreur inconnue');
+                    continue;
+                }
+                $lines = [];
+                foreach ($this->navidrome->summarize($r->trackIds) as $t) {
+                    $lines[] = sprintf('%s — %s', $t->artist, $t->title);
+                }
+                $io->listing($lines !== [] ? $lines : ['(vide)']);
+            }
+        }
+
+        $rows = [];
+        foreach ($results as $r) {
+            $rows[] = [$r->slug, $r->action, (string) $r->trackCount(), $r->error ?? ''];
+        }
+        $io->table(['slug', 'action', 'morceaux', 'erreur'], $rows);
+        $io->success(sprintf('%d playlist(s) traitée(s).', count($results)));
+    }
+}

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -2,9 +2,13 @@
 
 namespace App\Controller;
 
+use App\Message\GeneratePlaylistsMessage;
+use App\Playlist\PlaylistGenerator;
 use App\Subsonic\SubsonicClient;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
@@ -21,7 +25,7 @@ use Symfony\Component\Routing\Attribute\Route;
 class PlaylistController extends AbstractController
 {
     #[Route('/playlists', name: 'app_playlists_index', methods: ['GET'])]
-    public function index(SubsonicClient $subsonic): Response
+    public function index(SubsonicClient $subsonic, PlaylistGenerator $generator): Response
     {
         try {
             $playlists = $subsonic->getPlaylists();
@@ -42,7 +46,34 @@ class PlaylistController extends AbstractController
         return $this->render('playlist_management/index.html.twig', [
             'playlists' => $playlists,
             'error' => $error,
+            'definitions' => $generator->listDefinitions(),
         ]);
+    }
+
+    #[Route('/playlists/generate', name: 'app_playlists_generate', methods: ['POST'])]
+    public function generateAll(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('playlists_generate', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $bus->dispatch(new GeneratePlaylistsMessage(null));
+        $this->addFlash('success', 'Génération de toutes les playlists activées lancée en arrière-plan.');
+
+        return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/playlists/generate/{slug}', name: 'app_playlists_generate_one', methods: ['POST'])]
+    public function generateOne(string $slug, Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('playlists_generate_one', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $bus->dispatch(new GeneratePlaylistsMessage($slug));
+        $this->addFlash('success', sprintf('Génération de la playlist « %s » lancée en arrière-plan.', $slug));
+
+        return $this->redirectToRoute('app_history');
     }
 
     #[Route('/playlists/{id}', name: 'app_playlists_show', methods: ['GET'])]

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -24,6 +24,7 @@ class RunHistory
     public const TYPE_STRAWBERRY_SYNC = 'strawberry-sync';
     public const TYPE_STRAWBERRY_REMATCH = 'strawberry-rematch';
     public const TYPE_STATS = 'stats';
+    public const TYPE_PLAYLIST_GENERATE = 'playlist-generate';
     public const TYPE_BACKUP_PURGE = 'backup-purge';
     public const TYPE_HISTORY_PURGE = 'history-purge';
 

--- a/src/Message/GeneratePlaylistsMessage.php
+++ b/src/Message/GeneratePlaylistsMessage.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Async request to (re)generate playlists in Navidrome. Handled by the
+ * Messenger worker so the web request returns immediately — generation
+ * reads the scrobble history and writes to Navidrome over HTTP, which can
+ * take a moment on large libraries.
+ *
+ * `$slug === null` regenerates every ENABLED playlist; a slug regenerates
+ * just that one (the per-row UI button), bypassing the enable list.
+ */
+final class GeneratePlaylistsMessage
+{
+    public function __construct(
+        public readonly ?string $slug = null,
+    ) {
+    }
+}

--- a/src/MessageHandler/GeneratePlaylistsMessageHandler.php
+++ b/src/MessageHandler/GeneratePlaylistsMessageHandler.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\GeneratePlaylistsMessage;
+use App\Playlist\PlaylistGenerator;
+use App\Playlist\PlaylistRunResult;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Worker-side handler for {@see GeneratePlaylistsMessage}. Runs the
+ * generator (always non-dry-run from the web) and records a RunHistory
+ * entry so the outcome shows up on the history page — like Sync / Rematch.
+ */
+#[AsMessageHandler]
+class GeneratePlaylistsMessageHandler
+{
+    public function __construct(
+        private readonly PlaylistGenerator $generator,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function __invoke(GeneratePlaylistsMessage $message): void
+    {
+        $label = $message->slug !== null
+            ? sprintf('Génération playlist [%s]', $message->slug)
+            : 'Génération playlists [toutes]';
+
+        $this->recorder->record(
+            type: RunHistory::TYPE_PLAYLIST_GENERATE,
+            reference: $message->slug ?? 'all',
+            label: $label,
+            action: fn (): array => $this->generator->generate($message->slug, dryRun: false),
+            extractMetrics: static function (array $results): array {
+                $byAction = [];
+                $tracks = 0;
+                foreach ($results as $r) {
+                    /** @var PlaylistRunResult $r */
+                    $byAction[$r->action] = ($byAction[$r->action] ?? 0) + 1;
+                    $tracks += $r->trackCount();
+                }
+
+                return ['playlists' => count($results), 'tracks' => $tracks] + $byAction;
+            },
+        );
+    }
+}

--- a/src/Playlist/Definition/RetourEnArriereDefinition.php
+++ b/src/Playlist/Definition/RetourEnArriereDefinition.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Retour en arrière » — a nostalgia playlist. For each of the past N
+ * years (bounded by the first scrobble), it takes the top `perYear`
+ * tracks from the `windowDays`-day window leading up to today's
+ * anniversary that year, unions them (dedup, first-seen order) and
+ * shuffles the result.
+ *
+ * E.g. on 27 June with the defaults: top 10 of [12–27 June 2025], top 10
+ * of [12–27 June 2024], … — « what was I listening to around now, in
+ * years past ».
+ *
+ * Pure read against {@see NavidromeRepository::topTracksInWindow()} (which
+ * already returns media_file ids) — no Subsonic dependency here.
+ */
+final class RetourEnArriereDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $maxYears = 10,
+        private readonly int $windowDays = 15,
+        private readonly int $perYear = 10,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'retour-en-arriere';
+    }
+
+    public function getName(): string
+    {
+        return 'Retour en arrière';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Top %d des %d derniers jours, pour chaque année écoulée depuis le premier scrobble, en aléatoire.',
+            $this->perYear,
+            $this->windowDays,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $first = $this->navidrome->getScrobbleBounds()['first'] ?? null;
+        if ($first === null) {
+            return [];
+        }
+
+        $now = $context->now;
+        // Clamp the number of anniversary windows to the years of history
+        // we actually have, so we never query a window before the first
+        // scrobble (it would just return nothing anyway).
+        $years = min($this->maxYears, (int) $first->diff($now)->y);
+        if ($years < 1) {
+            return [];
+        }
+
+        $ids = [];
+        $seen = [];
+        for ($y = 1; $y <= $years; $y++) {
+            $anniversary = $now->modify(sprintf('-%d years', $y));
+            $from = $anniversary->modify(sprintf('-%d days', $this->windowDays));
+            foreach ($this->navidrome->topTracksInWindow($from, $anniversary, $this->perYear) as $id) {
+                if (!isset($seen[$id])) {
+                    $seen[$id] = true;
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/src/Playlist/PlaylistContext.php
+++ b/src/Playlist/PlaylistContext.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Playlist;
+
+/**
+ * Shared inputs handed to every {@see PlaylistDefinitionInterface::build()}.
+ * Keeps the algorithms pure / testable: `now` is injected rather than read
+ * from the wall clock, so date-based generators (e.g. the anniversary
+ * windows of « Retour en arrière ») can be exercised deterministically.
+ */
+final class PlaylistContext
+{
+    public function __construct(
+        public readonly \DateTimeImmutable $now,
+        public readonly int $defaultLimit = 50,
+    ) {
+    }
+}

--- a/src/Playlist/PlaylistDefinitionInterface.php
+++ b/src/Playlist/PlaylistDefinitionInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Playlist;
+
+/**
+ * A single playlist « algorithm » plugin. Each implementation is a Symfony
+ * service tagged `app.playlist_definition` (see config/services.yaml) and
+ * discovered by {@see PlaylistGenerator} via a tagged iterator — the exact
+ * pattern used by {@see \App\Notifier\NotifierDriverInterface}.
+ *
+ * Implementations are PURE selection logic: `build()` returns an ordered
+ * list of Navidrome media_file ids (= Subsonic song ids). Writing the
+ * playlist to Navidrome is the orchestrator's job, so algorithms stay
+ * testable without any Subsonic / HTTP dependency.
+ */
+interface PlaylistDefinitionInterface
+{
+    /**
+     * Stable identifier, lowercase-kebab (e.g. "retour-en-arriere"). Used
+     * as the CLI `--slug` value and the `PLAYLISTS_ENABLED` CSV token.
+     */
+    public function getSlug(): string;
+
+    /** Human name written to Navidrome as the playlist title. */
+    public function getName(): string;
+
+    /** One-line description, written to Navidrome as the playlist comment. */
+    public function getDescription(): string;
+
+    /**
+     * Build the ordered track list. The algorithm owns the ordering,
+     * shuffling included.
+     *
+     * @return list<string> media_file ids, in playlist order
+     */
+    public function build(PlaylistContext $context): array;
+}

--- a/src/Playlist/PlaylistGenerator.php
+++ b/src/Playlist/PlaylistGenerator.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Playlist;
+
+use App\Subsonic\SubsonicClient;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Orchestrates the playlist-definition plugins: discovers every service
+ * tagged `app.playlist_definition`, decides which ones run, builds their
+ * track lists and writes them to Navidrome via Subsonic. Mirrors
+ * {@see \App\Notifier\Notifier} (tagged iterator + CSV enable list +
+ * best-effort per-item isolation).
+ *
+ * Enablement model:
+ *   - `PLAYLISTS_ENABLED` (CSV of slugs) gates the « generate all » run
+ *     (`generate(null)`), so a fresh install ships nothing until opted in.
+ *   - An explicit `generate($slug)` (CLI `--slug`, per-row UI button)
+ *     bypasses the CSV — generating one by name is an explicit intent.
+ *
+ * Idempotent write: a playlist of the same name owned by the configured
+ * user is overwritten in place; otherwise a new one is created.
+ */
+class PlaylistGenerator
+{
+    /** @var list<PlaylistDefinitionInterface> */
+    private readonly array $definitions;
+
+    /** @var list<string> */
+    private readonly array $enabledSlugs;
+
+    /**
+     * @param iterable<PlaylistDefinitionInterface> $definitions
+     */
+    public function __construct(
+        iterable $definitions,
+        string $enabledCsv,
+        private readonly SubsonicClient $subsonic,
+        private readonly int $defaultLimit = 50,
+        private readonly LoggerInterface $logger = new NullLogger(),
+    ) {
+        $this->definitions = is_array($definitions) ? array_values($definitions) : iterator_to_array($definitions, false);
+        $this->enabledSlugs = self::parseCsv($enabledCsv);
+    }
+
+    /**
+     * @return list<array{slug: string, name: string, description: string, enabled: bool}>
+     */
+    public function listDefinitions(): array
+    {
+        $out = [];
+        foreach ($this->definitions as $def) {
+            $out[] = [
+                'slug' => $def->getSlug(),
+                'name' => $def->getName(),
+                'description' => $def->getDescription(),
+                'enabled' => in_array($def->getSlug(), $this->enabledSlugs, true),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Generate playlists and (unless dry-run) write them to Navidrome.
+     *
+     * @param ?string $slug   null → every ENABLED definition ; a slug →
+     *                        that one definition regardless of the CSV.
+     *
+     * @return list<PlaylistRunResult>
+     *
+     * @throws \InvalidArgumentException when an explicit slug is unknown
+     */
+    public function generate(?string $slug, bool $dryRun): array
+    {
+        $targets = $this->resolveTargets($slug);
+        $context = new PlaylistContext(new \DateTimeImmutable(), $this->defaultLimit);
+
+        $results = [];
+        foreach ($targets as $def) {
+            try {
+                $results[] = $this->runOne($def, $context, $dryRun);
+            } catch (\Throwable $e) {
+                // One broken algorithm never blocks the others.
+                $this->logger->error('Playlist definition "{slug}" failed: {message}', [
+                    'slug' => $def->getSlug(),
+                    'message' => $e->getMessage(),
+                    'exception' => $e,
+                ]);
+                $results[] = new PlaylistRunResult(
+                    slug: $def->getSlug(),
+                    name: $def->getName(),
+                    action: PlaylistRunResult::ACTION_ERROR,
+                    error: $e->getMessage(),
+                );
+            }
+        }
+
+        return $results;
+    }
+
+    private function runOne(PlaylistDefinitionInterface $def, PlaylistContext $context, bool $dryRun): PlaylistRunResult
+    {
+        $ids = array_values($def->build($context));
+
+        if ($dryRun) {
+            return new PlaylistRunResult($def->getSlug(), $def->getName(), PlaylistRunResult::ACTION_DRY_RUN, $ids);
+        }
+        if ($ids === []) {
+            // Don't overwrite an existing playlist with an empty list — a
+            // transient empty result (e.g. no recent scrobbles) shouldn't
+            // wipe what's there.
+            return new PlaylistRunResult($def->getSlug(), $def->getName(), PlaylistRunResult::ACTION_EMPTY);
+        }
+
+        $existing = $this->subsonic->findPlaylistByName($def->getName());
+        if ($existing !== null) {
+            $this->subsonic->replacePlaylist($existing['id'], $def->getName(), $ids);
+
+            return new PlaylistRunResult(
+                $def->getSlug(),
+                $def->getName(),
+                PlaylistRunResult::ACTION_REPLACED,
+                $ids,
+                $existing['id'],
+            );
+        }
+
+        $newId = $this->subsonic->createPlaylist($def->getName(), $ids);
+
+        return new PlaylistRunResult($def->getSlug(), $def->getName(), PlaylistRunResult::ACTION_CREATED, $ids, $newId);
+    }
+
+    /**
+     * @return list<PlaylistDefinitionInterface>
+     */
+    private function resolveTargets(?string $slug): array
+    {
+        if ($slug !== null) {
+            foreach ($this->definitions as $def) {
+                if ($def->getSlug() === $slug) {
+                    return [$def];
+                }
+            }
+
+            throw new \InvalidArgumentException(sprintf('Unknown playlist definition "%s".', $slug));
+        }
+
+        return array_values(array_filter(
+            $this->definitions,
+            fn (PlaylistDefinitionInterface $d): bool => in_array($d->getSlug(), $this->enabledSlugs, true),
+        ));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function parseCsv(string $csv): array
+    {
+        $slugs = [];
+        foreach (explode(',', $csv) as $raw) {
+            $slug = strtolower(trim($raw));
+            if ($slug !== '') {
+                $slugs[] = $slug;
+            }
+        }
+
+        return array_values(array_unique($slugs));
+    }
+}

--- a/src/Playlist/PlaylistRunResult.php
+++ b/src/Playlist/PlaylistRunResult.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Playlist;
+
+/**
+ * Outcome of generating one playlist. Returned (one per definition) by
+ * {@see PlaylistGenerator::generate()} for the command / handler to report.
+ */
+final class PlaylistRunResult
+{
+    public const ACTION_CREATED = 'created';
+    public const ACTION_REPLACED = 'replaced';
+    public const ACTION_EMPTY = 'empty';      // algorithm produced no tracks → nothing written
+    public const ACTION_DRY_RUN = 'dry-run';  // computed, not written
+    public const ACTION_ERROR = 'error';
+
+    /**
+     * @param list<string> $trackIds
+     */
+    public function __construct(
+        public readonly string $slug,
+        public readonly string $name,
+        public readonly string $action,
+        public readonly array $trackIds = [],
+        public readonly ?string $playlistId = null,
+        public readonly ?string $error = null,
+    ) {
+    }
+
+    public function trackCount(): int
+    {
+        return count($this->trackIds);
+    }
+}

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -29,6 +29,55 @@
         </div>
     {% endif %}
 
+    {% if definitions is not empty %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden mb-6">
+            <div class="flex items-center justify-between px-4 py-3 bg-slate-50 border-b">
+                <div>
+                    <h2 class="font-semibold">Playlists générées</h2>
+                    <p class="text-xs text-slate-500">Algorithmes de génération — création / rafraîchissement dans Navidrome.</p>
+                </div>
+                <form method="post" action="{{ path('app_playlists_generate') }}"
+                      onsubmit="return confirm('(Re)générer toutes les playlists activées ?');">
+                    <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate') }}">
+                    <button type="submit"
+                            class="bg-sky-700 hover:bg-sky-800 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                        ↻ Tout (re)générer
+                    </button>
+                </form>
+            </div>
+            <table class="w-full text-sm">
+                <tbody class="divide-y">
+                    {% for d in definitions %}
+                        <tr class="hover:bg-slate-50">
+                            <td class="px-4 py-2">
+                                <div class="font-medium">{{ d.name }}</div>
+                                <div class="text-xs text-slate-500">{{ d.description }}</div>
+                                <div class="text-xs text-slate-400 mt-0.5 font-mono">{{ d.slug }}</div>
+                            </td>
+                            <td class="px-3 py-2 text-xs">
+                                {% if d.enabled %}
+                                    <span class="inline-block bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-sm">Activée</span>
+                                {% else %}
+                                    <span class="inline-block bg-slate-100 text-slate-500 px-2 py-0.5 rounded-sm"
+                                          title="Non listée dans PLAYLISTS_ENABLED — exclue du « Tout générer », mais régénérable à la demande">Désactivée</span>
+                                {% endif %}
+                            </td>
+                            <td class="px-4 py-2 text-right">
+                                <form method="post" action="{{ path('app_playlists_generate_one', { slug: d.slug }) }}">
+                                    <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate_one') }}">
+                                    <button type="submit"
+                                            class="bg-amber-600 hover:bg-amber-700 text-white px-3 py-1 rounded-sm text-xs font-medium">
+                                        ↻ {{ d.enabled ? 'Régénérer' : 'Générer' }}
+                                    </button>
+                                </form>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+
     {% if playlists is empty and not error %}
         <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
             Aucune playlist trouvée côté Navidrome.

--- a/tests/MessageHandler/GeneratePlaylistsMessageHandlerTest.php
+++ b/tests/MessageHandler/GeneratePlaylistsMessageHandlerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\GeneratePlaylistsMessage;
+use App\MessageHandler\GeneratePlaylistsMessageHandler;
+use App\Playlist\PlaylistGenerator;
+use App\Playlist\PlaylistRunResult;
+use App\Service\RunHistoryRecorder;
+use PHPUnit\Framework\TestCase;
+
+class GeneratePlaylistsMessageHandlerTest extends TestCase
+{
+    public function testHandlerGeneratesRequestedSlugAndRecordsRun(): void
+    {
+        $generator = $this->createMock(PlaylistGenerator::class);
+        $generator->expects($this->once())
+            ->method('generate')
+            ->with('retour-en-arriere', false)
+            ->willReturn([new PlaylistRunResult('retour-en-arriere', 'Retour en arrière', PlaylistRunResult::ACTION_CREATED, ['mf-1'])]);
+
+        $recorder = $this->createMock(RunHistoryRecorder::class);
+        $recorder->expects($this->once())
+            ->method('record')
+            ->with(
+                RunHistory::TYPE_PLAYLIST_GENERATE,
+                'retour-en-arriere',
+                $this->stringContains('retour-en-arriere'),
+                $this->isCallable(),
+                $this->isCallable(),
+            )
+            // Execute the wrapped action so the generator is actually invoked.
+            ->willReturnCallback(fn (string $t, string $r, string $l, callable $action) => $action());
+
+        (new GeneratePlaylistsMessageHandler($generator, $recorder))(new GeneratePlaylistsMessage('retour-en-arriere'));
+    }
+
+    public function testHandlerWithNullSlugGeneratesAll(): void
+    {
+        $generator = $this->createMock(PlaylistGenerator::class);
+        $generator->expects($this->once())->method('generate')->with(null, false)->willReturn([]);
+
+        $recorder = $this->createMock(RunHistoryRecorder::class);
+        $recorder->expects($this->once())
+            ->method('record')
+            ->with(RunHistory::TYPE_PLAYLIST_GENERATE, 'all', $this->anything(), $this->isCallable(), $this->isCallable())
+            ->willReturnCallback(fn (string $t, string $r, string $l, callable $action) => $action());
+
+        (new GeneratePlaylistsMessageHandler($generator, $recorder))(new GeneratePlaylistsMessage(null));
+    }
+}

--- a/tests/Playlist/PlaylistGeneratorTest.php
+++ b/tests/Playlist/PlaylistGeneratorTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Tests\Playlist;
+
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+use App\Playlist\PlaylistGenerator;
+use App\Playlist\PlaylistRunResult;
+use App\Subsonic\SubsonicClient;
+use PHPUnit\Framework\TestCase;
+
+class PlaylistGeneratorTest extends TestCase
+{
+    public function testGenerateAllRunsOnlyEnabledDefinitions(): void
+    {
+        $enabled = $this->def('enabled-one', 'Enabled One', ['mf-1', 'mf-2']);
+        $disabled = $this->def('disabled-one', 'Disabled One', ['mf-3']);
+
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->method('findPlaylistByName')->willReturn(null);
+        $subsonic->expects($this->once())
+            ->method('createPlaylist')
+            ->with('Enabled One', ['mf-1', 'mf-2'])
+            ->willReturn('pl-new');
+
+        $gen = new PlaylistGenerator([$enabled, $disabled], 'enabled-one', $subsonic);
+        $results = $gen->generate(null, dryRun: false);
+
+        $this->assertCount(1, $results);
+        $this->assertSame('enabled-one', $results[0]->slug);
+        $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[0]->action);
+    }
+
+    public function testGenerateBySlugBypassesEnabledList(): void
+    {
+        $disabled = $this->def('disabled-one', 'Disabled One', ['mf-3']);
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->method('findPlaylistByName')->willReturn(null);
+        $subsonic->expects($this->once())->method('createPlaylist')->willReturn('pl-x');
+
+        // Empty CSV → nothing enabled, yet an explicit slug still runs.
+        $gen = new PlaylistGenerator([$disabled], '', $subsonic);
+        $results = $gen->generate('disabled-one', dryRun: false);
+
+        $this->assertCount(1, $results);
+        $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[0]->action);
+    }
+
+    public function testUnknownSlugThrows(): void
+    {
+        $gen = new PlaylistGenerator([$this->def('a', 'A', ['mf-1'])], 'a', $this->createMock(SubsonicClient::class));
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown playlist definition "nope"');
+        $gen->generate('nope', dryRun: false);
+    }
+
+    public function testExistingPlaylistIsReplacedNotDuplicated(): void
+    {
+        $def = $this->def('a', 'A', ['mf-1', 'mf-2']);
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->method('findPlaylistByName')->with('A')->willReturn([
+            'id' => 'pl-existing', 'name' => 'A', 'owner' => 'admin',
+            'songCount' => 0, 'duration' => 0, 'public' => false,
+            'created' => null, 'changed' => null, 'comment' => '',
+        ]);
+        $subsonic->expects($this->once())->method('replacePlaylist')->with('pl-existing', 'A', ['mf-1', 'mf-2']);
+        $subsonic->expects($this->never())->method('createPlaylist');
+
+        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
+
+        $this->assertSame(PlaylistRunResult::ACTION_REPLACED, $results[0]->action);
+        $this->assertSame('pl-existing', $results[0]->playlistId);
+    }
+
+    public function testDryRunNeverWrites(): void
+    {
+        $def = $this->def('a', 'A', ['mf-1', 'mf-2']);
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->expects($this->never())->method('createPlaylist');
+        $subsonic->expects($this->never())->method('replacePlaylist');
+        $subsonic->expects($this->never())->method('findPlaylistByName');
+
+        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: true);
+
+        $this->assertSame(PlaylistRunResult::ACTION_DRY_RUN, $results[0]->action);
+        $this->assertSame(['mf-1', 'mf-2'], $results[0]->trackIds);
+    }
+
+    public function testEmptyResultDoesNotWrite(): void
+    {
+        $def = $this->def('a', 'A', []);
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->expects($this->never())->method('createPlaylist');
+        $subsonic->expects($this->never())->method('replacePlaylist');
+
+        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
+
+        $this->assertSame(PlaylistRunResult::ACTION_EMPTY, $results[0]->action);
+    }
+
+    public function testOneBrokenDefinitionDoesNotBlockOthers(): void
+    {
+        $broken = $this->createMock(PlaylistDefinitionInterface::class);
+        $broken->method('getSlug')->willReturn('broken');
+        $broken->method('getName')->willReturn('Broken');
+        $broken->method('build')->willThrowException(new \RuntimeException('boom'));
+
+        $ok = $this->def('ok', 'OK', ['mf-1']);
+
+        $subsonic = $this->createMock(SubsonicClient::class);
+        $subsonic->method('findPlaylistByName')->willReturn(null);
+        $subsonic->method('createPlaylist')->willReturn('pl-ok');
+
+        $results = (new PlaylistGenerator([$broken, $ok], 'broken,ok', $subsonic))->generate(null, dryRun: false);
+
+        $this->assertCount(2, $results);
+        $this->assertSame(PlaylistRunResult::ACTION_ERROR, $results[0]->action);
+        $this->assertSame('boom', $results[0]->error);
+        $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[1]->action);
+    }
+
+    public function testListDefinitionsReportsEnabledState(): void
+    {
+        $gen = new PlaylistGenerator(
+            [$this->def('a', 'A', []), $this->def('b', 'B', [])],
+            'a',
+            $this->createMock(SubsonicClient::class),
+        );
+
+        $list = $gen->listDefinitions();
+
+        $this->assertTrue($list[0]['enabled']);
+        $this->assertFalse($list[1]['enabled']);
+    }
+
+    /**
+     * @param list<string> $ids
+     */
+    private function def(string $slug, string $name, array $ids): PlaylistDefinitionInterface
+    {
+        return new class ($slug, $name, $ids) implements PlaylistDefinitionInterface {
+            /** @param list<string> $ids */
+            public function __construct(
+                private readonly string $slug,
+                private readonly string $name,
+                private readonly array $ids,
+            ) {
+            }
+
+            public function getSlug(): string
+            {
+                return $this->slug;
+            }
+
+            public function getName(): string
+            {
+                return $this->name;
+            }
+
+            public function getDescription(): string
+            {
+                return 'desc ' . $this->slug;
+            }
+
+            public function build(PlaylistContext $context): array
+            {
+                return $this->ids;
+            }
+        };
+    }
+}

--- a/tests/Playlist/RetourEnArriereDefinitionTest.php
+++ b/tests/Playlist/RetourEnArriereDefinitionTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Tests\Playlist;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\Definition\RetourEnArriereDefinition;
+use App\Playlist\PlaylistContext;
+use PHPUnit\Framework\TestCase;
+
+class RetourEnArriereDefinitionTest extends TestCase
+{
+    public function testReturnsEmptyWhenNoScrobbleHistory(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getScrobbleBounds')->willReturn(['first' => null, 'last' => null]);
+        $navidrome->expects($this->never())->method('topTracksInWindow');
+
+        $def = new RetourEnArriereDefinition($navidrome);
+        $this->assertSame([], $def->build($this->ctx('2026-06-27')));
+    }
+
+    public function testClampsYearsToAvailableHistory(): void
+    {
+        // First scrobble ~2.5 years before "now" → only 2 full years back,
+        // so exactly 2 windows are queried even though maxYears=10.
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getScrobbleBounds')->willReturn([
+            'first' => new \DateTimeImmutable('2024-01-01'),
+            'last' => new \DateTimeImmutable('2026-06-27'),
+        ]);
+        $navidrome->expects($this->exactly(2))
+            ->method('topTracksInWindow')
+            ->willReturn(['mf-1']);
+
+        $def = new RetourEnArriereDefinition($navidrome, maxYears: 10, windowDays: 15, perYear: 10);
+        $ids = $def->build($this->ctx('2026-06-27'));
+
+        // Same id across both windows → deduped to one.
+        $this->assertSame(['mf-1'], $ids);
+    }
+
+    public function testWindowsEndAtEachAnniversaryAndSpanWindowDays(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getScrobbleBounds')->willReturn([
+            'first' => new \DateTimeImmutable('2010-01-01'),
+            'last' => new \DateTimeImmutable('2026-06-27'),
+        ]);
+
+        $captured = [];
+        $navidrome->method('topTracksInWindow')->willReturnCallback(
+            function (\DateTimeInterface $from, \DateTimeInterface $to, int $limit) use (&$captured): array {
+                $captured[] = [$from->format('Y-m-d'), $to->format('Y-m-d'), $limit];
+
+                return [];
+            },
+        );
+
+        $def = new RetourEnArriereDefinition($navidrome, maxYears: 2, windowDays: 15, perYear: 10);
+        $def->build($this->ctx('2026-06-27'));
+
+        // Year 1: [2025-06-12, 2025-06-27]; Year 2: [2024-06-12, 2024-06-27].
+        $this->assertSame(['2025-06-12', '2025-06-27', 10], $captured[0]);
+        $this->assertSame(['2024-06-12', '2024-06-27', 10], $captured[1]);
+    }
+
+    public function testUnionDedupesAcrossYearsPreservingFirstSeen(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getScrobbleBounds')->willReturn([
+            'first' => new \DateTimeImmutable('2010-01-01'),
+            'last' => new \DateTimeImmutable('2026-06-27'),
+        ]);
+        // Year 1 → [a, b]; Year 2 → [b, c]. Union must be {a, b, c}.
+        $navidrome->method('topTracksInWindow')->willReturnOnConsecutiveCalls(
+            ['a', 'b'],
+            ['b', 'c'],
+        );
+
+        $def = new RetourEnArriereDefinition($navidrome, maxYears: 2, windowDays: 15, perYear: 10);
+        $ids = $def->build($this->ctx('2026-06-27'));
+
+        sort($ids); // build() shuffles — assert the set, not the order.
+        $this->assertSame(['a', 'b', 'c'], $ids);
+    }
+
+    private function ctx(string $now): PlaylistContext
+    {
+        return new PlaylistContext(new \DateTimeImmutable($now));
+    }
+}


### PR DESCRIPTION
## Résumé (PR 2/3 du chantier playlists)

Système où **chaque playlist = une classe contenant son algorithme** (service taggé `app.playlist_definition`, découvert via `tagged_iterator`) — calque exact du système `Notifier`. **Deux points de déclenchement** : commande CLI et UI web. Régénération **idempotente** : écrasement de la playlist du même nom appartenant à l'utilisateur, sinon création (réutilise la PR #202).

## Infra plugin (`src/Playlist/`)

- **`PlaylistDefinitionInterface`** : `getSlug`/`getName`/`getDescription`/`build(ctx)` → media_file ids ordonnés. Logique pure, **sans dépendance Subsonic** (testable sans HTTP).
- **`PlaylistContext`** : `now` injectable (algos datés déterministes) + `defaultLimit`.
- **`PlaylistRunResult`** : DTO (`created`/`replaced`/`empty`/`dry-run`/`error`).
- **`PlaylistGenerator`** (orchestrateur) : `PLAYLISTS_ENABLED` (CSV) gate le « tout générer » ; un slug explicite passe outre (intent explicite) ; **try/catch par définition** (un algo cassé n'empêche pas les autres) ; `listDefinitions()` partagé CLI+UI.

## Algorithme livré

**`RetourEnArriereDefinition`** — pour chaque année depuis le 1er scrobble (borné `maxYears`), top `perYear` de la fenêtre de `windowDays` jours finissant à l'anniversaire d'aujourd'hui ; union dédupliquée puis `shuffle`. N'appelle que des requêtes repo **existantes** (`getScrobbleBounds`, `topTracksInWindow`).

## Déclenchement

- **CLI** `app:playlists:generate [--slug= | --all] [--dry-run] [--list]` — `--slug` une seule (même désactivée), `--all` toutes les activées ; `--dry-run` imprime la tracklist via `summarize()` sans écrire ; `--list` liste slugs/nom/activé. Enveloppé dans `RunHistoryRecorder`.
- **Web** : `GeneratePlaylistsMessage` (routé **async**) + handler ; `PlaylistController` routes POST CSRF (toutes / une par slug) → historique. Panneau **« Playlists générées »** sur `/playlists` avec boutons **Générer/Régénérer** par ligne + **Tout (re)générer**.

## Divers

- `RunHistory::TYPE_PLAYLIST_GENERATE` ; câblage `services.yaml`/`messenger.yaml` ; bloc Playlists dans `.env.dist` + `phpunit.xml.dist`.

## Tests (212/212, phpcs clean, phpstan inchangé)

- Orchestrateur : CSV, slug ciblé vs toutes, slug inconnu→erreur, replace vs create, dry-run n'écrit jamais, résultat vide n'écrase pas, algo cassé isolé, `listDefinitions`.
- Retour en arrière : bornage années sur l'historique, calcul des fenêtres (anniversaire − 15 j), dédup union.
- Handler web.

## Suite

PR 3 = les 4 autres playlists (Top du mois, Top all-time, Pépites oubliées, Coups de cœur) — chacune une classe fine réutilisant les requêtes repo existantes.

> Note env : `bin/console` ne boote pas dans ce conteneur (`autoload_runtime.php` non généré) — artefact préexistant ; la couverture est assurée par phpunit (aucun test ne boote le kernel ici).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_