### PR TITLE
feat(docker): planificateur Ofelia pour la régénération des playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,26 @@ Points d'attention (prod) :
 - `scripts/navidrome-sync.sh.example` : wrapper bash pour orchestrer un cycle
   complet en crontab.
 
+### Planification de la (re)génération des playlists
+
+`docker-compose.example.yml` embarque un service **Ofelia** (`navidrome-tools-scheduler`)
+qui planifie la régénération des playlists sans crontab hôte. Les jobs sont
+déclarés en **labels** sur le conteneur `navidrome-tools-web` :
+
+```yaml
+labels:
+  ofelia.enabled: "true"
+  ofelia.job-exec.playlists-all.schedule: "0 0 4 * * *"   # cron 6 champs : tous les jours à 4h
+  ofelia.job-exec.playlists-all.command: "php bin/console app:playlists:generate --all"
+```
+
+- `--all` ne régénère que les slugs listés dans `PLAYLISTS_ENABLED` ; pour une
+  seule playlist, un job avec `--slug=<slug>` (et sa propre cadence).
+- Le scheduler lit le **socket Docker** (monté en `:ro`) — accès large à l'hôte ;
+  pour durcir, passer par un proxy type `tecnativa/docker-socket-proxy`.
+- Sans planificateur, la commande reste lançable à la main ou via un crontab
+  hôte : `docker compose exec -T navidrome-tools-web php bin/console app:playlists:generate --all`.
+
 ---
 
 ## Configuration

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -41,6 +41,21 @@ services:
       # - /path/to/strawberry/data:/data/strawberry
       # Optionnel : socket Docker pour start/stop Navidrome depuis l'UI
       # - /var/run/docker.sock:/var/run/docker.sock
+    # Planification (cron) de la (re)génération des playlists via Ofelia.
+    # Le service navidrome-tools-scheduler (plus bas) lit ces labels et
+    # exécute la commande DANS ce conteneur. Cadence au format cron Ofelia :
+    # 6 champs « sec min heure jour mois jour-semaine ».
+    # Rappel : --all ne régénère que les slugs listés dans PLAYLISTS_ENABLED
+    # (sinon no-op). Pour cibler une playlist, utilisez --slug=<slug>.
+    labels:
+      ofelia.enabled: "true"
+      # Toutes les playlists activées, chaque jour à 4h00.
+      ofelia.job-exec.playlists-all.schedule: "0 0 4 * * *"
+      ofelia.job-exec.playlists-all.command: "php bin/console app:playlists:generate --all"
+      # Exemple d'un job dédié à une playlist avec sa propre cadence
+      # (décommentez/adaptez si vous ne voulez pas tout régénérer en bloc) :
+      # ofelia.job-exec.top-du-mois.schedule: "0 0 5 1 * *"   # le 1er du mois à 5h00
+      # ofelia.job-exec.top-du-mois.command: "php bin/console app:playlists:generate --slug=top-du-mois"
 
   # Worker Symfony Messenger — consomme la file des jobs lancés depuis l'UI
   # (fetch Last.fm, sync Navidrome, sync Strawberry, rematch…).
@@ -77,6 +92,23 @@ services:
       - /path/to/navidrome/data/navidrome.db:/data/navidrome.db  # RW pour le sync
       # - /path/to/strawberry/data:/data/strawberry
       # - /var/run/docker.sock:/var/run/docker.sock
+
+  # Planificateur Ofelia — déclenche les jobs définis par les labels
+  # ofelia.* du conteneur navidrome-tools-web (ici : régénération des
+  # playlists). Léger, configuré entièrement par labels, aucune image
+  # maison à maintenir.
+  #
+  # Sécurité : le socket Docker donne un accès équivalent root sur l'hôte.
+  # Il est monté en lecture seule (:ro) ; pour durcir, intercalez un proxy
+  # type tecnativa/docker-socket-proxy plutôt que de l'exposer directement.
+  navidrome-tools-scheduler:
+    image: mcuadros/ofelia:latest
+    restart: unless-stopped
+    depends_on:
+      - navidrome-tools-web
+    command: daemon --docker
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
 
 volumes:
   navidrome-tools-data:


### PR DESCRIPTION
Closes #213.

## Résumé

Ajoute un **planificateur versionné** dans la stack Docker pour régénérer les playlists sans crontab hôte : service **Ofelia** (`mcuadros/ofelia`) configuré par **labels** sur le conteneur `navidrome-tools-web`.

## Changements

- `docker-compose.example.yml` :
  - nouveau service `navidrome-tools-scheduler` (Ofelia, `daemon --docker`, socket monté `:ro`).
  - labels d'exemple sur `navidrome-tools-web` : job `playlists-all` tous les jours à 4h (`app:playlists:generate --all`), + exemple commenté d'un job `--slug` avec sa propre cadence.
- `README.md` : section *« Planification de la (re)génération des playlists »* (format cron 6 champs, rappel que `--all` ne couvre que `PLAYLISTS_ENABLED`, note sécurité socket Docker, fallback `docker compose exec`).

## Notes

- **Sécurité** : le socket Docker = accès large à l'hôte ; monté en lecture seule, avec mention du durcissement possible via `tecnativa/docker-socket-proxy`.
- Aucun code PHP modifié (docs + compose). La CI valide phpcs/phpstan/phpunit inchangés.

## Vérif

- `docker-compose.example.yml` parse (YAML OK, 3 services).
- Je confirme la CI verte avant merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_