### PR TITLE
feat(playlists): activation par playlist via checkbox (persistée en DB)

### DIFF
--- a/src/Command/GeneratePlaylistsCommand.php
+++ b/src/Command/GeneratePlaylistsCommand.php
@@ -21,13 +21,14 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  *   app:playlists:generate --slug=retour-en-arriere [--dry-run]
  *   app:playlists:generate --all [--dry-run]
  *
- * `--slug` generates exactly one definition; `--all` generates every
- * defined playlist. `--dry-run` resolves and prints the track list without
+ * `--slug` generates exactly one definition (regardless of its flag);
+ * `--all` generates every ENABLED playlist (per-slug flag toggled from the
+ * /playlists page). `--dry-run` resolves and prints the track list without
  * writing anything to Navidrome.
  */
 #[AsCommand(
     name: 'app:playlists:generate',
-    description: 'Generate algorithmic playlists in Navidrome (one via --slug, or all via --all).',
+    description: 'Generate algorithmic playlists in Navidrome (one via --slug, or all enabled via --all).',
 )]
 class GeneratePlaylistsCommand extends Command
 {
@@ -43,7 +44,7 @@ class GeneratePlaylistsCommand extends Command
     {
         $this
             ->addOption('slug', null, InputOption::VALUE_REQUIRED, 'Generate only this playlist definition.')
-            ->addOption('all', null, InputOption::VALUE_NONE, 'Generate every defined playlist.')
+            ->addOption('all', null, InputOption::VALUE_NONE, 'Generate every enabled playlist.')
             ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Resolve and print tracks without writing to Navidrome.')
             ->addOption('list', null, InputOption::VALUE_NONE, 'List available playlist definitions and exit.');
     }
@@ -95,9 +96,9 @@ class GeneratePlaylistsCommand extends Command
     {
         $rows = [];
         foreach ($this->generator->listDefinitions() as $d) {
-            $rows[] = [$d['slug'], $d['name'], $d['description']];
+            $rows[] = [$d['slug'], $d['name'], $d['enabled'] ? '✓' : '—', $d['description']];
         }
-        $io->table(['slug', 'nom', 'description'], $rows);
+        $io->table(['slug', 'nom', 'activé', 'description'], $rows);
 
         return Command::SUCCESS;
     }
@@ -108,7 +109,7 @@ class GeneratePlaylistsCommand extends Command
     private function printResults(SymfonyStyle $io, array $results, bool $dryRun): void
     {
         if ($results === []) {
-            $io->warning('Aucune playlist définie.');
+            $io->warning('Aucune playlist activée (cochez-en sur la page /playlists).');
             return;
         }
 

--- a/src/Controller/PlaylistController.php
+++ b/src/Controller/PlaylistController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use App\Message\GeneratePlaylistsMessage;
+use App\Playlist\PlaylistEnablement;
 use App\Playlist\PlaylistGenerator;
 use App\Subsonic\SubsonicClient;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -74,6 +75,27 @@ class PlaylistController extends AbstractController
         $this->addFlash('success', sprintf('Génération de la playlist « %s » lancée en arrière-plan.', $slug));
 
         return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/playlists/{slug}/toggle', name: 'app_playlists_toggle', methods: ['POST'])]
+    public function toggle(
+        string $slug,
+        Request $request,
+        PlaylistGenerator $generator,
+        PlaylistEnablement $enablement,
+    ): Response {
+        if (!$this->isCsrfTokenValid('playlists_toggle', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+        $known = array_column($generator->listDefinitions(), 'slug');
+        if (!in_array($slug, $known, true)) {
+            throw $this->createNotFoundException(sprintf('Unknown playlist "%s".', $slug));
+        }
+
+        $enablement->setEnabled($slug, $request->request->getBoolean('enabled'));
+
+        // 204: the checkbox toggles via fetch() and stays put — no reload.
+        return new Response(status: Response::HTTP_NO_CONTENT);
     }
 
     #[Route('/playlists/{id}', name: 'app_playlists_show', methods: ['GET'])]

--- a/src/Playlist/PlaylistEnablement.php
+++ b/src/Playlist/PlaylistEnablement.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Playlist;
+
+use App\Repository\SettingRepository;
+
+/**
+ * Per-playlist on/off flag, persisted in the tools SQLite DB via the
+ * generic key/value {@see SettingRepository} (key
+ * `playlist.enabled.<slug>`). Drives which playlists the « generate all »
+ * run touches. Toggled from the /playlists listing.
+ *
+ * Default = enabled: a fresh install regenerates every playlist out of the
+ * box (no silent « 0 generated » surprise); the user unchecks the ones
+ * they don't want.
+ */
+final class PlaylistEnablement
+{
+    private const PREFIX = 'playlist.enabled.';
+
+    public function __construct(
+        private readonly SettingRepository $settings,
+    ) {
+    }
+
+    public function isEnabled(string $slug): bool
+    {
+        return $this->settings->get(self::PREFIX . $slug, '1') === '1';
+    }
+
+    public function setEnabled(string $slug, bool $enabled): void
+    {
+        $this->settings->set(self::PREFIX . $slug, $enabled ? '1' : '0');
+    }
+}

--- a/src/Playlist/PlaylistGenerator.php
+++ b/src/Playlist/PlaylistGenerator.php
@@ -12,9 +12,9 @@ use Psr\Log\NullLogger;
  * them to Navidrome via Subsonic. Mirrors {@see \App\Notifier\Notifier}
  * (tagged iterator + best-effort per-item isolation).
  *
- * `generate(null)` regenerates EVERY defined playlist; `generate($slug)`
- * just that one. (There is no enable/disable list — « generate all » means
- * all.)
+ * `generate(null)` regenerates every ENABLED playlist (per-slug flag in
+ * the DB, see {@see PlaylistEnablement}); `generate($slug)` regenerates
+ * that one regardless of its flag (explicit intent).
  *
  * Idempotent write: a playlist of the same name owned by the configured
  * user is overwritten in place; otherwise a new one is created.
@@ -30,6 +30,7 @@ class PlaylistGenerator
     public function __construct(
         iterable $definitions,
         private readonly SubsonicClient $subsonic,
+        private readonly PlaylistEnablement $enablement,
         private readonly int $defaultLimit = 50,
         private readonly LoggerInterface $logger = new NullLogger(),
     ) {
@@ -37,7 +38,7 @@ class PlaylistGenerator
     }
 
     /**
-     * @return list<array{slug: string, name: string, description: string}>
+     * @return list<array{slug: string, name: string, description: string, enabled: bool}>
      */
     public function listDefinitions(): array
     {
@@ -47,6 +48,7 @@ class PlaylistGenerator
                 'slug' => $def->getSlug(),
                 'name' => $def->getName(),
                 'description' => $def->getDescription(),
+                'enabled' => $this->enablement->isEnabled($def->getSlug()),
             ];
         }
 
@@ -56,8 +58,8 @@ class PlaylistGenerator
     /**
      * Generate playlists and (unless dry-run) write them to Navidrome.
      *
-     * @param ?string $slug   null → every defined playlist ; a slug → that
-     *                        one definition.
+     * @param ?string $slug   null → every ENABLED playlist ; a slug → that
+     *                        one definition (regardless of its flag).
      *
      * @return list<PlaylistRunResult>
      *
@@ -144,7 +146,10 @@ class PlaylistGenerator
     private function resolveTargets(?string $slug): array
     {
         if ($slug === null) {
-            return $this->definitions;
+            return array_values(array_filter(
+                $this->definitions,
+                fn (PlaylistDefinitionInterface $d): bool => $this->enablement->isEnabled($d->getSlug()),
+            ));
         }
 
         foreach ($this->definitions as $def) {

--- a/templates/playlist_management/index.html.twig
+++ b/templates/playlist_management/index.html.twig
@@ -37,7 +37,7 @@
                     <p class="text-xs text-slate-500">Algorithmes de génération — création / rafraîchissement dans Navidrome.</p>
                 </div>
                 <form method="post" action="{{ path('app_playlists_generate') }}"
-                      onsubmit="return confirm('(Re)générer toutes les playlists ?');">
+                      onsubmit="return confirm('(Re)générer toutes les playlists activées ?');">
                     <input type="hidden" name="_token" value="{{ csrf_token('playlists_generate') }}">
                     <button type="submit"
                             class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium">
@@ -45,11 +45,17 @@
                     </button>
                 </form>
             </div>
-            <table class="w-full text-sm">
+            <table class="w-full text-sm" data-toggle-token="{{ csrf_token('playlists_toggle') }}">
                 <tbody class="divide-y">
                     {% for d in definitions %}
                         <tr class="hover:bg-slate-50">
-                            <td class="px-4 py-2">
+                            <td class="pl-4 pr-2 py-2 w-px">
+                                <label class="inline-flex items-center cursor-pointer" title="Inclure dans « Tout (re)générer »">
+                                    <input type="checkbox" class="js-playlist-toggle w-4 h-4 accent-[#F2A93C]"
+                                           data-slug="{{ d.slug }}" {{ d.enabled ? 'checked' : '' }}>
+                                </label>
+                            </td>
+                            <td class="px-2 py-2">
                                 <div class="font-medium">{{ d.name }}</div>
                                 <div class="text-xs text-slate-500">{{ d.description }}</div>
                                 <div class="text-xs text-slate-400 mt-0.5 font-mono">{{ d.slug }}</div>
@@ -67,7 +73,32 @@
                     {% endfor %}
                 </tbody>
             </table>
+            <p class="px-4 py-2 text-xs text-slate-400 border-t">
+                La case inclut (ou non) la playlist dans « Tout (re)générer » et la planification.
+                « Régénérer » fonctionne toujours, même décochée.
+            </p>
         </div>
+        <script>
+            document.querySelectorAll('.js-playlist-toggle').forEach(function (cb) {
+                cb.addEventListener('change', function () {
+                    var table = cb.closest('table');
+                    var token = table ? table.getAttribute('data-toggle-token') : '';
+                    var body = new URLSearchParams();
+                    body.set('_token', token);
+                    body.set('enabled', cb.checked ? '1' : '0');
+                    cb.disabled = true;
+                    fetch('{{ path('app_playlists_index') }}/' + encodeURIComponent(cb.dataset.slug) + '/toggle', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: body.toString(),
+                    }).then(function (r) {
+                        if (!r.ok) { cb.checked = !cb.checked; }
+                    }).catch(function () {
+                        cb.checked = !cb.checked;
+                    }).finally(function () { cb.disabled = false; });
+                });
+            });
+        </script>
     {% endif %}
 
     {% if playlists is empty and not error %}

--- a/tests/Playlist/PlaylistEnablementTest.php
+++ b/tests/Playlist/PlaylistEnablementTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Tests\Playlist;
+
+use App\Playlist\PlaylistEnablement;
+use App\Repository\SettingRepository;
+use PHPUnit\Framework\TestCase;
+
+class PlaylistEnablementTest extends TestCase
+{
+    public function testDefaultsToEnabledWhenNoSetting(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        // Unset → repository returns the provided default ('1').
+        $settings->method('get')->willReturnCallback(fn (string $k, string $d = '') => $d);
+
+        $this->assertTrue((new PlaylistEnablement($settings))->isEnabled('kickstart'));
+    }
+
+    public function testReadsStoredDisabledFlag(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->with('playlist.enabled.kickstart', '1')->willReturn('0');
+
+        $this->assertFalse((new PlaylistEnablement($settings))->isEnabled('kickstart'));
+    }
+
+    public function testSetEnabledPersistsCanonicalValue(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->expects($this->exactly(2))
+            ->method('set')
+            ->willReturnCallback(function (string $key, string $value): void {
+                $this->assertSame('playlist.enabled.hit-parade', $key);
+                $this->assertContains($value, ['0', '1']);
+            });
+
+        $e = new PlaylistEnablement($settings);
+        $e->setEnabled('hit-parade', true);
+        $e->setEnabled('hit-parade', false);
+    }
+}

--- a/tests/Playlist/PlaylistGeneratorTest.php
+++ b/tests/Playlist/PlaylistGeneratorTest.php
@@ -4,31 +4,33 @@ namespace App\Tests\Playlist;
 
 use App\Playlist\PlaylistContext;
 use App\Playlist\PlaylistDefinitionInterface;
+use App\Playlist\PlaylistEnablement;
 use App\Playlist\PlaylistGenerator;
 use App\Playlist\PlaylistRunResult;
+use App\Repository\SettingRepository;
 use App\Subsonic\SubsonicClient;
 use PHPUnit\Framework\TestCase;
 
 class PlaylistGeneratorTest extends TestCase
 {
-    public function testGenerateAllRunsEveryDefinition(): void
+    public function testGenerateAllRunsOnlyEnabledDefinitions(): void
     {
         $a = $this->def('a', 'A', ['mf-1', 'mf-2']);
         $b = $this->def('b', 'B', ['mf-3']);
 
         $subsonic = $this->createMock(SubsonicClient::class);
         $subsonic->method('findPlaylistByName')->willReturn(null);
-        $subsonic->expects($this->exactly(2))->method('createPlaylist')->willReturn('pl-new');
+        // Only 'a' is enabled → only one createPlaylist call.
+        $subsonic->expects($this->once())->method('createPlaylist')->with('A', ['mf-1', 'mf-2'])->willReturn('pl-a');
 
-        $gen = new PlaylistGenerator([$a, $b], $subsonic);
+        $gen = new PlaylistGenerator([$a, $b], $subsonic, $this->enablement(disabled: ['b']));
         $results = $gen->generate(null, dryRun: false);
 
-        // Both playlists generated — no enable list to filter on.
-        $this->assertCount(2, $results);
-        $this->assertSame(['a', 'b'], array_map(fn ($r) => $r->slug, $results));
+        $this->assertCount(1, $results);
+        $this->assertSame('a', $results[0]->slug);
     }
 
-    public function testGenerateBySlugRunsThatOneOnly(): void
+    public function testGenerateBySlugRunsThatOneEvenIfDisabled(): void
     {
         $a = $this->def('a', 'A', ['mf-1']);
         $b = $this->def('b', 'B', ['mf-3']);
@@ -36,7 +38,8 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->method('findPlaylistByName')->willReturn(null);
         $subsonic->expects($this->once())->method('createPlaylist')->with('B', ['mf-3'])->willReturn('pl-b');
 
-        $gen = new PlaylistGenerator([$a, $b], $subsonic);
+        // 'b' is disabled, yet an explicit slug still runs.
+        $gen = new PlaylistGenerator([$a, $b], $subsonic, $this->enablement(disabled: ['b']));
         $results = $gen->generate('b', dryRun: false);
 
         $this->assertCount(1, $results);
@@ -46,7 +49,7 @@ class PlaylistGeneratorTest extends TestCase
 
     public function testUnknownSlugThrows(): void
     {
-        $gen = new PlaylistGenerator([$this->def('a', 'A', ['mf-1'])], $this->createMock(SubsonicClient::class));
+        $gen = new PlaylistGenerator([$this->def('a', 'A', ['mf-1'])], $this->createMock(SubsonicClient::class), $this->enablement());
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown playlist definition "nope"');
@@ -67,7 +70,7 @@ class PlaylistGeneratorTest extends TestCase
         // Comment refreshed on the existing playlist too.
         $subsonic->expects($this->once())->method('updatePlaylist')->with('pl-existing', null, 'desc a');
 
-        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: false);
+        $results = (new PlaylistGenerator([$def], $subsonic, $this->enablement()))->generate('a', dryRun: false);
 
         $this->assertSame(PlaylistRunResult::ACTION_REPLACED, $results[0]->action);
         $this->assertSame('pl-existing', $results[0]->playlistId);
@@ -82,7 +85,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->expects($this->never())->method('findPlaylistByName');
         $subsonic->expects($this->never())->method('updatePlaylist');
 
-        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: true);
+        $results = (new PlaylistGenerator([$def], $subsonic, $this->enablement()))->generate('a', dryRun: true);
 
         $this->assertSame(PlaylistRunResult::ACTION_DRY_RUN, $results[0]->action);
         $this->assertSame(['mf-1', 'mf-2'], $results[0]->trackIds);
@@ -96,7 +99,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->expects($this->never())->method('replacePlaylist');
         $subsonic->expects($this->never())->method('updatePlaylist');
 
-        $results = (new PlaylistGenerator([$def], $subsonic))->generate('a', dryRun: false);
+        $results = (new PlaylistGenerator([$def], $subsonic, $this->enablement()))->generate('a', dryRun: false);
 
         $this->assertSame(PlaylistRunResult::ACTION_EMPTY, $results[0]->action);
     }
@@ -114,7 +117,7 @@ class PlaylistGeneratorTest extends TestCase
         $subsonic->method('findPlaylistByName')->willReturn(null);
         $subsonic->method('createPlaylist')->willReturn('pl-ok');
 
-        $results = (new PlaylistGenerator([$broken, $ok], $subsonic))->generate(null, dryRun: false);
+        $results = (new PlaylistGenerator([$broken, $ok], $subsonic, $this->enablement()))->generate(null, dryRun: false);
 
         $this->assertCount(2, $results);
         $this->assertSame(PlaylistRunResult::ACTION_ERROR, $results[0]->action);
@@ -122,18 +125,43 @@ class PlaylistGeneratorTest extends TestCase
         $this->assertSame(PlaylistRunResult::ACTION_CREATED, $results[1]->action);
     }
 
-    public function testListDefinitionsReturnsSlugNameDescription(): void
+    public function testListDefinitionsReportsEnabledState(): void
     {
         $gen = new PlaylistGenerator(
             [$this->def('a', 'A', []), $this->def('b', 'B', [])],
             $this->createMock(SubsonicClient::class),
+            $this->enablement(disabled: ['b']),
         );
 
         $list = $gen->listDefinitions();
 
         $this->assertSame(['a', 'b'], array_map(fn ($d) => $d['slug'], $list));
-        $this->assertSame('A', $list[0]['name']);
         $this->assertSame('desc a', $list[0]['description']);
+        $this->assertTrue($list[0]['enabled']);
+        $this->assertFalse($list[1]['enabled']);
+    }
+
+    /**
+     * @param list<string> $disabled slugs reported as disabled (others enabled)
+     */
+    private function enablement(array $disabled = []): PlaylistEnablement
+    {
+        // PlaylistEnablement is final → wrap a mocked SettingRepository
+        // that reports '0' for disabled slugs and the default ('1') otherwise.
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('get')->willReturnCallback(
+            function (string $key, string $default = '') use ($disabled): string {
+                foreach ($disabled as $slug) {
+                    if ($key === 'playlist.enabled.' . $slug) {
+                        return '0';
+                    }
+                }
+
+                return $default;
+            },
+        );
+
+        return new PlaylistEnablement($settings);
     }
 
     /**


### PR DESCRIPTION
## Résumé

Réintroduit l'activation des playlists — mais **togglable depuis le listing `/playlists`** via une **checkbox**, et **persistée en base SQLite** (au lieu de l'ancienne variable d'env `PLAYLISTS_ENABLED`).

## Fonctionnement

- **Stockage** : réutilise le store clé/valeur `Setting` existant → **aucune migration** (clé `playlist.enabled.<slug>`).
- **Défaut = activée** : une install neuve régénère tout d'emblée (pas de piège « 0 généré ») ; on décoche ce qu'on ne veut pas.
- **`generate(null)`** (CLI `--all` / bouton « Tout (re)générer ») ne touche que les **activées** ; **`generate(slug)`** (bouton « Régénérer » / `--slug`) marche toujours, même décochée.
- **Toggle** : `POST /playlists/{slug}/toggle` (CSRF, 204), checkbox qui persiste via `fetch()` **sans rechargement** (l'accent de la case est l'orange marque).

## Changements

- `src/Playlist/PlaylistEnablement.php` (nouveau) — wrapper `SettingRepository`.
- `src/Playlist/PlaylistGenerator.php` — filtre sur l'activation + `listDefinitions()` renvoie `enabled`.
- `src/Controller/PlaylistController.php` — route `toggle`.
- `templates/playlist_management/index.html.twig` — colonne checkbox + script fetch.
- `src/Command/GeneratePlaylistsCommand.php` — `--all` = activées ; `--list` réaffiche « activé ».

## Tests (230/230, phpcs clean, phpstan inchangé)

- Générateur : `generate(null)` ne prend que les activées ; `generate(slug)` bypass même si décochée ; `listDefinitions` rapporte l'état ; algo cassé isolé ; dry-run/vide.
- `PlaylistEnablement` : défaut activé, lecture du flag stocké, écriture de la valeur canonique.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_