### PR TITLE
feat(playlists): écrit la description comme commentaire de la playlist

### DIFF
--- a/src/Playlist/PlaylistGenerator.php
+++ b/src/Playlist/PlaylistGenerator.php
@@ -117,6 +117,7 @@ class PlaylistGenerator
         $existing = $this->subsonic->findPlaylistByName($def->getName());
         if ($existing !== null) {
             $this->subsonic->replacePlaylist($existing['id'], $def->getName(), $ids);
+            $this->stampDescription($existing['id'], $def);
 
             return new PlaylistRunResult(
                 $def->getSlug(),
@@ -128,8 +129,22 @@ class PlaylistGenerator
         }
 
         $newId = $this->subsonic->createPlaylist($def->getName(), $ids);
+        $this->stampDescription($newId, $def);
 
         return new PlaylistRunResult($def->getSlug(), $def->getName(), PlaylistRunResult::ACTION_CREATED, $ids, $newId);
+    }
+
+    /**
+     * Write the definition's description onto the Navidrome playlist as its
+     * comment, so a listener can see how the playlist is computed. Subsonic
+     * `createPlaylist` can't carry a comment, hence this follow-up call.
+     */
+    private function stampDescription(string $playlistId, PlaylistDefinitionInterface $def): void
+    {
+        $description = $def->getDescription();
+        if ($description !== '') {
+            $this->subsonic->updatePlaylist($playlistId, comment: $description);
+        }
     }
 
     /**

--- a/src/Subsonic/SubsonicClient.php
+++ b/src/Subsonic/SubsonicClient.php
@@ -177,6 +177,30 @@ class SubsonicClient
     }
 
     /**
+     * Update a playlist's metadata (name / comment) in place. Subsonic
+     * `createPlaylist` can't carry a comment, so the generator calls this
+     * after writing the songs to stamp the « how this playlist is computed »
+     * description onto the Navidrome `comment` field. Only the non-null
+     * params are sent.
+     */
+    public function updatePlaylist(string $playlistId, ?string $name = null, ?string $comment = null): void
+    {
+        if ($playlistId === '') {
+            throw new \RuntimeException('updatePlaylist requires a non-empty playlistId.');
+        }
+
+        $params = ['playlistId' => $playlistId];
+        if ($name !== null) {
+            $params['name'] = $name;
+        }
+        if ($comment !== null) {
+            $params['comment'] = $comment;
+        }
+
+        $this->call('updatePlaylist', $params);
+    }
+
+    /**
      * Find one playlist owned by the configured user whose name matches
      * exactly (case-sensitive, as Navidrome stores it). Returns the
      * normalized {@see getPlaylists()} row or null. Used by the generator

--- a/tests/Playlist/PlaylistGeneratorTest.php
+++ b/tests/Playlist/PlaylistGeneratorTest.php
@@ -22,6 +22,10 @@ class PlaylistGeneratorTest extends TestCase
             ->method('createPlaylist')
             ->with('Enabled One', ['mf-1', 'mf-2'])
             ->willReturn('pl-new');
+        // Description stamped as the playlist comment after creation.
+        $subsonic->expects($this->once())
+            ->method('updatePlaylist')
+            ->with('pl-new', null, 'desc enabled-one');
 
         $gen = new PlaylistGenerator([$enabled, $disabled], 'enabled-one', $subsonic);
         $results = $gen->generate(null, dryRun: false);
@@ -66,6 +70,8 @@ class PlaylistGeneratorTest extends TestCase
         ]);
         $subsonic->expects($this->once())->method('replacePlaylist')->with('pl-existing', 'A', ['mf-1', 'mf-2']);
         $subsonic->expects($this->never())->method('createPlaylist');
+        // Comment refreshed on the existing playlist too.
+        $subsonic->expects($this->once())->method('updatePlaylist')->with('pl-existing', null, 'desc a');
 
         $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
 
@@ -80,6 +86,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->expects($this->never())->method('createPlaylist');
         $subsonic->expects($this->never())->method('replacePlaylist');
         $subsonic->expects($this->never())->method('findPlaylistByName');
+        $subsonic->expects($this->never())->method('updatePlaylist');
 
         $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: true);
 
@@ -93,6 +100,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic = $this->createMock(SubsonicClient::class);
         $subsonic->expects($this->never())->method('createPlaylist');
         $subsonic->expects($this->never())->method('replacePlaylist');
+        $subsonic->expects($this->never())->method('updatePlaylist');
 
         $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
 

--- a/tests/Subsonic/SubsonicClientTest.php
+++ b/tests/Subsonic/SubsonicClientTest.php
@@ -260,6 +260,37 @@ class SubsonicClientTest extends TestCase
         $client->replacePlaylist('', 'X', ['mf-1']);
     }
 
+    public function testUpdatePlaylistSendsCommentAndPlaylistId(): void
+    {
+        $captured = null;
+        $http = new MockHttpClient(function (string $method, string $url) use (&$captured): MockResponse {
+            $captured = $url;
+
+            return new MockResponse($this->envelope(['status' => 'ok']));
+        });
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $client->updatePlaylist('pl-1', comment: 'Top 3 de chaque semaine');
+
+        $this->assertIsString($captured);
+        $this->assertStringContainsString('updatePlaylist.view?', $captured);
+        $this->assertStringContainsString('playlistId=pl-1', $captured);
+        parse_str(parse_url($captured, \PHP_URL_QUERY) ?: '', $q);
+        $this->assertSame('Top 3 de chaque semaine', $q['comment'] ?? null);
+        // name omitted → not sent.
+        $this->assertArrayNotHasKey('name', $q);
+    }
+
+    public function testUpdatePlaylistRejectsEmptyId(): void
+    {
+        $http = new MockHttpClient([]);
+        $client = new SubsonicClient($http, 'http://nd:4533', 'admin', 'pwd');
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('non-empty playlistId');
+        $client->updatePlaylist('', comment: 'x');
+    }
+
     public function testFindPlaylistByNameMatchesNameAndOwner(): void
     {
         $payload = $this->envelope([


### PR DESCRIPTION
## Résumé

Chaque définition expose déjà un `getDescription()` qui **explique comment la playlist est calculée**, mais il n'était pas écrit dans Navidrome. On le pose désormais comme **commentaire** de la playlist — visible sur `/playlists` (déjà affiché via `p.comment`) et dans les clients Subsonic.

## Changements

- Subsonic `createPlaylist` ne porte pas de commentaire → **`SubsonicClient::updatePlaylist(playlistId, name?, comment?)`** (n'envoie que les params non-null).
- **`PlaylistGenerator`** : après `create`/`replace`, appelle `updatePlaylist(playlistId, comment: getDescription())` (helper `stampDescription`). Rien en dry-run ni sur résultat vide. Un appel HTTP de plus par playlist écrite (job CLI/async, acceptable).

Exemples de commentaires obtenus : *« Top 3 de chacune des 52 dernières semaines, de la plus récente à la plus ancienne. »*, *« Les morceaux qui ouvrent le plus souvent ta journée d'écoute. »*, *« 50 morceaux au hasard parmi tes plus écoutés un 22/05, toutes années confondues. »*

## Tests (227/227, phpcs clean, phpstan inchangé)

- SubsonicClient : `updatePlaylist` envoie `playlistId=` + `comment=` (name omis si null), garde sur id vide.
- Générateur : commentaire posé après create **et** replace (avec la description) ; **jamais** en dry-run ni sur résultat vide.

## Pour le voir

Régénère une playlist (bouton « Régénérer » ou `--slug=…`) → le commentaire apparaît sur `/playlists` et dans ton client Subsonic/Navidrome.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_