### PR TITLE
feat(playlists): 3 nouvelles playlists (top de l'année, découvertes récentes, fidèles compagnons)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -81,7 +81,8 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # playlists définies ; --slug=<slug> en cible une seule.
 # Slugs disponibles : retour-en-arriere, top-du-mois, top-all-time,
 #                     pepites-oubliees, coups-de-coeur, kickstart,
-#                     happy-birthday, hit-parade
+#                     happy-birthday, hit-parade, top-de-lannee,
+#                     decouvertes-recentes, fideles-compagnons
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
@@ -101,6 +102,8 @@ PLAYLIST_BIRTHDAY_DAY=22
 # glissantes de 7 jours).
 PLAYLIST_HITPARADE_WEEKS=52
 PLAYLIST_HITPARADE_PER_WEEK=3
+# « Découvertes récentes » — fenêtre (jours) sur la 1ʳᵉ écoute d'un morceau.
+PLAYLIST_DISCOVERIES_DAYS=30
 ###< Playlists ###
 
 ###> Notifications ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ parameters:
     env(PLAYLIST_BIRTHDAY_DAY): '22'
     env(PLAYLIST_HITPARADE_WEEKS): '52'
     env(PLAYLIST_HITPARADE_PER_WEEK): '3'
+    env(PLAYLIST_DISCOVERIES_DAYS): '30'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -49,6 +50,7 @@ parameters:
     playlist.birthday.day: '%env(int:PLAYLIST_BIRTHDAY_DAY)%'
     playlist.hitparade.weeks: '%env(int:PLAYLIST_HITPARADE_WEEKS)%'
     playlist.hitparade.per_week: '%env(int:PLAYLIST_HITPARADE_PER_WEEK)%'
+    playlist.discoveries.days: '%env(int:PLAYLIST_DISCOVERIES_DAYS)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -127,6 +129,19 @@ services:
         arguments:
             $weeks: '%playlist.hitparade.weeks%'
             $perWeek: '%playlist.hitparade.per_week%'
+
+    App\Playlist\Definition\TopDeLanneeDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\FidelesCompagnonsDefinition:
+        arguments:
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\DecouvertesRecentesDefinition:
+        arguments:
+            $sinceDays: '%playlist.discoveries.days%'
+            $limit: '%playlists.default_limit%'
 
     App\Playlist\Definition\PepitesOublieesDefinition:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -52,6 +52,7 @@
         <env name="PLAYLIST_BIRTHDAY_DAY" value="22"/>
         <env name="PLAYLIST_HITPARADE_WEEKS" value="52"/>
         <env name="PLAYLIST_HITPARADE_PER_WEEK" value="3"/>
+        <env name="PLAYLIST_DISCOVERIES_DAYS" value="30"/>
     </php>
 
     <testsuites>

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -504,6 +504,78 @@ class NavidromeRepository
     }
 
     /**
+     * « Découvertes récentes » : tracks whose VERY FIRST scrobble (ever, for
+     * this user) falls on/after `$since`, newest discovery first. Requires
+     * the scrobbles table — the annotation table has no per-play history, so
+     * « first heard on date X » can't be reconstructed; returns [] on
+     * Navidrome < 0.55.
+     *
+     * @return string[] media_file ids, most-recently-discovered first
+     */
+    public function getRecentlyDiscoveredTracks(\DateTimeInterface $since, int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT s.media_file_id AS id
+            FROM scrobbles s
+            WHERE s.user_id = :uid
+            GROUP BY s.media_file_id
+            HAVING MIN(s.submission_time) >= :since
+            ORDER BY MIN(s.submission_time) DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'since' => $since->getTimestamp(), 'lim' => $limit],
+            [
+                'since' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
+     * « Fidèles compagnons » : tracks played across the MOST DISTINCT days
+     * (regularity, not raw volume — a track heard once a week for a year
+     * beats one binged 50× in a day). Requires the scrobbles table; returns
+     * [] on Navidrome < 0.55. Day bucketing in `date(...,'unixepoch')` (UTC).
+     *
+     * @return string[] media_file ids, most-distinct-days first
+     */
+    public function getMostConsistentTracks(int $limit): array
+    {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT s.media_file_id AS id,
+                   COUNT(DISTINCT date(s.submission_time, 'unixepoch')) AS days
+            FROM scrobbles s
+            WHERE s.user_id = :uid
+            GROUP BY s.media_file_id
+            ORDER BY days DESC, COUNT(*) DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            ['uid' => $userId, 'lim' => $limit],
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
      * Top tracks ever played on a given day-of-year (e.g. every 22 May,
      * across all years) ranked by play count. Used by the « Happy
      * birthday » playlist. Requires the scrobbles table — the annotation

--- a/src/Playlist/Definition/DecouvertesRecentesDefinition.php
+++ b/src/Playlist/Definition/DecouvertesRecentesDefinition.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Découvertes récentes » — tracks first heard in the last `$sinceDays`
+ * days (their very first scrobble falls in the window), newest discovery
+ * first. Reuses {@see NavidromeRepository::getRecentlyDiscoveredTracks()};
+ * order is meaningful (recency of discovery) so no shuffle.
+ */
+final class DecouvertesRecentesDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $sinceDays = 30,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'decouvertes-recentes';
+    }
+
+    public function getName(): string
+    {
+        return 'Découvertes récentes';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Morceaux découverts (1ʳᵉ écoute) durant les %d derniers jours, du plus récent au plus ancien.', $this->sinceDays);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $since = $context->now->modify(sprintf('-%d days', $this->sinceDays));
+
+        return $this->navidrome->getRecentlyDiscoveredTracks($since, $this->limit);
+    }
+}

--- a/src/Playlist/Definition/FidelesCompagnonsDefinition.php
+++ b/src/Playlist/Definition/FidelesCompagnonsDefinition.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Fidèles compagnons » — the tracks you come back to across the most
+ * distinct days (regularity, not raw volume). Reuses
+ * {@see NavidromeRepository::getMostConsistentTracks()}; ranked by
+ * distinct-days desc, so no shuffle.
+ */
+final class FidelesCompagnonsDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'fideles-compagnons';
+    }
+
+    public function getName(): string
+    {
+        return 'Fidèles compagnons';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Les %d morceaux écoutés sur le plus de jours différents — ceux qui t’accompagnent vraiment.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        return $this->navidrome->getMostConsistentTracks($this->limit);
+    }
+}

--- a/src/Playlist/Definition/TopDeLanneeDefinition.php
+++ b/src/Playlist/Definition/TopDeLanneeDefinition.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Top de l'année » — a yearly retrospective (« Wrapped ») of the last
+ * COMPLETED calendar year, shuffled. Reuses
+ * {@see NavidromeRepository::getTopTracksWithDates()} with that year.
+ *
+ * Static name: the single « Top de l'année » playlist is overwritten each
+ * run and always reflects the last full year.
+ */
+final class TopDeLanneeDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'top-de-lannee';
+    }
+
+    public function getName(): string
+    {
+        return 'Top de l’année';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf('Top %d des morceaux les plus écoutés sur l’année calendaire écoulée, en aléatoire.', $this->limit);
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $year = (int) $context->now->format('Y') - 1;
+        $rows = $this->navidrome->getTopTracksWithDates($year, null, null, $this->limit);
+
+        $ids = array_map(static fn (array $r): string => (string) $r['id'], $rows);
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Navidrome/NavidromeDiscoveryConsistencyTest.php
+++ b/tests/Navidrome/NavidromeDiscoveryConsistencyTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for getRecentlyDiscoveredTracks() (first-heard window)
+ * and getMostConsistentTracks() (distinct-days ranking).
+ */
+class NavidromeDiscoveryConsistencyTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testRecentlyDiscoveredKeepsOnlyTracksFirstHeardInWindow(): void
+    {
+        $conn = $this->db($path);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-new', 'New', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-old', 'Old', 'Artist');
+        // mf-new: first (and only) heard inside the window.
+        self::play($conn, 'mf-new', '2024-03-10 10:00:00');
+        // mf-old: first heard BEFORE the window (even if replayed inside it).
+        self::play($conn, 'mf-old', '2020-01-01 10:00:00');
+        self::play($conn, 'mf-old', '2024-03-12 10:00:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+        $since = new \DateTimeImmutable('2024-03-01 00:00:00');
+
+        $this->assertSame(['mf-new'], $repo->getRecentlyDiscoveredTracks($since, 10));
+    }
+
+    public function testRecentlyDiscoveredEmptyWhenNoScrobblesTable(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-disc-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+        $this->assertSame([], $repo->getRecentlyDiscoveredTracks(new \DateTimeImmutable(), 10));
+    }
+
+    public function testMostConsistentRanksByDistinctDaysNotVolume(): void
+    {
+        $conn = $this->db($path);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-regular', 'Regular', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-binge', 'Binge', 'Artist');
+        // mf-regular: 3 distinct days, 1 play each.
+        self::play($conn, 'mf-regular', '2024-01-01 09:00:00');
+        self::play($conn, 'mf-regular', '2024-01-05 09:00:00');
+        self::play($conn, 'mf-regular', '2024-01-09 09:00:00');
+        // mf-binge: 10 plays but all on the SAME day → 1 distinct day.
+        for ($h = 0; $h < 10; $h++) {
+            self::play($conn, 'mf-binge', sprintf('2024-02-02 %02d:00:00', $h));
+        }
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        // Regular (3 days) ranks above binge (1 day) despite fewer plays.
+        $this->assertSame(['mf-regular', 'mf-binge'], $repo->getMostConsistentTracks(10));
+    }
+
+    public function testMostConsistentEmptyWhenNoScrobblesTable(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-cons-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+        $this->assertSame([], $repo->getMostConsistentTracks(10));
+    }
+
+    private function db(?string &$path): Connection
+    {
+        $path = sys_get_temp_dir() . '/nd-disccons-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+
+        return NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+    }
+
+    private static function play(Connection $conn, string $mediaId, string $time): void
+    {
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', $mediaId, $time);
+    }
+}

--- a/tests/Navidrome/NavidromeDiscoveryConsistencyTest.php
+++ b/tests/Navidrome/NavidromeDiscoveryConsistencyTest.php
@@ -28,7 +28,8 @@ class NavidromeDiscoveryConsistencyTest extends TestCase
 
     public function testRecentlyDiscoveredKeepsOnlyTracksFirstHeardInWindow(): void
     {
-        $conn = $this->db($path);
+        $path = $this->tmpPath();
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
         NavidromeFixtureFactory::insertTrack($conn, 'mf-new', 'New', 'Artist');
         NavidromeFixtureFactory::insertTrack($conn, 'mf-old', 'Old', 'Artist');
         // mf-new: first (and only) heard inside the window.
@@ -57,7 +58,8 @@ class NavidromeDiscoveryConsistencyTest extends TestCase
 
     public function testMostConsistentRanksByDistinctDaysNotVolume(): void
     {
-        $conn = $this->db($path);
+        $path = $this->tmpPath();
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
         NavidromeFixtureFactory::insertTrack($conn, 'mf-regular', 'Regular', 'Artist');
         NavidromeFixtureFactory::insertTrack($conn, 'mf-binge', 'Binge', 'Artist');
         // mf-regular: 3 distinct days, 1 play each.
@@ -87,12 +89,12 @@ class NavidromeDiscoveryConsistencyTest extends TestCase
         $this->assertSame([], $repo->getMostConsistentTracks(10));
     }
 
-    private function db(?string &$path): Connection
+    private function tmpPath(): string
     {
         $path = sys_get_temp_dir() . '/nd-disccons-' . uniqid() . '.db';
         $this->cleanup[] = $path;
 
-        return NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        return $path;
     }
 
     private static function play(Connection $conn, string $mediaId, string $time): void

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -4,11 +4,14 @@ namespace App\Tests\Playlist;
 
 use App\Navidrome\NavidromeRepository;
 use App\Playlist\Definition\CoupsDeCoeurDefinition;
+use App\Playlist\Definition\DecouvertesRecentesDefinition;
+use App\Playlist\Definition\FidelesCompagnonsDefinition;
 use App\Playlist\Definition\HappyBirthdayDefinition;
 use App\Playlist\Definition\HitParadeDefinition;
 use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
+use App\Playlist\Definition\TopDeLanneeDefinition;
 use App\Playlist\Definition\TopDuMoisDefinition;
 use App\Playlist\PlaylistContext;
 use PHPUnit\Framework\TestCase;
@@ -130,6 +133,48 @@ class DefinitionsTest extends TestCase
         $this->assertSame(['a', 'b', 'c'], $ids);
     }
 
+    public function testTopDeLanneeQueriesPreviousCalendarYear(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        // now = 2026-06-27 → previous full year = 2025.
+        $navidrome->expects($this->once())
+            ->method('getTopTracksWithDates')
+            ->with(2025, null, null, 50)
+            ->willReturn([['id' => 'mf-1'], ['id' => 'mf-2']]);
+
+        $ids = (new TopDeLanneeDefinition($navidrome, 50))->build($this->ctx('2026-06-27'));
+
+        sort($ids); // shuffled → assert the set.
+        $this->assertSame(['mf-1', 'mf-2'], $ids);
+    }
+
+    public function testDecouvertesRecentesUsesCutoffFromSinceDays(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getRecentlyDiscoveredTracks')
+            ->with(
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2026-05-28'),
+                50,
+            )
+            ->willReturn(['mf-new']);
+
+        $def = new DecouvertesRecentesDefinition($navidrome, sinceDays: 30, limit: 50);
+        $this->assertSame(['mf-new'], $def->build($this->ctx('2026-06-27')));
+    }
+
+    public function testFidelesCompagnonsKeepsRepoOrder(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getMostConsistentTracks')
+            ->with(50)
+            ->willReturn(['mf-a', 'mf-b']);
+
+        // Ranked by regularity → no shuffle.
+        $this->assertSame(['mf-a', 'mf-b'], (new FidelesCompagnonsDefinition($navidrome, 50))->build($this->ctx('2026-06-27')));
+    }
+
     public function testSlugsAndNamesAreStable(): void
     {
         $navidrome = $this->createMock(NavidromeRepository::class);
@@ -140,6 +185,9 @@ class DefinitionsTest extends TestCase
         $this->assertSame('kickstart', (new KickstartDefinition($navidrome))->getSlug());
         $this->assertSame('happy-birthday', (new HappyBirthdayDefinition($navidrome))->getSlug());
         $this->assertSame('hit-parade', (new HitParadeDefinition($navidrome))->getSlug());
+        $this->assertSame('top-de-lannee', (new TopDeLanneeDefinition($navidrome))->getSlug());
+        $this->assertSame('decouvertes-recentes', (new DecouvertesRecentesDefinition($navidrome))->getSlug());
+        $this->assertSame('fideles-compagnons', (new FidelesCompagnonsDefinition($navidrome))->getSlug());
     }
 
     private function ctx(string $now): PlaylistContext


### PR DESCRIPTION
## Résumé

Trois nouveaux types de playlist (auto-découverts par le système plugin → **cochés par défaut**).

| Slug | Algo | Requête |
|------|------|---------|
| `top-de-lannee` | **Top de l'année** : top de l'année calendaire écoulée (`now.Y-1`), shuffle | réutilise `getTopTracksWithDates` — **aucune nouvelle** |
| `decouvertes-recentes` | **Découvertes récentes** : morceaux dont le **1ᵉʳ scrobble** date des N derniers jours (défaut 30), du plus récent au plus ancien | nouvelle `getRecentlyDiscoveredTracks` |
| `fideles-compagnons` | **Fidèles compagnons** : morceaux écoutés sur le **plus de jours distincts** (régularité, pas volume), classé | nouvelle `getMostConsistentTracks` |

## Nouvelles requêtes repo

Calquées sur `getDailyKickstartTracks` (guard `hasScrobblesTable` → `[]` sur Navidrome < 0.55, UTC `date(...,'unixepoch')`, pas de window function) :
- `getRecentlyDiscoveredTracks(since, limit)` → `HAVING MIN(submission_time) >= :since`.
- `getMostConsistentTracks(limit)` → `ORDER BY COUNT(DISTINCT jour) DESC`.

## Câblage

`services.yaml` (3 services, `PLAYLIST_DISCOVERIES_DAYS=30`), `.env.dist` + `phpunit.xml.dist`, slugs documentés. « Top de l'année » a un **nom statique** (écrasement par nom → reflète toujours la dernière année pleine).

## Tests (237/237, phpcs clean, phpstan inchangé)

- Repo : découvertes ne garde que les morceaux 1ᵉʳ-joués dans la fenêtre ; fidèles classe par jours distincts (régulier > binge) ; table absente → `[]`.
- Définitions : année précédente interrogée, cutoff = `now-sinceDays`, ordre conservé, slugs stables.

Tu passes à **11 playlists**. (Découvertes/Fidèles nécessitent la table `scrobbles` de Navidrome ≥ 0.55.)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_