### PR TITLE
feat(playlists): « Tout générer » couvre toutes les playlists (suppr. PLAYLISTS_ENABLED)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -77,13 +77,11 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 ###< Help page ###
 
 ###> Playlists ###
-# Comma-separated slugs of playlist definitions to (re)generate when
-# running « tout générer » (CLI --all / UI button). Empty = none auto-run;
-# any definition can still be generated on demand by slug.
-# Available slugs: retour-en-arriere, top-du-mois, top-all-time,
-#                  pepites-oubliees, coups-de-coeur, kickstart, happy-birthday,
-#                  hit-parade
-PLAYLISTS_ENABLED=
+# « Tout (re)générer » (CLI --all / bouton UI) régénère TOUTES les
+# playlists définies ; --slug=<slug> en cible une seule.
+# Slugs disponibles : retour-en-arriere, top-du-mois, top-all-time,
+#                     pepites-oubliees, coups-de-coeur, kickstart,
+#                     happy-birthday, hit-parade
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,7 +4,6 @@ parameters:
     # var (.env, docker-compose, phpunit) always overrides these. `default::`
     # is unfit for the ints (it falls back to 0 → empty/broken playlists),
     # hence parameter-level defaults with real values.
-    env(PLAYLISTS_ENABLED): ''
     env(PLAYLIST_DEFAULT_LIMIT): '50'
     env(PLAYLIST_RETOUR_MAX_YEARS): '25'
     env(PLAYLIST_RETOUR_WINDOW_DAYS): '30'
@@ -40,7 +39,6 @@ parameters:
     lidarr.url: '%env(default::LIDARR_URL)%'
     help.compose_service: '%env(default::HELP_COMPOSE_SERVICE)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
-    playlists.enabled: '%env(PLAYLISTS_ENABLED)%'
     playlists.default_limit: '%env(int:PLAYLIST_DEFAULT_LIMIT)%'
     playlist.retour.max_years: '%env(int:PLAYLIST_RETOUR_MAX_YEARS)%'
     playlist.retour.window_days: '%env(int:PLAYLIST_RETOUR_WINDOW_DAYS)%'
@@ -95,7 +93,6 @@ services:
     App\Playlist\PlaylistGenerator:
         arguments:
             $definitions: !tagged_iterator app.playlist_definition
-            $enabledCsv: '%playlists.enabled%'
             $defaultLimit: '%playlists.default_limit%'
 
     App\Playlist\Definition\RetourEnArriereDefinition:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -42,7 +42,6 @@
         <env name="NOTIFY_DISCORD_WEBHOOK_URL" value=""/>
         <env name="NOTIFY_PUSHOVER_TOKEN" value=""/>
         <env name="NOTIFY_PUSHOVER_USER" value=""/>
-        <env name="PLAYLISTS_ENABLED" value=""/>
         <env name="PLAYLIST_DEFAULT_LIMIT" value="50"/>
         <env name="PLAYLIST_RETOUR_MAX_YEARS" value="25"/>
         <env name="PLAYLIST_RETOUR_WINDOW_DAYS" value="30"/>

--- a/src/Command/GeneratePlaylistsCommand.php
+++ b/src/Command/GeneratePlaylistsCommand.php
@@ -21,13 +21,13 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *   app:playlists:generate --slug=retour-en-arriere [--dry-run]
  *   app:playlists:generate --all [--dry-run]
  *
- * `--slug` generates exactly one definition (regardless of PLAYLISTS_ENABLED);
- * `--all` generates every enabled one. `--dry-run` resolves and prints the
- * track list without writing anything to Navidrome.
+ * `--slug` generates exactly one definition; `--all` generates every
+ * defined playlist. `--dry-run` resolves and prints the track list without
+ * writing anything to Navidrome.
  */
 #[AsCommand(
     name: 'app:playlists:generate',
-    description: 'Generate algorithmic playlists in Navidrome (one via --slug, or all enabled via --all).',
+    description: 'Generate algorithmic playlists in Navidrome (one via --slug, or all via --all).',
 )]
 class GeneratePlaylistsCommand extends Command
 {
@@ -43,7 +43,7 @@ class GeneratePlaylistsCommand extends Command
     {
         $this
             ->addOption('slug', null, InputOption::VALUE_REQUIRED, 'Generate only this playlist definition.')
-            ->addOption('all', null, InputOption::VALUE_NONE, 'Generate every enabled playlist definition.')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Generate every defined playlist.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Resolve and print tracks without writing to Navidrome.')
             ->addOption('list', null, InputOption::VALUE_NONE, 'List available playlist definitions and exit.');
     }
@@ -62,7 +62,7 @@ class GeneratePlaylistsCommand extends Command
         $dryRun = (bool) $input->getOption('dry-run');
 
         if ($slug === null && !$all) {
-            $io->error('Précisez --slug=<slug> pour une playlist, ou --all pour toutes les playlists activées. (--list pour la liste.)');
+            $io->error('Précisez --slug=<slug> pour une playlist, ou --all pour toutes. (--list pour la liste.)');
             return Command::INVALID;
         }
         if ($slug !== null && $all) {
@@ -95,9 +95,9 @@ class GeneratePlaylistsCommand extends Command
     {
         $rows = [];
         foreach ($this->generator->listDefinitions() as $d) {
-            $rows[] = [$d['slug'], $d['name'], $d['enabled'] ? '✓' : '—', $d['description']];
+            $rows[] = [$d['slug'], $d['name'], $d['description']];
         }
-        $io->table(['slug', 'nom', 'activé', 'description'], $rows);
+        $io->table(['slug', 'nom', 'description'], $rows);
 
         return Command::SUCCESS;
     }
@@ -108,7 +108,7 @@ class GeneratePlaylistsCommand extends Command
     private function printResults(SymfonyStyle $io, array $results, bool $dryRun): void
     {
         if ($results === []) {
-            $io->warning('Aucune playlist générée (aucune définition activée ? voir PLAYLISTS_ENABLED).');
+            $io->warning('Aucune playlist définie.');
             return;
         }
 

--- a/src/Playlist/PlaylistDefinitionInterface.php
+++ b/src/Playlist/PlaylistDefinitionInterface.php
@@ -17,7 +17,7 @@ interface PlaylistDefinitionInterface
 {
     /**
      * Stable identifier, lowercase-kebab (e.g. "retour-en-arriere"). Used
-     * as the CLI `--slug` value and the `PLAYLISTS_ENABLED` CSV token.
+     * as the CLI `--slug` value and the per-row UI button target.
      */
     public function getSlug(): string;
 

--- a/src/Playlist/PlaylistGenerator.php
+++ b/src/Playlist/PlaylistGenerator.php
@@ -8,16 +8,13 @@ use Psr\Log\NullLogger;
 
 /**
  * Orchestrates the playlist-definition plugins: discovers every service
- * tagged `app.playlist_definition`, decides which ones run, builds their
- * track lists and writes them to Navidrome via Subsonic. Mirrors
- * {@see \App\Notifier\Notifier} (tagged iterator + CSV enable list +
- * best-effort per-item isolation).
+ * tagged `app.playlist_definition`, builds their track lists and writes
+ * them to Navidrome via Subsonic. Mirrors {@see \App\Notifier\Notifier}
+ * (tagged iterator + best-effort per-item isolation).
  *
- * Enablement model:
- *   - `PLAYLISTS_ENABLED` (CSV of slugs) gates the « generate all » run
- *     (`generate(null)`), so a fresh install ships nothing until opted in.
- *   - An explicit `generate($slug)` (CLI `--slug`, per-row UI button)
- *     bypasses the CSV — generating one by name is an explicit intent.
+ * `generate(null)` regenerates EVERY defined playlist; `generate($slug)`
+ * just that one. (There is no enable/disable list — « generate all » means
+ * all.)
  *
  * Idempotent write: a playlist of the same name owned by the configured
  * user is overwritten in place; otherwise a new one is created.
@@ -27,25 +24,20 @@ class PlaylistGenerator
     /** @var list<PlaylistDefinitionInterface> */
     private readonly array $definitions;
 
-    /** @var list<string> */
-    private readonly array $enabledSlugs;
-
     /**
      * @param iterable<PlaylistDefinitionInterface> $definitions
      */
     public function __construct(
         iterable $definitions,
-        string $enabledCsv,
         private readonly SubsonicClient $subsonic,
         private readonly int $defaultLimit = 50,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
         $this->definitions = is_array($definitions) ? array_values($definitions) : iterator_to_array($definitions, false);
-        $this->enabledSlugs = self::parseCsv($enabledCsv);
     }
 
     /**
-     * @return list<array{slug: string, name: string, description: string, enabled: bool}>
+     * @return list<array{slug: string, name: string, description: string}>
      */
     public function listDefinitions(): array
     {
@@ -55,7 +47,6 @@ class PlaylistGenerator
                 'slug' => $def->getSlug(),
                 'name' => $def->getName(),
                 'description' => $def->getDescription(),
-                'enabled' => in_array($def->getSlug(), $this->enabledSlugs, true),
             ];
         }
 
@@ -65,8 +56,8 @@ class PlaylistGenerator
     /**
      * Generate playlists and (unless dry-run) write them to Navidrome.
      *
-     * @param ?string $slug   null → every ENABLED definition ; a slug →
-     *                        that one definition regardless of the CSV.
+     * @param ?string $slug   null → every defined playlist ; a slug → that
+     *                        one definition.
      *
      * @return list<PlaylistRunResult>
      *
@@ -152,35 +143,16 @@ class PlaylistGenerator
      */
     private function resolveTargets(?string $slug): array
     {
-        if ($slug !== null) {
-            foreach ($this->definitions as $def) {
-                if ($def->getSlug() === $slug) {
-                    return [$def];
-                }
-            }
-
-            throw new \InvalidArgumentException(sprintf('Unknown playlist definition "%s".', $slug));
+        if ($slug === null) {
+            return $this->definitions;
         }
 
-        return array_values(array_filter(
-            $this->definitions,
-            fn (PlaylistDefinitionInterface $d): bool => in_array($d->getSlug(), $this->enabledSlugs, true),
-        ));
-    }
-
-    /**
-     * @return list<string>
-     */
-    private static function parseCsv(string $csv): array
-    {
-        $slugs = [];
-        foreach (explode(',', $csv) as $raw) {
-            $slug = strtolower(trim($raw));
-            if ($slug !== '') {
-                $slugs[] = $slug;
+        foreach ($this->definitions as $def) {
+            if ($def->getSlug() === $slug) {
+                return [$def];
             }
         }
 
-        return array_values(array_unique($slugs));
+        throw new \InvalidArgumentException(sprintf('Unknown playlist definition "%s".', $slug));
     }
 }

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -37,7 +37,7 @@
                     <p class="text-xs text-slate-500">Algorithmes de génération — création / rafraîchissement dans Navidrome.</p>
                 </div>
                 <form method="post" action="{{ path('app_playlists_generate') }}"
-                      onsubmit="return confirm('(Re)générer toutes les playlists activées ?');">
+                      onsubmit="return confirm('(Re)générer toutes les playlists ?');">
                     <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate') }}">
                     <button type="submit"
                             class="bg-sky-700 hover:bg-sky-800 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
@@ -54,20 +54,12 @@
                                 <div class="text-xs text-slate-500">{{ d.description }}</div>
                                 <div class="text-xs text-slate-400 mt-0.5 font-mono">{{ d.slug }}</div>
                             </td>
-                            <td class="px-3 py-2 text-xs">
-                                {% if d.enabled %}
-                                    <span class="inline-block bg-emerald-100 text-emerald-800 px-2 py-0.5 rounded-sm">Activée</span>
-                                {% else %}
-                                    <span class="inline-block bg-slate-100 text-slate-500 px-2 py-0.5 rounded-sm"
-                                          title="Non listée dans PLAYLISTS_ENABLED — exclue du « Tout générer », mais régénérable à la demande">Désactivée</span>
-                                {% endif %}
-                            </td>
                             <td class="px-4 py-2 text-right">
                                 <form method="post" action="{{ path('app_playlists_generate_one', { slug: d.slug }) }}">
                                     <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate_one') }}">
                                     <button type="submit"
                                             class="bg-amber-600 hover:bg-amber-700 text-white px-3 py-1 rounded-sm text-xs font-medium">
-                                        ↻ {{ d.enabled ? 'Régénérer' : 'Générer' }}
+                                        ↻ Régénérer
                                     </button>
                                 </form>
                             </td>

--- a/tests/Playlist/PlaylistGeneratorTest.php
+++ b/tests/Playlist/PlaylistGeneratorTest.php
@@ -11,48 +11,42 @@ use PHPUnit\Framework\TestCase;
 
 class PlaylistGeneratorTest extends TestCase
 {
-    public function testGenerateAllRunsOnlyEnabledDefinitions(): void
+    public function testGenerateAllRunsEveryDefinition(): void
     {
-        $enabled = $this->def('enabled-one', 'Enabled One', ['mf-1', 'mf-2']);
-        $disabled = $this->def('disabled-one', 'Disabled One', ['mf-3']);
+        $a = $this->def('a', 'A', ['mf-1', 'mf-2']);
+        $b = $this->def('b', 'B', ['mf-3']);
 
         $subsonic = $this->createMock(SubsonicClient::class);
         $subsonic->method('findPlaylistByName')->willReturn(null);
-        $subsonic->expects($this->once())
-            ->method('createPlaylist')
-            ->with('Enabled One', ['mf-1', 'mf-2'])
-            ->willReturn('pl-new');
-        // Description stamped as the playlist comment after creation.
-        $subsonic->expects($this->once())
-            ->method('updatePlaylist')
-            ->with('pl-new', null, 'desc enabled-one');
+        $subsonic->expects($this->exactly(2))->method('createPlaylist')->willReturn('pl-new');
 
-        $gen = new PlaylistGenerator([$enabled, $disabled], 'enabled-one', $subsonic);
+        $gen = new PlaylistGenerator([$a, $b], $subsonic);
         $results = $gen->generate(null, dryRun: false);
 
-        $this->assertCount(1, $results);
-        $this->assertSame('enabled-one', $results[0]->slug);
-        $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[0]->action);
+        // Both playlists generated — no enable list to filter on.
+        $this->assertCount(2, $results);
+        $this->assertSame(['a', 'b'], array_map(fn ($r) => $r->slug, $results));
     }
 
-    public function testGenerateBySlugBypassesEnabledList(): void
+    public function testGenerateBySlugRunsThatOneOnly(): void
     {
-        $disabled = $this->def('disabled-one', 'Disabled One', ['mf-3']);
+        $a = $this->def('a', 'A', ['mf-1']);
+        $b = $this->def('b', 'B', ['mf-3']);
         $subsonic = $this->createMock(SubsonicClient::class);
         $subsonic->method('findPlaylistByName')->willReturn(null);
-        $subsonic->expects($this->once())->method('createPlaylist')->willReturn('pl-x');
+        $subsonic->expects($this->once())->method('createPlaylist')->with('B', ['mf-3'])->willReturn('pl-b');
 
-        // Empty CSV → nothing enabled, yet an explicit slug still runs.
-        $gen = new PlaylistGenerator([$disabled], '', $subsonic);
-        $results = $gen->generate('disabled-one', dryRun: false);
+        $gen = new PlaylistGenerator([$a, $b], $subsonic);
+        $results = $gen->generate('b', dryRun: false);
 
         $this->assertCount(1, $results);
+        $this->assertSame('b', $results[0]->slug);
         $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[0]->action);
     }
 
     public function testUnknownSlugThrows(): void
     {
-        $gen = new PlaylistGenerator([$this->def('a', 'A', ['mf-1'])], 'a', $this->createMock(SubsonicClient::class));
+        $gen = new PlaylistGenerator([$this->def('a', 'A', ['mf-1'])], $this->createMock(SubsonicClient::class));
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown playlist definition "nope"');
@@ -73,7 +67,7 @@ class PlaylistGeneratorTest extends TestCase
         // Comment refreshed on the existing playlist too.
         $subsonic->expects($this->once())->method('updatePlaylist')->with('pl-existing', null, 'desc a');
 
-        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
+        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: false);
 
         $this->assertSame(PlaylistRunResult::ACTION_REPLACED, $results[0]->action);
         $this->assertSame('pl-existing', $results[0]->playlistId);
@@ -88,7 +82,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->expects($this->never())->method('findPlaylistByName');
         $subsonic->expects($this->never())->method('updatePlaylist');
 
-        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: true);
+        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: true);
 
         $this->assertSame(PlaylistRunResult::ACTION_DRY_RUN, $results[0]->action);
         $this->assertSame(['mf-1', 'mf-2'], $results[0]->trackIds);
@@ -102,7 +96,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->expects($this->never())->method('replacePlaylist');
         $subsonic->expects($this->never())->method('updatePlaylist');
 
-        $results = (new PlaylistGenerator([$def], 'a', $subsonic))->generate('a', dryRun: false);
+        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: false);
 
         $this->assertSame(PlaylistRunResult::ACTION_EMPTY, $results[0]->action);
     }
@@ -120,7 +114,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->method('findPlaylistByName')->willReturn(null);
         $subsonic->method('createPlaylist')->willReturn('pl-ok');
 
-        $results = (new PlaylistGenerator([$broken, $ok], 'broken,ok', $subsonic))->generate(null, dryRun: false);
+        $results = (new PlaylistGenerator([$broken, $ok], $subsonic))->generate(null, dryRun: false);
 
         $this->assertCount(2, $results);
         $this->assertSame(PlaylistRunResult::ACTION_ERROR, $results[0]->action);
@@ -128,18 +122,18 @@ class PlaylistGeneratorTest extends TestCase
         $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[1]->action);
     }
 
-    public function testListDefinitionsReportsEnabledState(): void
+    public function testListDefinitionsReturnsSlugNameDescription(): void
     {
         $gen = new PlaylistGenerator(
             [$this->def('a', 'A', []), $this->def('b', 'B', [])],
-            'a',
             $this->createMock(SubsonicClient::class),
         );
 
         $list = $gen->listDefinitions();
 
-        $this->assertTrue($list[0]['enabled']);
-        $this->assertFalse($list[1]['enabled']);
+        $this->assertSame(['a', 'b'], array_map(fn ($d) => $d['slug'], $list));
+        $this->assertSame('A', $list[0]['name']);
+        $this->assertSame('desc a', $list[0]['description']);
     }
 
     /**


### PR DESCRIPTION
## Contexte

Symptôme : « Tout (re)générer » renvoyait `playlists=0` en silence parce que `PLAYLISTS_ENABLED` était vide. La notion d'activation servait à filtrer le `--all`, mais elle n'avait plus aucun autre consommateur depuis le revert du scheduler cron (#216) — un piège pour rien.

## Changement (option 2)

« Tout (re)générer » (CLI `--all` / bouton UI) régénère désormais **toutes les playlists définies**. `--slug=<slug>` en cible une seule. La notion `PLAYLISTS_ENABLED` est supprimée.

- `PlaylistGenerator` : retrait de `$enabledCsv` / `enabledSlugs` / `parseCsv` ; `generate(null)` = toutes, `generate(slug)` = celle-ci ; `listDefinitions()` ne renvoie plus `enabled`.
- `services.yaml` / `.env.dist` / `phpunit.xml.dist` : suppression de `PLAYLISTS_ENABLED` (un `.env` qui la définit encore l'ignore simplement).
- UI `/playlists` : retrait du badge « activée/désactivée », bouton par ligne = « Régénérer ». Commande `--list` : colonne « activé » retirée.
- Docblocks/commande mis à jour.

## Tests (227/227, phpcs clean, phpstan inchangé)

- `generate(null)` → toutes les définitions ; `generate(slug)` → une seule ; slug inconnu → erreur ; dry-run/vide n'écrivent pas ; algo cassé isolé ; `listDefinitions` renvoie slug/nom/description.

## Effet

Plus besoin de configurer quoi que ce soit : le bouton « Tout (re)générer » et `--all` font toutes les 8 playlists. Tu peux retirer `PLAYLISTS_ENABLED` de ton `.env` (sans danger si tu l'y laisses).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_