### PR TITLE
fix(playlists): rendre les variables PLAYLIST* optionnelles (défauts)

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,4 +1,17 @@
 parameters:
+    # Defaults for the optional Playlists env vars: a deployment whose .env
+    # predates the playlist feature keeps booting without edits. A real env
+    # var (.env, docker-compose, phpunit) always overrides these. `default::`
+    # is unfit for the ints (it falls back to 0 → empty/broken playlists),
+    # hence parameter-level defaults with real values.
+    env(PLAYLISTS_ENABLED): ''
+    env(PLAYLIST_DEFAULT_LIMIT): '50'
+    env(PLAYLIST_RETOUR_MAX_YEARS): '10'
+    env(PLAYLIST_RETOUR_WINDOW_DAYS): '15'
+    env(PLAYLIST_RETOUR_PER_YEAR): '10'
+    env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
+    env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
+
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
     app.version: '%env(default::APP_VERSION)%'


### PR DESCRIPTION
## Problème

Les 7 variables `PLAYLIST*` introduites en #203/#204 sont référencées dans `config/services.yaml` en `%env(int:…)%` / `%env(…)%` **sans défaut**. Le runtime charge `.env` (pas `.env.dist`), donc un déploiement dont le `.env` précède la feature playlists **refuse de booter** : `Environment variable not found: PLAYLIST_RETOUR_MAX_YEARS`.

## Correctif

Défauts au **niveau paramètre** (`env(VAR): valeur`) en tête du bloc `parameters:`. Le repo a déjà l'idiome `%env(default::…)%`, mais `default::` retombe sur `null`/`0` — ce qui casserait les entiers (limit 0, max_years 0 → playlists vides). Les défauts paramètre fixent de vraies valeurs.

```yaml
env(PLAYLISTS_ENABLED): ''
env(PLAYLIST_DEFAULT_LIMIT): '50'
env(PLAYLIST_RETOUR_MAX_YEARS): '10'
env(PLAYLIST_RETOUR_WINDOW_DAYS): '15'
env(PLAYLIST_RETOUR_PER_YEAR): '10'
env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
```

Précédence inchangée : une vraie variable d'env (`.env`, docker-compose, `phpunit.xml.dist`) **prime toujours** ; ces défauts ne s'appliquent que si la variable est absente partout. Les références `%env(int:VAR)%` existantes ne bougent pas. `.env.dist` reste la doc de référence.

## Effet

Un déploiement existant **boote sans toucher au `.env`** ; les playlists fonctionnent avec les défauts, et `PLAYLISTS_ENABLED` reste vide (rien en auto) jusqu'à opt-in.

## Test plan

- [x] `composer ci` vert (217/217, phpcs clean, phpstan inchangé) — comportement des tests inchangé (`phpunit.xml.dist` fixe déjà ces vars).
- [ ] Côté déploiement : retirer les `PLAYLIST*` du `.env`, confirmer que le conteneur boote et que `app:playlists:generate --list` répond.

> Seul fichier modifié : `config/services.yaml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_