### PR TITLE
feat(playlists): Retour en arrière — profondeur par défaut 25 ans

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -87,7 +87,7 @@ PLAYLISTS_ENABLED=
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
 # today's anniversary each year, and tracks kept per year.
-PLAYLIST_RETOUR_MAX_YEARS=10
+PLAYLIST_RETOUR_MAX_YEARS=25
 PLAYLIST_RETOUR_WINDOW_DAYS=30
 PLAYLIST_RETOUR_PER_YEAR=10
 # « Pépites oubliées » — min lifetime plays to qualify, and how many months

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,7 @@ parameters:
     # hence parameter-level defaults with real values.
     env(PLAYLISTS_ENABLED): ''
     env(PLAYLIST_DEFAULT_LIMIT): '50'
-    env(PLAYLIST_RETOUR_MAX_YEARS): '10'
+    env(PLAYLIST_RETOUR_MAX_YEARS): '25'
     env(PLAYLIST_RETOUR_WINDOW_DAYS): '30'
     env(PLAYLIST_RETOUR_PER_YEAR): '10'
     env(PLAYLIST_PEPITES_MIN_PLAYS): '5'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -44,7 +44,7 @@
         <env name="NOTIFY_PUSHOVER_USER" value=""/>
         <env name="PLAYLISTS_ENABLED" value=""/>
         <env name="PLAYLIST_DEFAULT_LIMIT" value="50"/>
-        <env name="PLAYLIST_RETOUR_MAX_YEARS" value="10"/>
+        <env name="PLAYLIST_RETOUR_MAX_YEARS" value="25"/>
         <env name="PLAYLIST_RETOUR_WINDOW_DAYS" value="30"/>
         <env name="PLAYLIST_RETOUR_PER_YEAR" value="10"/>
         <env name="PLAYLIST_PEPITES_MIN_PLAYS" value="5"/>

--- a/src/Playlist/Definition/RetourEnArriereDefinition.php
+++ b/src/Playlist/Definition/RetourEnArriereDefinition.php
@@ -25,7 +25,7 @@ final class RetourEnArriereDefinition implements PlaylistDefinitionInterface
 {
     public function __construct(
         private readonly NavidromeRepository $navidrome,
-        private readonly int $maxYears = 10,
+        private readonly int $maxYears = 25,
         private readonly int $windowDays = 30,
         private readonly int $perYear = 10,
     ) {


### PR DESCRIPTION
## Résumé

Profondeur par défaut de « Retour en arrière » : **10 → 25 ans**. Toujours bornée par le 1er scrobble (`min(maxYears, années d'historique)`), donc une bibliothèque de 6 ans génère 6 fenêtres, une de 25+ ans en génère 25.

## Fichiers

- `src/Playlist/Definition/RetourEnArriereDefinition.php` (param `$maxYears` par défaut)
- `config/services.yaml` (`env(PLAYLIST_RETOUR_MAX_YEARS): '25'`)
- `.env.dist`, `phpunit.xml.dist`

## Test plan

- [x] `composer ci` vert (le test de bornage passe `maxYears` explicitement → inchangé).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_