### PR TITLE
feat(playlists): nouvelle playlist « Happy birthday »

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -81,7 +81,7 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # running « tout générer » (CLI --all / UI button). Empty = none auto-run;
 # any definition can still be generated on demand by slug.
 # Available slugs: retour-en-arriere, top-du-mois, top-all-time,
-#                  pepites-oubliees, coups-de-coeur, kickstart
+#                  pepites-oubliees, coups-de-coeur, kickstart, happy-birthday
 PLAYLISTS_ENABLED=
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
@@ -94,6 +94,10 @@ PLAYLIST_RETOUR_PER_YEAR=10
 # of silence (no play) before a track counts as « forgotten ».
 PLAYLIST_PEPITES_MIN_PLAYS=5
 PLAYLIST_PEPITES_SILENCE_MONTHS=12
+# « Happy birthday » — jour anniversaire (mois / jour) dont on tire au
+# hasard les morceaux les plus écoutés, toutes années confondues.
+PLAYLIST_BIRTHDAY_MONTH=5
+PLAYLIST_BIRTHDAY_DAY=22
 ###< Playlists ###
 
 ###> Notifications ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,8 @@ parameters:
     env(PLAYLIST_RETOUR_PER_YEAR): '10'
     env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
     env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
+    env(PLAYLIST_BIRTHDAY_MONTH): '5'
+    env(PLAYLIST_BIRTHDAY_DAY): '22'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -43,6 +45,8 @@ parameters:
     playlist.retour.per_year: '%env(int:PLAYLIST_RETOUR_PER_YEAR)%'
     playlist.pepites.min_plays: '%env(int:PLAYLIST_PEPITES_MIN_PLAYS)%'
     playlist.pepites.silence_months: '%env(int:PLAYLIST_PEPITES_SILENCE_MONTHS)%'
+    playlist.birthday.month: '%env(int:PLAYLIST_BIRTHDAY_MONTH)%'
+    playlist.birthday.day: '%env(int:PLAYLIST_BIRTHDAY_DAY)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -110,6 +114,12 @@ services:
 
     App\Playlist\Definition\KickstartDefinition:
         arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\HappyBirthdayDefinition:
+        arguments:
+            $month: '%playlist.birthday.month%'
+            $day: '%playlist.birthday.day%'
             $limit: '%playlists.default_limit%'
 
     App\Playlist\Definition\PepitesOublieesDefinition:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -49,6 +49,8 @@
         <env name="PLAYLIST_RETOUR_PER_YEAR" value="10"/>
         <env name="PLAYLIST_PEPITES_MIN_PLAYS" value="5"/>
         <env name="PLAYLIST_PEPITES_SILENCE_MONTHS" value="12"/>
+        <env name="PLAYLIST_BIRTHDAY_MONTH" value="5"/>
+        <env name="PLAYLIST_BIRTHDAY_DAY" value="22"/>
     </php>
 
     <testsuites>

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -504,6 +504,45 @@ class NavidromeRepository
     }
 
     /**
+     * Top tracks ever played on a given day-of-year (e.g. every 22 May,
+     * across all years) ranked by play count. Used by the « Happy
+     * birthday » playlist. Requires the scrobbles table — the annotation
+     * table only keeps the LAST play date, so it can't recover « played on
+     * 22 May 2019 » alongside « …2022 ». Returns [] on Navidrome < 0.55.
+     *
+     * Day matched via `strftime('%m-%d', submission_time, 'unixepoch')`
+     * (UTC), the same convention as the other day-grouped queries.
+     *
+     * @return string[] media_file ids ordered by play count DESC
+     */
+    public function getTopTracksOnDayOfYear(int $month, int $day, int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $monthDay = sprintf('%02d-%02d', $month, $day);
+        $sql = <<<'SQL'
+            SELECT s.media_file_id AS id, COUNT(*) AS plays
+            FROM scrobbles s
+            WHERE s.user_id = :uid
+              AND strftime('%m-%d', s.submission_time, 'unixepoch') = :md
+            GROUP BY s.media_file_id
+            ORDER BY COUNT(*) DESC, MAX(s.submission_time) DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'md' => $monthDay, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
      * Top tracks within [from, to). Uses scrobbles when available, otherwise
      * falls back to annotation.play_date.
      *

--- a/src/Playlist/Definition/HappyBirthdayDefinition.php
+++ b/src/Playlist/Definition/HappyBirthdayDefinition.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Happy birthday » — a random selection among the tracks you played the
+ * most on your birthday (a fixed month/day, every year). Reuses
+ * {@see NavidromeRepository::getTopTracksOnDayOfYear()}: it fetches the
+ * top `limit` tracks ranked by play count on that day-of-year, then
+ * shuffles them so the playlist order is random.
+ */
+final class HappyBirthdayDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $month = 5,
+        private readonly int $day = 22,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'happy-birthday';
+    }
+
+    public function getName(): string
+    {
+        return 'Happy birthday';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            '%d morceaux au hasard parmi tes plus écoutés un %02d/%02d, toutes années confondues.',
+            $this->limit,
+            $this->day,
+            $this->month,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $ids = $this->navidrome->getTopTracksOnDayOfYear($this->month, $this->day, $this->limit);
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Navidrome/NavidromeDayOfYearTest.php
+++ b/tests/Navidrome/NavidromeDayOfYearTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for getTopTracksOnDayOfYear(): aggregates every play
+ * on a given month/day across all years, ranked by play count.
+ */
+class NavidromeDayOfYearTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testAggregatesPlaysOnTheSameDayAcrossYears(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-doy-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a', 'A', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b', 'B', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-c', 'C', 'Artist');
+
+        // 22 May, two different years → mf-a is the day's top (3 plays).
+        self::play($conn, 'mf-a', '2021-05-22 10:00:00');
+        self::play($conn, 'mf-a', '2022-05-22 11:00:00');
+        self::play($conn, 'mf-a', '2023-05-22 12:00:00');
+        self::play($conn, 'mf-b', '2022-05-22 13:00:00');
+        // mf-c only ever played on OTHER days → excluded.
+        self::play($conn, 'mf-c', '2022-05-23 10:00:00');
+        self::play($conn, 'mf-c', '2022-06-22 10:00:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $this->assertSame(['mf-a', 'mf-b'], $repo->getTopTracksOnDayOfYear(5, 22, 10));
+    }
+
+    public function testReturnsEmptyWhenNoScrobblesTable(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-doy-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $this->assertSame([], $repo->getTopTracksOnDayOfYear(5, 22, 10));
+    }
+
+    private static function play(Connection $conn, string $mediaId, string $time): void
+    {
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', $mediaId, $time);
+    }
+}

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Playlist;
 
 use App\Navidrome\NavidromeRepository;
 use App\Playlist\Definition\CoupsDeCoeurDefinition;
+use App\Playlist\Definition\HappyBirthdayDefinition;
 use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
@@ -91,6 +92,20 @@ class DefinitionsTest extends TestCase
         $this->assertSame(['mf-a', 'mf-b', 'mf-c'], $ids);
     }
 
+    public function testHappyBirthdayQueriesConfiguredDayAndShuffles(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getTopTracksOnDayOfYear')
+            ->with(5, 22, 50)
+            ->willReturn(['mf-a', 'mf-b', 'mf-c']);
+
+        $ids = (new HappyBirthdayDefinition($navidrome, month: 5, day: 22, limit: 50))->build($this->ctx('2026-06-27'));
+
+        sort($ids); // shuffled → assert the set.
+        $this->assertSame(['mf-a', 'mf-b', 'mf-c'], $ids);
+    }
+
     public function testSlugsAndNamesAreStable(): void
     {
         $navidrome = $this->createMock(NavidromeRepository::class);
@@ -99,6 +114,7 @@ class DefinitionsTest extends TestCase
         $this->assertSame('pepites-oubliees', (new PepitesOublieesDefinition($navidrome))->getSlug());
         $this->assertSame('coups-de-coeur', (new CoupsDeCoeurDefinition($navidrome))->getSlug());
         $this->assertSame('kickstart', (new KickstartDefinition($navidrome))->getSlug());
+        $this->assertSame('happy-birthday', (new HappyBirthdayDefinition($navidrome))->getSlug());
     }
 
     private function ctx(string $now): PlaylistContext


### PR DESCRIPTION
## Résumé

Nouvelle playlist **« Happy birthday »** : 50 morceaux **au hasard** parmi tes plus écoutés un **jour anniversaire** (par défaut le **22 mai**), toutes années confondues.

## Changements

- **`NavidromeRepository::getTopTracksOnDayOfYear(month, day, limit)`** : top par nombre d'écoutes des morceaux joués un jour-mois donné, matché via `strftime('%m-%d', submission_time, 'unixepoch')` (UTC). Guard `hasScrobblesTable()` → `[]` sur Navidrome < 0.55 (l'`annotation` ne garde que la dernière date de lecture — insuffisant pour « joué un 22 mai de 2019 *et* de 2022 »).
  - Pourquoi une nouvelle méthode : `getTopTracksWithDates` ne peut pas le faire, car `DateCascadeFilter::parse` abandonne mois/jour quand l'année est absente.
- **`HappyBirthdayDefinition`** (slug `happy-birthday`) : date **configurable** (`month`/`day`), récupère le top `limit` puis `shuffle`. Découverte automatique par le `tagged_iterator`.
- **Config** : params `playlist.birthday.month/day`, défauts `env(...)` 5/22 (optionnels), câblage `services.yaml`, vars `.env.dist` + `phpunit.xml.dist`, slug ajouté à la liste documentée.

## Note de conception

- Date **configurable** plutôt que codée en dur : c'est un anniversaire, tu mets le tien via `PLAYLIST_BIRTHDAY_MONTH` / `PLAYLIST_BIRTHDAY_DAY` (défaut 22/05 comme demandé).
- « En random parmi le top » = on prend les `limit` (50) morceaux les plus écoutés ce jour-là, puis on mélange l'ordre.

## Tests (224/224, phpcs clean, phpstan inchangé)

- Repo : agrège plusieurs années d'un 22 mai (mf-a 3 plays → top, mf-b 1, mf-c jamais ce jour → exclu) ; table scrobbles absente → `[]`.
- Définition : interroge le jour configuré, shuffle (assert d'ensemble), slug stable.

## Pour l'activer

`app:playlists:generate --slug=happy-birthday`, bouton « Générer » sur `/playlists`, ou ajouter `happy-birthday` à `PLAYLISTS_ENABLED`. Règle ta date via `PLAYLIST_BIRTHDAY_MONTH`/`_DAY`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_