### PR TITLE
feat(lidarr): client API (lookup + add artist + dédup + profils)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -54,6 +54,15 @@ MUSICBRAINZ_BASE_URL=https://musicbrainz.org/ws/2/
 # new screen pre-filled with the artist (or artist + album when known).
 # Leave empty to hide the links.
 LIDARR_URL=
+# API (optionnel) — requis seulement pour l'ajout d'artistes via les
+# recommandations (« Ajouter à Lidarr »). Sans clé, seuls les liens profonds
+# fonctionnent. Dossier/profils laissés vides = 1er trouvé via l'API Lidarr.
+LIDARR_API_KEY=
+LIDARR_ROOT_FOLDER=
+LIDARR_QUALITY_PROFILE_ID=0
+LIDARR_METADATA_PROFILE_ID=0
+LIDARR_MONITOR=all
+LIDARR_SEARCH_ON_ADD=true
 ###< Lidarr ###
 
 ###> Strawberry ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -15,6 +15,13 @@ parameters:
     env(PLAYLIST_HITPARADE_WEEKS): '52'
     env(PLAYLIST_HITPARADE_PER_WEEK): '3'
     env(PLAYLIST_DISCOVERIES_DAYS): '30'
+    # Lidarr API (optional; the deep-link extension works with just LIDARR_URL).
+    env(LIDARR_API_KEY): ''
+    env(LIDARR_ROOT_FOLDER): ''
+    env(LIDARR_QUALITY_PROFILE_ID): '0'
+    env(LIDARR_METADATA_PROFILE_ID): '0'
+    env(LIDARR_MONITOR): 'all'
+    env(LIDARR_SEARCH_ON_ADD): 'true'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -38,6 +45,12 @@ parameters:
     musicbrainz.user_agent: '%env(MUSICBRAINZ_USER_AGENT)%'
     musicbrainz.base_url: '%env(MUSICBRAINZ_BASE_URL)%'
     lidarr.url: '%env(default::LIDARR_URL)%'
+    lidarr.api_key: '%env(LIDARR_API_KEY)%'
+    lidarr.root_folder: '%env(LIDARR_ROOT_FOLDER)%'
+    lidarr.quality_profile_id: '%env(int:LIDARR_QUALITY_PROFILE_ID)%'
+    lidarr.metadata_profile_id: '%env(int:LIDARR_METADATA_PROFILE_ID)%'
+    lidarr.monitor: '%env(LIDARR_MONITOR)%'
+    lidarr.search_on_add: '%env(bool:LIDARR_SEARCH_ON_ADD)%'
     help.compose_service: '%env(default::HELP_COMPOSE_SERVICE)%'
     strawberry.db_path: '%env(resolve:STRAWBERRY_DB_PATH)%'
     playlists.default_limit: '%env(int:PLAYLIST_DEFAULT_LIMIT)%'
@@ -242,6 +255,16 @@ services:
         arguments:
             $lidarrUrl: '%lidarr.url%'
         tags: ['twig.extension']
+
+    App\Lidarr\LidarrClient:
+        arguments:
+            $baseUrl: '%lidarr.url%'
+            $apiKey: '%lidarr.api_key%'
+            $rootFolder: '%lidarr.root_folder%'
+            $qualityProfileId: '%lidarr.quality_profile_id%'
+            $metadataProfileId: '%lidarr.metadata_profile_id%'
+            $monitor: '%lidarr.monitor%'
+            $searchOnAdd: '%lidarr.search_on_add%'
 
     App\Twig\ScrobbleLinksExtension:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,6 +31,12 @@
         <env name="LASTFM_FUZZY_MAX_DISTANCE" value="0"/>
         <env name="LASTFM_MATCH_CACHE_TTL_DAYS" value="30"/>
         <env name="STRAWBERRY_DB_PATH" value=""/>
+        <env name="LIDARR_API_KEY" value=""/>
+        <env name="LIDARR_ROOT_FOLDER" value=""/>
+        <env name="LIDARR_QUALITY_PROFILE_ID" value="0"/>
+        <env name="LIDARR_METADATA_PROFILE_ID" value="0"/>
+        <env name="LIDARR_MONITOR" value="all"/>
+        <env name="LIDARR_SEARCH_ON_ADD" value="true"/>
         <env name="BACKUP_RETENTION_DAYS" value="7"/>
         <env name="RUN_HISTORY_RETENTION_DAYS" value="90"/>
         <env name="NOTIFY_DRIVERS" value=""/>

--- a/src/Lidarr/LidarrClient.php
+++ b/src/Lidarr/LidarrClient.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace App\Lidarr;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Minimal client for Lidarr's v1 REST API — just what the artist
+ * recommendation feature needs: discover config (root folders / quality /
+ * metadata profiles), list already-tracked artists for dedup, and ADD an
+ * artist by its MusicBrainz id.
+ *
+ * Auth: `X-Api-Key` header. {@see isConfigured()} guards every write so the
+ * UI / engine can degrade to the deep-link {@see \App\Twig\LidarrExtension}
+ * when Lidarr isn't wired.
+ *
+ * Defaults for root folder / profiles come from config but are resolved
+ * lazily against the live instance when left blank (first root folder, first
+ * profile) so a minimal `LIDARR_URL` + `LIDARR_API_KEY` is enough to start.
+ */
+class LidarrClient
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $baseUrl = '',
+        #[\SensitiveParameter] private readonly string $apiKey = '',
+        private readonly string $rootFolder = '',
+        private readonly int $qualityProfileId = 0,
+        private readonly int $metadataProfileId = 0,
+        private readonly string $monitor = 'all',
+        private readonly bool $searchOnAdd = true,
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return trim($this->baseUrl) !== '' && trim($this->apiKey) !== '';
+    }
+
+    public function ping(): bool
+    {
+        try {
+            $this->get('/api/v1/system/status');
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * @return list<array{id: int, path: string, accessible: bool, freeSpace: int}>
+     */
+    public function getRootFolders(): array
+    {
+        $out = [];
+        foreach ($this->get('/api/v1/rootfolder') as $r) {
+            if (!is_array($r)) {
+                continue;
+            }
+            $out[] = [
+                'id' => (int) ($r['id'] ?? 0),
+                'path' => (string) ($r['path'] ?? ''),
+                'accessible' => (bool) ($r['accessible'] ?? false),
+                'freeSpace' => (int) ($r['freeSpace'] ?? 0),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function getQualityProfiles(): array
+    {
+        return $this->namedIdList('/api/v1/qualityprofile');
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    public function getMetadataProfiles(): array
+    {
+        return $this->namedIdList('/api/v1/metadataprofile');
+    }
+
+    /**
+     * MusicBrainz artist ids already tracked by Lidarr, as `[mbid => true]`
+     * for O(1) dedup before recommending / adding.
+     *
+     * @return array<string, true>
+     */
+    public function existingArtistMbids(): array
+    {
+        $out = [];
+        foreach ($this->get('/api/v1/artist') as $a) {
+            if (is_array($a) && isset($a['foreignArtistId']) && is_string($a['foreignArtistId']) && $a['foreignArtistId'] !== '') {
+                $out[$a['foreignArtistId']] = true;
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Add an artist to Lidarr by its MusicBrainz id. Looks the artist up so
+     * Lidarr fills the canonical metadata, then POSTs it with our monitor /
+     * profile / root-folder choices. Returns the created artist resource.
+     *
+     * @return array<string, mixed>
+     */
+    public function addArtist(string $mbid): array
+    {
+        if (!$this->isConfigured()) {
+            throw new LidarrException('Lidarr is not configured (LIDARR_URL / LIDARR_API_KEY).');
+        }
+        $mbid = trim($mbid);
+        if ($mbid === '') {
+            throw new LidarrException('addArtist requires a non-empty MusicBrainz id.');
+        }
+
+        $lookup = $this->get('/api/v1/artist/lookup', ['term' => 'lidarr:' . $mbid]);
+        $artist = $lookup[0] ?? null;
+        if (!is_array($artist)) {
+            throw new LidarrException(sprintf('Lidarr found no artist for MBID %s.', $mbid));
+        }
+
+        $artist['qualityProfileId'] = $this->resolveQualityProfileId();
+        $artist['metadataProfileId'] = $this->resolveMetadataProfileId();
+        $artist['rootFolderPath'] = $this->resolveRootFolder();
+        $artist['monitored'] = true;
+        $artist['monitorNewItems'] = 'all';
+        $artist['addOptions'] = [
+            'monitor' => $this->monitor,
+            'searchForMissingAlbums' => $this->searchOnAdd,
+        ];
+
+        return $this->post('/api/v1/artist', $artist);
+    }
+
+    // --- internals -------------------------------------------------------
+
+    private function resolveRootFolder(): string
+    {
+        if (trim($this->rootFolder) !== '') {
+            return $this->rootFolder;
+        }
+        $folders = $this->getRootFolders();
+        if ($folders === []) {
+            throw new LidarrException('No Lidarr root folder configured (set LIDARR_ROOT_FOLDER).');
+        }
+
+        return $folders[0]['path'];
+    }
+
+    private function resolveQualityProfileId(): int
+    {
+        if ($this->qualityProfileId > 0) {
+            return $this->qualityProfileId;
+        }
+        $profiles = $this->getQualityProfiles();
+        if ($profiles === []) {
+            throw new LidarrException('No Lidarr quality profile found.');
+        }
+
+        return $profiles[0]['id'];
+    }
+
+    private function resolveMetadataProfileId(): int
+    {
+        if ($this->metadataProfileId > 0) {
+            return $this->metadataProfileId;
+        }
+        $profiles = $this->getMetadataProfiles();
+        if ($profiles === []) {
+            throw new LidarrException('No Lidarr metadata profile found.');
+        }
+
+        return $profiles[0]['id'];
+    }
+
+    /**
+     * @return list<array{id: int, name: string}>
+     */
+    private function namedIdList(string $path): array
+    {
+        $out = [];
+        foreach ($this->get($path) as $r) {
+            if (is_array($r)) {
+                $out[] = ['id' => (int) ($r['id'] ?? 0), 'name' => (string) ($r['name'] ?? '')];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, scalar> $query
+     *
+     * @return list<mixed>|array<string, mixed>
+     */
+    private function get(string $path, array $query = []): array
+    {
+        return $this->request('GET', $path, ['query' => $query]);
+    }
+
+    /**
+     * @param array<string, mixed> $body
+     *
+     * @return array<string, mixed>
+     */
+    private function post(string $path, array $body): array
+    {
+        /** @var array<string, mixed> $res */
+        $res = $this->request('POST', $path, ['json' => $body]);
+
+        return $res;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @return array<int|string, mixed>
+     */
+    private function request(string $method, string $path, array $options): array
+    {
+        if (trim($this->baseUrl) === '') {
+            throw new LidarrException('Lidarr base URL is not set (LIDARR_URL).');
+        }
+
+        $url = rtrim($this->baseUrl, '/') . $path;
+        $options['headers'] = ['X-Api-Key' => $this->apiKey, 'Accept' => 'application/json'];
+        $options['timeout'] = 30;
+
+        try {
+            $response = $this->httpClient->request($method, $url, $options);
+            $status = $response->getStatusCode();
+        } catch (ExceptionInterface $e) {
+            throw new LidarrException(sprintf('Lidarr %s %s failed: %s', $method, $path, $e->getMessage()), 0, $e);
+        }
+
+        if ($status >= 400) {
+            throw new LidarrException(sprintf('Lidarr %s %s returned HTTP %d.', $method, $path, $status));
+        }
+
+        try {
+            /** @var array<int|string, mixed> $body */
+            $body = $response->toArray(false);
+        } catch (ExceptionInterface $e) {
+            throw new LidarrException(sprintf('Lidarr %s %s returned invalid JSON: %s', $method, $path, $e->getMessage()), 0, $e);
+        }
+
+        return $body;
+    }
+}

--- a/src/Lidarr/LidarrException.php
+++ b/src/Lidarr/LidarrException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace App\Lidarr;
+
+class LidarrException extends \RuntimeException
+{
+}

--- a/tests/Lidarr/LidarrClientTest.php
+++ b/tests/Lidarr/LidarrClientTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Tests\Lidarr;
+
+use App\Lidarr\LidarrClient;
+use App\Lidarr\LidarrException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class LidarrClientTest extends TestCase
+{
+    public function testIsConfiguredRequiresUrlAndKey(): void
+    {
+        $http = new MockHttpClient([]);
+        $this->assertFalse((new LidarrClient($http, '', ''))->isConfigured());
+        $this->assertFalse((new LidarrClient($http, 'http://l:8686', ''))->isConfigured());
+        $this->assertTrue((new LidarrClient($http, 'http://l:8686', 'key'))->isConfigured());
+    }
+
+    public function testExistingArtistMbidsCollectsForeignIds(): void
+    {
+        $http = new MockHttpClient([
+            new MockResponse(json_encode([
+                ['foreignArtistId' => 'mbid-a', 'artistName' => 'A'],
+                ['foreignArtistId' => 'mbid-b', 'artistName' => 'B'],
+                ['artistName' => 'No id'],
+            ], \JSON_THROW_ON_ERROR)),
+        ]);
+        $client = new LidarrClient($http, 'http://l:8686', 'key');
+
+        $mbids = $client->existingArtistMbids();
+
+        $this->assertArrayHasKey('mbid-a', $mbids);
+        $this->assertArrayHasKey('mbid-b', $mbids);
+        $this->assertCount(2, $mbids);
+    }
+
+    public function testAddArtistLooksUpThenPostsWithProfilesAndFolder(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured[] = [$method, $url, $options];
+            // 1st call: lookup → return a candidate; 2nd: POST → echo created.
+            if (str_contains($url, '/artist/lookup')) {
+                return new MockResponse(json_encode([[
+                    'foreignArtistId' => 'mbid-x', 'artistName' => 'New Artist',
+                ]], \JSON_THROW_ON_ERROR));
+            }
+
+            return new MockResponse(json_encode(['id' => 7, 'artistName' => 'New Artist'], \JSON_THROW_ON_ERROR));
+        });
+
+        $client = new LidarrClient(
+            $http,
+            'http://l:8686',
+            'secret-key',
+            rootFolder: '/music',
+            qualityProfileId: 3,
+            metadataProfileId: 2,
+            monitor: 'all',
+            searchOnAdd: true,
+        );
+
+        $created = $client->addArtist('mbid-x');
+
+        $this->assertSame(7, $created['id']);
+        // Lookup carried the lidarr:{mbid} term and the api key header.
+        [$m0, $u0, $o0] = $captured[0];
+        $this->assertSame('GET', $m0);
+        $this->assertStringContainsString('/api/v1/artist/lookup', $u0);
+        $this->assertStringContainsString('term=lidarr', $u0);
+        $this->assertStringContainsString('mbid-x', $u0);
+        $this->assertContains('X-Api-Key: secret-key', $o0['headers']);
+        // POST body merged our profile/folder/monitor choices.
+        [$m1, $u1, $o1] = $captured[1];
+        $this->assertSame('POST', $m1);
+        $this->assertStringEndsWith('/api/v1/artist', $u1);
+        $body = json_decode($o1['body'], true);
+        $this->assertSame(3, $body['qualityProfileId']);
+        $this->assertSame(2, $body['metadataProfileId']);
+        $this->assertSame('/music', $body['rootFolderPath']);
+        $this->assertTrue($body['monitored']);
+        $this->assertSame('all', $body['addOptions']['monitor']);
+        $this->assertTrue($body['addOptions']['searchForMissingAlbums']);
+    }
+
+    public function testAddArtistResolvesRootFolderAndProfilesWhenBlank(): void
+    {
+        $http = new MockHttpClient(function (string $method, string $url): MockResponse {
+            if (str_contains($url, '/artist/lookup')) {
+                return new MockResponse(json_encode([['foreignArtistId' => 'mbid-x', 'artistName' => 'X']], \JSON_THROW_ON_ERROR));
+            }
+            if (str_contains($url, '/rootfolder')) {
+                return new MockResponse(json_encode([['id' => 1, 'path' => '/data/music', 'accessible' => true, 'freeSpace' => 10]], \JSON_THROW_ON_ERROR));
+            }
+            if (str_contains($url, '/qualityprofile')) {
+                return new MockResponse(json_encode([['id' => 9, 'name' => 'Lossless']], \JSON_THROW_ON_ERROR));
+            }
+            if (str_contains($url, '/metadataprofile')) {
+                return new MockResponse(json_encode([['id' => 4, 'name' => 'Standard']], \JSON_THROW_ON_ERROR));
+            }
+
+            // POST /artist
+            return new MockResponse(json_encode(['id' => 1], \JSON_THROW_ON_ERROR));
+        });
+
+        // Blank root folder + profile ids → resolved from the live instance.
+        $client = new LidarrClient($http, 'http://l:8686', 'key');
+        $created = $client->addArtist('mbid-x');
+
+        $this->assertSame(1, $created['id']);
+    }
+
+    public function testAddArtistThrowsWhenNotConfigured(): void
+    {
+        $client = new LidarrClient(new MockHttpClient([]), '', '');
+
+        $this->expectException(LidarrException::class);
+        $this->expectExceptionMessage('not configured');
+        $client->addArtist('mbid-x');
+    }
+
+    public function testHttpErrorIsWrapped(): void
+    {
+        $http = new MockHttpClient([new MockResponse('nope', ['http_code' => 401])]);
+        $client = new LidarrClient($http, 'http://l:8686', 'bad-key');
+
+        $this->expectException(LidarrException::class);
+        $this->expectExceptionMessage('HTTP 401');
+        $client->existingArtistMbids();
+    }
+
+    public function testPingReturnsFalseOnError(): void
+    {
+        $http = new MockHttpClient([new MockResponse('err', ['http_code' => 500])]);
+        $this->assertFalse((new LidarrClient($http, 'http://l:8686', 'key'))->ping());
+    }
+}


### PR DESCRIPTION
## Résumé (PR A/D — recommandations → Lidarr)

Fondation : un **client API Lidarr** (le projet n'avait que des liens profonds). Permettra l'ajout d'artistes recommandés en 1 clic (PR D).

## `LidarrClient` (`src/Lidarr/LidarrClient.php`)

HttpClientInterface, auth header `X-Api-Key` :
- `ping()`, `getRootFolders()` / `getQualityProfiles()` / `getMetadataProfiles()` (découverte config).
- `existingArtistMbids()` → `GET /api/v1/artist` → `[foreignArtistId => true]` pour la **dédup**.
- `addArtist(mbid)` → `GET /api/v1/artist/lookup?term=lidarr:{mbid}` (métadonnées canoniques), fixe `qualityProfileId`/`metadataProfileId`/`rootFolderPath`/`monitored`/`addOptions{monitor, searchForMissingAlbums}`, puis `POST /api/v1/artist`. **Dossier/profils résolus depuis l'instance** si laissés vides (1ᵉʳ trouvé) → un simple `LIDARR_URL` + `LIDARR_API_KEY` suffit.
- `isConfigured()` = url+clé non vides ; gardes claires sinon (`LidarrException`).

## Config

Params `lidarr.*` + défauts `env(...)` **optionnels** : `LIDARR_API_KEY`, `LIDARR_ROOT_FOLDER`, `LIDARR_QUALITY_PROFILE_ID`, `LIDARR_METADATA_PROFILE_ID`, `LIDARR_MONITOR=all`, `LIDARR_SEARCH_ON_ADD=true`. Câblage `services.yaml`, `.env.dist`, `phpunit.xml.dist`. (`LIDARR_URL` existait déjà.)

## Tests (244/244, phpcs clean, phpstan inchangé)

`MockHttpClient` : `isConfigured`, dédup `foreignArtistId`, `addArtist` (term `lidarr:{mbid}` + body profils/dossier/monitor), résolution dossier/profils si vides, gardes non-configuré / HTTP error / ping.

## Suite

PR B = moteur de reco Last.fm + snapshot async ; PR C = source ListenBrainz ; PR D = UI de revue + « Ajouter à Lidarr ».

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_