### PR TITLE
fix(ci): startup_failure — `${{ }}` vide dans un commentaire de run block

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,8 +154,10 @@ jobs:
           STATE: ${{ steps.status.outputs.state }}
           EMOJI: ${{ steps.status.outputs.emoji }}
         run: |
-          # Build the message from runner-provided env vars (never inline
-          # ${{ }} into the script — a crafted branch name could inject).
+          # Build the message from runner-provided env vars. Never inline
+          # workflow template expressions into the script (a crafted branch
+          # name could inject) — and note GitHub parses such expressions even
+          # inside run blocks, so don't write the empty-braces token here.
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           MSG="${EMOJI} CI ${STATE} — ${GITHUB_REPOSITORY} @ ${GITHUB_REF_NAME} (${GITHUB_SHA:0:7}) · ${GITHUB_EVENT_NAME} · ${RUN_URL}"
 


### PR DESCRIPTION
## Diagnostic

Depuis #211 (ajout du job `notify`), **toutes les CI échouent en `startup_failure`** : le run se termine instantanément en *failure* avec **0 job exécuté** (vu via l'API : `run_started_at == updated_at`, `total_count: 0`).

Cause : le commentaire à l'intérieur du bloc `run:` du job `notify` contenait un token **`${{ }}` vide**. GitHub évalue les expressions `${{ … }}` **partout, y compris dans les scripts `run:`** — un `${{ }}` vide est une expression invalide → le workflow ne parse plus → aucun job ne démarre. (Ironie : c'était le commentaire qui expliquait pourquoi ne pas inliner de `${{ }}` dans le script.)

## Correctif

Reformulation du commentaire pour supprimer le token braces-vides. Aucune autre modification. Audit : toutes les occurrences `${{ }}` restantes sont des expressions valides en contexte `env:`/`with:`.

## Vérification

Le run de cette PR doit repasser **vert** (jobs phpcs/phpstan/tests/docker-build qui s'exécutent réellement). Je ne merge qu'après confirmation.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_