### PR TITLE
feat(playlists): nouvelle playlist « Hit parade »

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -81,7 +81,8 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # running « tout générer » (CLI --all / UI button). Empty = none auto-run;
 # any definition can still be generated on demand by slug.
 # Available slugs: retour-en-arriere, top-du-mois, top-all-time,
-#                  pepites-oubliees, coups-de-coeur, kickstart, happy-birthday
+#                  pepites-oubliees, coups-de-coeur, kickstart, happy-birthday,
+#                  hit-parade
 PLAYLISTS_ENABLED=
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
@@ -98,6 +99,10 @@ PLAYLIST_PEPITES_SILENCE_MONTHS=12
 # hasard les morceaux les plus écoutés, toutes années confondues.
 PLAYLIST_BIRTHDAY_MONTH=5
 PLAYLIST_BIRTHDAY_DAY=22
+# « Hit parade » — top N de chacune des dernières semaines (fenêtres
+# glissantes de 7 jours).
+PLAYLIST_HITPARADE_WEEKS=52
+PLAYLIST_HITPARADE_PER_WEEK=3
 ###< Playlists ###
 
 ###> Notifications ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -13,6 +13,8 @@ parameters:
     env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
     env(PLAYLIST_BIRTHDAY_MONTH): '5'
     env(PLAYLIST_BIRTHDAY_DAY): '22'
+    env(PLAYLIST_HITPARADE_WEEKS): '52'
+    env(PLAYLIST_HITPARADE_PER_WEEK): '3'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -47,6 +49,8 @@ parameters:
     playlist.pepites.silence_months: '%env(int:PLAYLIST_PEPITES_SILENCE_MONTHS)%'
     playlist.birthday.month: '%env(int:PLAYLIST_BIRTHDAY_MONTH)%'
     playlist.birthday.day: '%env(int:PLAYLIST_BIRTHDAY_DAY)%'
+    playlist.hitparade.weeks: '%env(int:PLAYLIST_HITPARADE_WEEKS)%'
+    playlist.hitparade.per_week: '%env(int:PLAYLIST_HITPARADE_PER_WEEK)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -121,6 +125,11 @@ services:
             $month: '%playlist.birthday.month%'
             $day: '%playlist.birthday.day%'
             $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\HitParadeDefinition:
+        arguments:
+            $weeks: '%playlist.hitparade.weeks%'
+            $perWeek: '%playlist.hitparade.per_week%'
 
     App\Playlist\Definition\PepitesOublieesDefinition:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -51,6 +51,8 @@
         <env name="PLAYLIST_PEPITES_SILENCE_MONTHS" value="12"/>
         <env name="PLAYLIST_BIRTHDAY_MONTH" value="5"/>
         <env name="PLAYLIST_BIRTHDAY_DAY" value="22"/>
+        <env name="PLAYLIST_HITPARADE_WEEKS" value="52"/>
+        <env name="PLAYLIST_HITPARADE_PER_WEEK" value="3"/>
     </php>
 
     <testsuites>

--- a/src/Playlist/Definition/HitParadeDefinition.php
+++ b/src/Playlist/Definition/HitParadeDefinition.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Hit parade » — the top `perWeek` tracks of each of the last `weeks`
+ * rolling 7-day windows, unioned from the most recent week to the oldest
+ * (dedup, first-seen order — no shuffle). A running weekly chart of the
+ * past year.
+ *
+ * Reuses {@see NavidromeRepository::topTracksInWindow()} once per week
+ * (per-window top-N, which `topTracksInWindows()` can't do since it caps
+ * the whole union). No Subsonic dependency here.
+ */
+final class HitParadeDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $weeks = 52,
+        private readonly int $perWeek = 3,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'hit-parade';
+    }
+
+    public function getName(): string
+    {
+        return 'Hit parade';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Le top %d de chacune des %d dernières semaines, de la plus récente à la plus ancienne.',
+            $this->perWeek,
+            $this->weeks,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $now = $context->now;
+        $ids = [];
+        $seen = [];
+
+        // Week 1 = the most recent 7 days, … week N = N*7 days ago. The
+        // loop walks recent → old, so the list flows that way as-is.
+        for ($w = 1; $w <= $this->weeks; $w++) {
+            $end = $now->modify(sprintf('-%d days', ($w - 1) * 7));
+            $start = $now->modify(sprintf('-%d days', $w * 7));
+            foreach ($this->navidrome->topTracksInWindow($start, $end, $this->perWeek) as $id) {
+                if (!isset($seen[$id])) {
+                    $seen[$id] = true;
+                    $ids[] = $id;
+                }
+            }
+        }
+
+        return $ids;
+    }
+}

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Playlist;
 use App\Navidrome\NavidromeRepository;
 use App\Playlist\Definition\CoupsDeCoeurDefinition;
 use App\Playlist\Definition\HappyBirthdayDefinition;
+use App\Playlist\Definition\HitParadeDefinition;
 use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
@@ -106,6 +107,29 @@ class DefinitionsTest extends TestCase
         $this->assertSame(['mf-a', 'mf-b', 'mf-c'], $ids);
     }
 
+    public function testHitParadeQueriesEachWeekRecentFirstAndDedupes(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+
+        $captured = [];
+        $navidrome->method('topTracksInWindow')->willReturnCallback(
+            function (\DateTimeInterface $from, \DateTimeInterface $to, int $limit) use (&$captured): array {
+                $captured[] = [$from->format('Y-m-d'), $to->format('Y-m-d'), $limit];
+
+                // Week 1 → [a, b]; week 2 → [b, c]. Union dedup = [a, b, c].
+                return count($captured) === 1 ? ['a', 'b'] : ['b', 'c'];
+            },
+        );
+
+        $ids = (new HitParadeDefinition($navidrome, weeks: 2, perWeek: 3))->build($this->ctx('2026-06-27'));
+
+        // Two 7-day windows, most recent first, top-3 each.
+        $this->assertSame(['2026-06-20', '2026-06-27', 3], $captured[0]);
+        $this->assertSame(['2026-06-13', '2026-06-20', 3], $captured[1]);
+        // No shuffle: deterministic, recent week first, deduped.
+        $this->assertSame(['a', 'b', 'c'], $ids);
+    }
+
     public function testSlugsAndNamesAreStable(): void
     {
         $navidrome = $this->createMock(NavidromeRepository::class);
@@ -115,6 +139,7 @@ class DefinitionsTest extends TestCase
         $this->assertSame('coups-de-coeur', (new CoupsDeCoeurDefinition($navidrome))->getSlug());
         $this->assertSame('kickstart', (new KickstartDefinition($navidrome))->getSlug());
         $this->assertSame('happy-birthday', (new HappyBirthdayDefinition($navidrome))->getSlug());
+        $this->assertSame('hit-parade', (new HitParadeDefinition($navidrome))->getSlug());
     }
 
     private function ctx(string $now): PlaylistContext


### PR DESCRIPTION
## Résumé

Nouvelle playlist **« Hit parade »** : le **top 3 de chacune des 52 dernières semaines** (fenêtres glissantes de 7 jours), union dédupliquée, de la plus récente à la plus ancienne — un classement hebdo glissant de l'année écoulée (~jusqu'à 156 morceaux).

## Changements

- **`HitParadeDefinition`** (slug `hit-parade`) : boucle `weeks` semaines, `topTracksInWindow(start, end, perWeek)` par fenêtre, union dédupliquée (ordre de 1re apparition), **pas de shuffle** (chronologique récent→ancien comme « Retour en arrière »).
- **Réutilise `topTracksInWindow()`** une fois par semaine — pas de nouvelle requête repo. (`topTracksInWindows()` ne convient pas : il plafonne l'union entière, pas un top-N par fenêtre.)
- **Configurable** : `weeks` (52) et `perWeek` (3) via `PLAYLIST_HITPARADE_WEEKS` / `PLAYLIST_HITPARADE_PER_WEEK` (défauts optionnels).
- Câblage `services.yaml`, vars `.env.dist` + `phpunit.xml.dist`, slug ajouté à la liste documentée.

## Tests (225/225, phpcs clean, phpstan inchangé)

- Définition : appelle `topTracksInWindow` une fois par semaine, fenêtres de 7 j contiguës **récent d'abord** (`[06-20,06-27)` puis `[06-13,06-20)`), top-3, union dédupliquée déterministe `['a','b','c']` ; slug stable.

## Pour l'activer

`app:playlists:generate --slug=hit-parade`, bouton « Générer » sur `/playlists`, ou ajouter `hit-parade` à `PLAYLISTS_ENABLED`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_