### PR TITLE
feat(ui): accents marque — boutons d'action en orange, filtres en navy

### DIFF
--- a/templates/_top_filter_form.html.twig
+++ b/templates/_top_filter_form.html.twig
@@ -30,6 +30,6 @@
             {% endfor %}
         </select>
     </div>
-    <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+    <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
     <a href="{{ path(route) }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
 </form>

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -68,7 +68,7 @@
         </span>
         <form method="post" action="{{ path('app_navidrome_container_start') }}" class="inline">
             <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">
-            <button type="submit" class="text-xs bg-emerald-600 hover:bg-emerald-700 text-white px-3 py-1 rounded-sm">▶ Start</button>
+            <button type="submit" class="text-xs bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-3 py-1 rounded-sm">▶ Start</button>
         </form>
         <form method="post" action="{{ path('app_navidrome_container_stop') }}" class="inline">
             <input type="hidden" name="_token" value="{{ csrf_token('navidrome_container') }}">

--- a/templates/history/index.html.twig
+++ b/templates/history/index.html.twig
@@ -26,7 +26,7 @@
             <input type="text" name="q" value="{{ filters.q }}" placeholder="label…"
                    class="border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_history') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
     </form>
 

--- a/templates/lastfm/aliases/form.html.twig
+++ b/templates/lastfm/aliases/form.html.twig
@@ -49,7 +49,7 @@
             </div>
 
             <div class="flex items-center gap-3 mt-6">
-                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-[#15243A] text-white text-sm">
                     {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias' }}
                 </button>
                 <a href="{{ path('app_lastfm_alias_index') }}" class="text-sm text-slate-500 hover:underline">

--- a/templates/lastfm/aliases/index.html.twig
+++ b/templates/lastfm/aliases/index.html.twig
@@ -11,7 +11,7 @@
             </p>
         </div>
         <a href="{{ path('app_lastfm_alias_new') }}"
-           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias</a>
+           class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">+ Nouvel alias</a>
     </div>
 
     <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
@@ -20,7 +20,7 @@
             <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste ou titre source…"
                    class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_lastfm_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 

--- a/templates/lastfm/artist_aliases/form.html.twig
+++ b/templates/lastfm/artist_aliases/form.html.twig
@@ -37,7 +37,7 @@
             </div>
 
             <div class="flex items-center gap-3 mt-6">
-                <button type="submit" class="px-4 py-2 rounded-sm bg-slate-900 text-white text-sm">
+                <button type="submit" class="px-4 py-2 rounded-sm bg-[#15243A] text-white text-sm">
                     {{ alias ? 'Enregistrer les modifications' : 'Créer l\'alias artiste' }}
                 </button>
                 <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-sm text-slate-500 hover:underline">

--- a/templates/lastfm/artist_aliases/index.html.twig
+++ b/templates/lastfm/artist_aliases/index.html.twig
@@ -14,7 +14,7 @@
             </p>
         </div>
         <a href="{{ path('app_lastfm_artist_alias_new') }}"
-           class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">+ Nouvel alias artiste</a>
+           class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">+ Nouvel alias artiste</a>
     </div>
 
     <form method="get" class="bg-white shadow-sm rounded-sm p-4 mb-4 flex flex-wrap items-end gap-3">
@@ -23,7 +23,7 @@
             <input type="search" name="q" value="{{ filters.q }}" placeholder="Filtrer par artiste source ou cible…"
                    class="w-full border rounded-sm px-2 py-1 text-sm">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_lastfm_artist_alias_index') }}" class="text-xs text-slate-500 hover:underline">Réinitialiser</a>
     </form>
 

--- a/templates/lastfm/import.html.twig
+++ b/templates/lastfm/import.html.twig
@@ -77,7 +77,7 @@
             </div>
 
             <button type="submit"
-                    class="bg-slate-800 hover:bg-slate-900 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                    class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-6 py-2 rounded-sm text-sm font-medium">
                 ▶ Lancer le fetch
             </button>
         </form>

--- a/templates/lastfm/scrobbles.html.twig
+++ b/templates/lastfm/scrobbles.html.twig
@@ -64,7 +64,7 @@
                 {% endfor %}
             </select>
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_lastfm_scrobbles') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
     </form>
 

--- a/templates/navidrome/sync.html.twig
+++ b/templates/navidrome/sync.html.twig
@@ -60,7 +60,7 @@
             </div>
 
             <button type="submit"
-                    class="bg-slate-800 hover:bg-slate-900 text-white px-6 py-2 rounded-sm text-sm font-medium">
+                    class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-6 py-2 rounded-sm text-sm font-medium">
                 ▶ Lancer la sync
             </button>
         </form>

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -12,7 +12,7 @@
                   onsubmit="return confirm('Interroger MusicBrainz pour les artistes ayant ≥3 scrobbles non matchés ? Throttle ~1 req/s, les alias uniques sont appliqués automatiquement.');">
                 <input type="hidden" name="_token" value="{{ csrf_token('navidrome_suggest_aliases') }}">
                 <button type="submit"
-                        class="bg-emerald-700 hover:bg-emerald-800 text-white px-4 py-1.5 rounded-sm text-sm font-medium"
+                        class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium"
                         title="Interroge MusicBrainz et crée les alias artiste uniques haute-confiance (≥3 scrobbles)">
                     🎯 Suggérer des alias
                 </button>
@@ -23,7 +23,7 @@
                     <input type="checkbox" name="auto_stop" value="1"> auto-stop
                 </label>
                 <button type="submit"
-                        class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                        class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium">
                     ↺ Rematcher tous
                 </button>
             </form>
@@ -41,7 +41,7 @@
             <input type="text" name="title" value="{{ filter_title }}" placeholder="Rechercher…"
                    class="border rounded-sm px-2 py-1 text-sm w-40">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_navidrome_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
         <a href="{{ path('app_lastfm_alias_index') }}" class="ml-auto text-xs text-sky-700 hover:underline self-center">
             Gérer les alias track →

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -40,7 +40,7 @@
                       onsubmit="return confirm('(Re)générer toutes les playlists ?');">
                     <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate') }}">
                     <button type="submit"
-                            class="bg-sky-700 hover:bg-sky-800 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                            class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium">
                         ↻ Tout (re)générer
                     </button>
                 </form>
@@ -58,7 +58,7 @@
                                 <form method="post" action="{{ path('app_playlists_generate_one', { slug: d.slug }) }}">
                                     <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate_one') }}">
                                     <button type="submit"
-                                            class="bg-amber-600 hover:bg-amber-700 text-white px-3 py-1 rounded-sm text-xs font-medium">
+                                            class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-3 py-1 rounded-sm text-xs font-medium">
                                         ↻ Régénérer
                                     </button>
                                 </form>

--- a/templates/strawberry/sync.html.twig
+++ b/templates/strawberry/sync.html.twig
@@ -36,7 +36,7 @@
                 <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="dry_run" value="1"> Dry-run</label>
                 <label class="flex items-center gap-2 text-sm"><input type="checkbox" name="retry_unmatched" value="1"> Retry unmatched</label>
             </div>
-            <button type="submit" class="bg-slate-800 hover:bg-slate-900 text-white px-5 py-2 rounded-sm text-sm font-medium">▶ Lancer</button>
+            <button type="submit" class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-5 py-2 rounded-sm text-sm font-medium">▶ Lancer</button>
         </form>
         <div class="mt-3 text-xs text-slate-400">CLI : <code>php bin/console app:scrobbles:sync-strawberry [--retry-unmatched] [--dry-run]</code></div>
     </div>
@@ -56,7 +56,7 @@
                 </div>
                 <div class="flex gap-2 shrink-0">
                     <a href="{{ path('app_strawberry_download') }}"
-                       class="text-xs bg-sky-600 hover:bg-sky-700 text-white px-3 py-1 rounded-sm">⬇ Download</a>
+                       class="text-xs bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-3 py-1 rounded-sm">⬇ Download</a>
                     <form method="post" action="{{ path('app_strawberry_delete_upload') }}" class="inline">
                         <input type="hidden" name="_token" value="{{ csrf_token('strawberry_delete_upload') }}">
                         <button type="submit" onclick="return confirm('Supprimer ?')"
@@ -67,12 +67,12 @@
             <form method="post" action="{{ path('app_strawberry_process_upload') }}" class="mt-3 flex items-center gap-3">
                 <input type="hidden" name="_token" value="{{ csrf_token('strawberry_process') }}">
                 <button type="submit" name="retry_unmatched" value="0"
-                        class="text-sm bg-emerald-600 hover:bg-emerald-700 text-white px-4 py-1.5 rounded-sm font-medium">
+                        class="text-sm bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm font-medium">
                     ▶ Synchroniser
                 </button>
                 {% if unmatched > 0 %}
                 <button type="submit" name="retry_unmatched" value="1"
-                        class="text-sm bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm font-medium">
+                        class="text-sm bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm font-medium">
                     ↺ Retry {{ unmatched }} non matchés
                 </button>
                 {% endif %}

--- a/templates/strawberry/unmatched.html.twig
+++ b/templates/strawberry/unmatched.html.twig
@@ -10,7 +10,7 @@
         <form method="post" action="{{ path('app_strawberry_rematch') }}" class="flex gap-2">
             <input type="hidden" name="_token" value="{{ csrf_token('strawberry_rematch') }}">
             <button type="submit"
-                    class="bg-amber-600 hover:bg-amber-700 text-white px-4 py-1.5 rounded-sm text-sm font-medium">
+                    class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium">
                 ↺ Rematcher tous
             </button>
         </form>
@@ -27,7 +27,7 @@
             <input type="text" name="title" value="{{ filter_title }}" placeholder="Rechercher…"
                    class="border rounded-sm px-2 py-1 text-sm w-40">
         </div>
-        <button type="submit" class="px-3 py-1.5 rounded-sm bg-slate-900 text-white text-sm">Filtrer</button>
+        <button type="submit" class="px-3 py-1.5 rounded-sm bg-[#15243A] text-white text-sm">Filtrer</button>
         <a href="{{ path('app_strawberry_unmatched') }}" class="text-xs text-slate-500 hover:underline self-center">Reset</a>
     </form>
 


### PR DESCRIPTION
## Résumé

Second passage de la charte : migration des accents internes vers la palette marque (suite de #218).

## Mapping

- **Boutons d'action primaires** (rematch, sync, génération, suggestion d'alias…) : `amber`/`emerald`/`sky` → **orange `#F2A93C`** avec **texte navy `#15243A`** (l'orange est clair → texte foncé pour le contraste, conforme WCAG).
- **Boutons « Filtrer »** (submit secondaire) : `slate-900` → **navy marque `#15243A`**.
- **Conservés** : rouge destructif (`rose-600`), boutons neutres (`slate-200`), badges/chips de statut, et les **liens texte** (le cyan/teal marque est trop clair en texte → lisibilité préservée).

14 templates touchés (uniquement des classes Tailwind).

## Aperçu

Voir l'image jointe au fil (CTA orange, Filtrer navy, liens bleus, destructif rouge).

## Vérif

`composer ci` non impacté (aucun PHP modifié ; 227 tests verts).

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_