### PR TITLE
feat(playlists): nouvelle playlist « Kickstart »

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -81,7 +81,7 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # running « tout générer » (CLI --all / UI button). Empty = none auto-run;
 # any definition can still be generated on demand by slug.
 # Available slugs: retour-en-arriere, top-du-mois, top-all-time,
-#                  pepites-oubliees, coups-de-coeur
+#                  pepites-oubliees, coups-de-coeur, kickstart
 PLAYLISTS_ENABLED=
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -108,6 +108,10 @@ services:
         arguments:
             $limit: '%playlists.default_limit%'
 
+    App\Playlist\Definition\KickstartDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
     App\Playlist\Definition\PepitesOublieesDefinition:
         arguments:
             $minPlays: '%playlist.pepites.min_plays%'

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -457,6 +457,53 @@ class NavidromeRepository
     }
 
     /**
+     * « Kickstart » : tracks that most often OPEN the listening day. For
+     * each day we take the first scrobble (smallest submission_time across
+     * all tracks), then rank tracks by how many days they were that first
+     * play. Requires the scrobbles table — the annotation table has no
+     * per-play timestamp, so this returns [] on Navidrome < 0.55.
+     *
+     * Day bucketing uses `date(submission_time, 'unixepoch')` (UTC), the
+     * same convention as every other day-grouped query here.
+     *
+     * Tie note: if two tracks share the exact same minimum timestamp on a
+     * day (rare — same-second bulk import), both count for that day. We
+     * don't use a window function to break the tie, matching the repo style.
+     *
+     * @return string[] media_file ids ordered by « first of day » count DESC
+     */
+    public function getDailyKickstartTracks(int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT s.media_file_id AS id, COUNT(*) AS days
+            FROM scrobbles s
+            WHERE s.user_id = :uid
+              AND s.submission_time IN (
+                  SELECT MIN(submission_time)
+                  FROM scrobbles
+                  WHERE user_id = :uid
+                  GROUP BY date(submission_time, 'unixepoch')
+              )
+            GROUP BY s.media_file_id
+            ORDER BY COUNT(*) DESC, MAX(s.submission_time) DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
      * Top tracks within [from, to). Uses scrobbles when available, otherwise
      * falls back to annotation.play_date.
      *

--- a/src/Playlist/Definition/KickstartDefinition.php
+++ b/src/Playlist/Definition/KickstartDefinition.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Kickstart » — the tracks that most often open the listening day. Ranks
+ * songs by how many days they were the first scrobble of the day. Reuses
+ * {@see NavidromeRepository::getDailyKickstartTracks()} (already ranked by
+ * frequency desc, so no shuffle: « le top » means ordered).
+ */
+final class KickstartDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'kickstart';
+    }
+
+    public function getName(): string
+    {
+        return 'Kickstart';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Les %d morceaux qui ouvrent le plus souvent ta journée d’écoute.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        return $this->navidrome->getDailyKickstartTracks($this->limit);
+    }
+}

--- a/tests/Navidrome/NavidromeKickstartTest.php
+++ b/tests/Navidrome/NavidromeKickstartTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for getDailyKickstartTracks(): per-day first scrobble
+ * aggregated by track, ranked by how many days the track opened the day.
+ */
+class NavidromeKickstartTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testRanksTracksByHowOftenTheyOpenTheDay(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-kick-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a', 'A', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b', 'B', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-c', 'C', 'Artist');
+
+        // Day 1: a (09:00) opens, then b later.
+        self::play($conn, 'mf-a', '2024-01-01 09:00:00');
+        self::play($conn, 'mf-b', '2024-01-01 10:00:00');
+        // Day 2: a (08:00) opens, then c later.
+        self::play($conn, 'mf-a', '2024-01-02 08:00:00');
+        self::play($conn, 'mf-c', '2024-01-02 09:00:00');
+        // Day 3: b (07:30) opens.
+        self::play($conn, 'mf-b', '2024-01-03 07:30:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        // a opens 2 days, b opens 1 day, c never. c is excluded.
+        $this->assertSame(['mf-a', 'mf-b'], $repo->getDailyKickstartTracks(10));
+    }
+
+    public function testLimitCapsTheResult(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-kick-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a', 'A', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b', 'B', 'Artist');
+        self::play($conn, 'mf-a', '2024-01-01 09:00:00');
+        self::play($conn, 'mf-b', '2024-01-02 09:00:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $this->assertCount(1, $repo->getDailyKickstartTracks(1));
+    }
+
+    public function testReturnsEmptyWhenNoScrobblesTable(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-kick-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $this->assertSame([], $repo->getDailyKickstartTracks(10));
+    }
+
+    private static function play(Connection $conn, string $mediaId, string $time): void
+    {
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', $mediaId, $time);
+    }
+}

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Playlist;
 
 use App\Navidrome\NavidromeRepository;
 use App\Playlist\Definition\CoupsDeCoeurDefinition;
+use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
 use App\Playlist\Definition\TopDuMoisDefinition;
@@ -77,6 +78,19 @@ class DefinitionsTest extends TestCase
         }
     }
 
+    public function testKickstartReturnsRepoOrderWithoutShuffle(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getDailyKickstartTracks')
+            ->with(50)
+            ->willReturn(['mf-a', 'mf-b', 'mf-c']);
+
+        // No shuffle: « le top » keeps the frequency-ranked order as-is.
+        $ids = (new KickstartDefinition($navidrome, 50))->build($this->ctx('2026-06-27'));
+        $this->assertSame(['mf-a', 'mf-b', 'mf-c'], $ids);
+    }
+
     public function testSlugsAndNamesAreStable(): void
     {
         $navidrome = $this->createMock(NavidromeRepository::class);
@@ -84,6 +98,7 @@ class DefinitionsTest extends TestCase
         $this->assertSame('top-all-time', (new TopAllTimeDefinition($navidrome))->getSlug());
         $this->assertSame('pepites-oubliees', (new PepitesOublieesDefinition($navidrome))->getSlug());
         $this->assertSame('coups-de-coeur', (new CoupsDeCoeurDefinition($navidrome))->getSlug());
+        $this->assertSame('kickstart', (new KickstartDefinition($navidrome))->getSlug());
     }
 
     private function ctx(string $now): PlaylistContext


### PR DESCRIPTION
## Résumé

Nouvelle playlist **« Kickstart »** : les morceaux qui **ouvrent le plus souvent ta journée d'écoute**. Pour chaque jour, on prend le premier morceau scrobblé (plus petit `submission_time` du jour, toutes pistes confondues), puis on agrège par morceau le nombre de jours où il fut ce premier, classé décroissant.

## Changements

- **`NavidromeRepository::getDailyKickstartTracks(limit)`** : sous-requête des minima quotidiens (`date(submission_time,'unixepoch')`, UTC — convention maison, sans window function). Guard `hasScrobblesTable()` → `[]` sur Navidrome < 0.55 (l'`annotation` n'a pas d'horodatage par écoute, donc impossible d'y reconstruire le « premier du jour »).
- **`KickstartDefinition`** (slug `kickstart`) : **pas de shuffle** — « le top » garde l'ordre par fréquence du repo. Découverte automatique par le `tagged_iterator` → visible dans `--list` et l'UI sans autre changement.
- Câblage `services.yaml` (`$limit = PLAYLIST_DEFAULT_LIMIT`) ; slug ajouté à la liste documentée dans `.env.dist` (**aucune nouvelle variable**).

## Note de conception

- **All-time**, plafonné à `PLAYLIST_DEFAULT_LIMIT` (50).
- Cas limite toléré : deux pistes au même timestamp-min d'un jour comptent toutes deux pour ce jour (rare ; pas de window function pour départager, conforme au style du repo).

## Tests (221/221, phpcs clean, phpstan inchangé)

- Repo : `a` ouvre 2 jours, `b` 1 jour, `c` jamais → `['mf-a','mf-b']` ; cap `limit` ; table scrobbles absente → `[]`.
- Définition : ordre conservé (pas de shuffle), slug stable.

## Pour l'activer

`app:playlists:generate --slug=kickstart` (ou bouton « Générer » sur `/playlists`), ou l'ajouter à `PLAYLISTS_ENABLED` pour le « Tout (re)générer ».

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_