### PR TITLE
ci: notification Slack/Discord uniquement sur develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,11 @@ jobs:
     name: Notify CI result (Discord/Slack)
     runs-on: ubuntu-latest
     # Depend on every other job and run even when one failed, so the
-    # notification reflects the WHOLE run's outcome.
+    # notification reflects the WHOLE run's outcome. Scoped to the develop
+    # branch only: no notification on PRs, main, or tags. `always()` keeps
+    # it running after a failed job; the ref check gates the branch.
     needs: [phpcs, phpstan, tests, docker-build, docker-publish]
-    if: always()
+    if: ${{ always() && github.ref == 'refs/heads/develop' }}
     steps:
       - name: Compute overall status
         id: status


### PR DESCRIPTION
## Résumé

Le job `notify` (webhook Slack/Discord en fin de CI) ne se déclenche désormais **que sur les push de la branche `develop`** — plus rien sur les PR, ni `main`/tags.

## Changement

```yaml
if: ${{ always() && github.ref == 'refs/heads/develop' }}
```

- `always()` : garde le job actif même si un job précédent a échoué (pour notifier les échecs).
- `github.ref == 'refs/heads/develop'` : limite aux push sur develop (sur une PR, `github.ref` vaut `refs/pull/N/merge` → job skippé).

## Effet

- Push/merge sur `develop` → notif Slack (succès **et** échec).
- PR ouverte/mise à jour → CI tourne mais **pas de notif**.

Une seule ligne modifiée dans `.github/workflows/ci.yml`.

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_