### PR TITLE
feat(playlists): 4 définitions supplémentaires (top mois/all-time, pépites, coups de cœur)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -80,15 +80,20 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # Comma-separated slugs of playlist definitions to (re)generate when
 # running « tout générer » (CLI --all / UI button). Empty = none auto-run;
 # any definition can still be generated on demand by slug.
-# Available slugs: retour-en-arriere
+# Available slugs: retour-en-arriere, top-du-mois, top-all-time,
+#                  pepites-oubliees, coups-de-coeur
 PLAYLISTS_ENABLED=
-# Default track cap for definitions that don't override it.
+# Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
 # today's anniversary each year, and tracks kept per year.
 PLAYLIST_RETOUR_MAX_YEARS=10
 PLAYLIST_RETOUR_WINDOW_DAYS=15
 PLAYLIST_RETOUR_PER_YEAR=10
+# « Pépites oubliées » — min lifetime plays to qualify, and how many months
+# of silence (no play) before a track counts as « forgotten ».
+PLAYLIST_PEPITES_MIN_PLAYS=5
+PLAYLIST_PEPITES_SILENCE_MONTHS=12
 ###< Playlists ###
 
 ###> Notifications ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -28,6 +28,8 @@ parameters:
     playlist.retour.max_years: '%env(int:PLAYLIST_RETOUR_MAX_YEARS)%'
     playlist.retour.window_days: '%env(int:PLAYLIST_RETOUR_WINDOW_DAYS)%'
     playlist.retour.per_year: '%env(int:PLAYLIST_RETOUR_PER_YEAR)%'
+    playlist.pepites.min_plays: '%env(int:PLAYLIST_PEPITES_MIN_PLAYS)%'
+    playlist.pepites.silence_months: '%env(int:PLAYLIST_PEPITES_SILENCE_MONTHS)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -80,6 +82,24 @@ services:
             $maxYears: '%playlist.retour.max_years%'
             $windowDays: '%playlist.retour.window_days%'
             $perYear: '%playlist.retour.per_year%'
+
+    App\Playlist\Definition\TopDuMoisDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\TopAllTimeDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\CoupsDeCoeurDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\PepitesOublieesDefinition:
+        arguments:
+            $minPlays: '%playlist.pepites.min_plays%'
+            $silenceMonths: '%playlist.pepites.silence_months%'
+            $limit: '%playlists.default_limit%'
 
     App\Service\BackupService:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -47,6 +47,8 @@
         <env name="PLAYLIST_RETOUR_MAX_YEARS" value="10"/>
         <env name="PLAYLIST_RETOUR_WINDOW_DAYS" value="15"/>
         <env name="PLAYLIST_RETOUR_PER_YEAR" value="10"/>
+        <env name="PLAYLIST_PEPITES_MIN_PLAYS" value="5"/>
+        <env name="PLAYLIST_PEPITES_SILENCE_MONTHS" value="12"/>
     </php>
 
     <testsuites>

--- a/src/Playlist/Definition/CoupsDeCoeurDefinition.php
+++ b/src/Playlist/Definition/CoupsDeCoeurDefinition.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Coups de cœur » — starred (loved) tracks, shuffled and capped. Reuses
+ * {@see NavidromeRepository::iterateStarredMediaFiles()} and keeps only the
+ * media_file ids.
+ */
+final class CoupsDeCoeurDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'coups-de-coeur';
+    }
+
+    public function getName(): string
+    {
+        return 'Coups de cœur';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('%d morceaux likés (starred) dans Navidrome, en aléatoire.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $ids = [];
+        foreach ($this->navidrome->iterateStarredMediaFiles() as $row) {
+            $ids[] = (string) $row['id'];
+        }
+
+        shuffle($ids);
+
+        return array_slice($ids, 0, $this->limit);
+    }
+}

--- a/src/Playlist/Definition/PepitesOublieesDefinition.php
+++ b/src/Playlist/Definition/PepitesOublieesDefinition.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Pépites oubliées » — tracks heavily played in the past (≥ minPlays)
+ * but silent for at least `silenceMonths`. Reuses
+ * {@see NavidromeRepository::getSongsLovedAndForgotten()} which orders by
+ * play count desc / last play asc; order is preserved (no shuffle — the
+ * « most loved, longest forgotten » first is the point).
+ */
+final class PepitesOublieesDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $minPlays = 5,
+        private readonly int $silenceMonths = 12,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'pepites-oubliees';
+    }
+
+    public function getName(): string
+    {
+        return 'Pépites oubliées';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Morceaux écoutés au moins %d fois mais plus joués depuis %d mois.',
+            $this->minPlays,
+            $this->silenceMonths,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $cutoff = $context->now->modify(sprintf('-%d months', $this->silenceMonths));
+
+        return $this->navidrome->getSongsLovedAndForgotten($this->minPlays, $cutoff, $this->limit);
+    }
+}

--- a/src/Playlist/Definition/TopAllTimeDefinition.php
+++ b/src/Playlist/Definition/TopAllTimeDefinition.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Top de tous les temps » — the all-time most played tracks, shuffled.
+ * Reuses {@see NavidromeRepository::getTopTracksWithDates()} with no date
+ * filter.
+ */
+final class TopAllTimeDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'top-all-time';
+    }
+
+    public function getName(): string
+    {
+        return 'Top de tous les temps';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Top %d des morceaux les plus écoutés depuis toujours, en aléatoire.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $rows = $this->navidrome->getTopTracksWithDates(null, null, null, $this->limit);
+
+        $ids = array_map(static fn (array $r): string => (string) $r['id'], $rows);
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/src/Playlist/Definition/TopDuMoisDefinition.php
+++ b/src/Playlist/Definition/TopDuMoisDefinition.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Top du mois dernier » — the most played tracks of the previous
+ * calendar month, shuffled. Reuses
+ * {@see NavidromeRepository::getTopTracksWithDates()} with the year/month
+ * of `now - 1 month`.
+ */
+final class TopDuMoisDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'top-du-mois';
+    }
+
+    public function getName(): string
+    {
+        return 'Top du mois dernier';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Top %d des morceaux les plus écoutés le mois calendaire précédent, en aléatoire.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $lastMonth = $context->now->modify('first day of last month');
+        $rows = $this->navidrome->getTopTracksWithDates(
+            (int) $lastMonth->format('Y'),
+            (int) $lastMonth->format('n'),
+            null,
+            $this->limit,
+        );
+
+        $ids = array_map(static fn (array $r): string => (string) $r['id'], $rows);
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Tests\Playlist;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\Definition\CoupsDeCoeurDefinition;
+use App\Playlist\Definition\PepitesOublieesDefinition;
+use App\Playlist\Definition\TopAllTimeDefinition;
+use App\Playlist\Definition\TopDuMoisDefinition;
+use App\Playlist\PlaylistContext;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Thin coverage of the four reuse-heavy definitions: each must call the
+ * right existing repo method with the right args and return media_file ids.
+ * Shuffle makes order non-deterministic, so id-set assertions sort first.
+ */
+class DefinitionsTest extends TestCase
+{
+    public function testTopDuMoisQueriesPreviousCalendarMonth(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        // now = 2026-01-15 → previous month = December 2025.
+        $navidrome->expects($this->once())
+            ->method('getTopTracksWithDates')
+            ->with(2025, 12, null, 50)
+            ->willReturn([['id' => 'mf-1'], ['id' => 'mf-2']]);
+
+        $ids = (new TopDuMoisDefinition($navidrome, 50))->build($this->ctx('2026-01-15'));
+
+        sort($ids);
+        $this->assertSame(['mf-1', 'mf-2'], $ids);
+    }
+
+    public function testTopAllTimeQueriesWithoutDateFilter(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getTopTracksWithDates')
+            ->with(null, null, null, 25)
+            ->willReturn([['id' => 'mf-9']]);
+
+        $this->assertSame(['mf-9'], (new TopAllTimeDefinition($navidrome, 25))->build($this->ctx('2026-06-27')));
+    }
+
+    public function testPepitesOublieesUsesCutoffFromSilenceMonths(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getSongsLovedAndForgotten')
+            ->with(
+                5,
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2025-06-27'),
+                50,
+            )
+            ->willReturn(['mf-old']);
+
+        $def = new PepitesOublieesDefinition($navidrome, minPlays: 5, silenceMonths: 12, limit: 50);
+        $this->assertSame(['mf-old'], $def->build($this->ctx('2026-06-27')));
+    }
+
+    public function testCoupsDeCoeurCollectsStarredAndCapsAtLimit(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('iterateStarredMediaFiles')->willReturnCallback(function (): \Generator {
+            yield ['id' => 'a'];
+            yield ['id' => 'b'];
+            yield ['id' => 'c'];
+        });
+
+        $ids = (new CoupsDeCoeurDefinition($navidrome, 2))->build($this->ctx('2026-06-27'));
+
+        $this->assertCount(2, $ids);
+        // Both kept ids must come from the starred set.
+        foreach ($ids as $id) {
+            $this->assertContains($id, ['a', 'b', 'c']);
+        }
+    }
+
+    public function testSlugsAndNamesAreStable(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $this->assertSame('top-du-mois', (new TopDuMoisDefinition($navidrome))->getSlug());
+        $this->assertSame('top-all-time', (new TopAllTimeDefinition($navidrome))->getSlug());
+        $this->assertSame('pepites-oubliees', (new PepitesOublieesDefinition($navidrome))->getSlug());
+        $this->assertSame('coups-de-coeur', (new CoupsDeCoeurDefinition($navidrome))->getSlug());
+    }
+
+    private function ctx(string $now): PlaylistContext
+    {
+        return new PlaylistContext(new \DateTimeImmutable($now));
+    }
+}


### PR DESCRIPTION
## Résumé (PR 3/3 du chantier playlists)

Quatre algorithmes **fins** par-dessus l'infra plugin (#203), chacun ne réutilisant que des requêtes repo **existantes** — découverts automatiquement par le `tagged_iterator`, donc visibles dans `--list` et le panneau `/playlists` sans autre changement.

| Slug | Algo | Requête réutilisée |
|------|------|--------------------|
| `top-du-mois` | Top du mois calendaire précédent, shuffle | `getTopTracksWithDates(y, m)` sur `now-1 mois` |
| `top-all-time` | Top de toujours, shuffle | `getTopTracksWithDates()` sans filtre |
| `pepites-oubliees` | ≥ `minPlays` mais silencieux depuis `silenceMonths` | `getSongsLovedAndForgotten()` (ordre conservé : plus aimé / plus longtemps oublié d'abord) |
| `coups-de-coeur` | Starred Navidrome, shuffle + cap | `iterateStarredMediaFiles()` |

## Câblage

- `services.yaml` : `limit = PLAYLIST_DEFAULT_LIMIT` ; Pépites prend `min_plays`/`silence_months`.
- `.env.dist` + `phpunit.xml.dist` : `PLAYLIST_PEPITES_MIN_PLAYS=5`, `PLAYLIST_PEPITES_SILENCE_MONTHS=12` ; liste des slugs documentée.

## Tests (217/217, phpcs clean, phpstan inchangé)

- `tests/Playlist/DefinitionsTest.php` : mois précédent, all-time sans filtre, cutoff Pépites calculé depuis `silenceMonths`, Coups de cœur collecte+cap, slugs stables.

## Chantier playlists complet

PR #202 (écriture Subsonic) → #203 (infra plugin + commande/UI + Retour en arrière) → celle-ci. **5 playlists** disponibles, générables une-à-une ou toutes, en CLI ou via l'UI.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_