### PR TITLE
feat(reco): moteur de recommandations d'artistes Last.fm + snapshot async + CLI

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -65,6 +65,18 @@ LIDARR_MONITOR=all
 LIDARR_SEARCH_ON_ADD=true
 ###< Lidarr ###
 
+###> Recommandations d'artistes ###
+# Recommandations personnalisées d'artistes (similaires à ce que tu écoutes),
+# à ajouter à Lidarr en 1 clic depuis /recommendations. Source Last.fm active
+# dès que LASTFM_API_KEY est défini. Tous optionnels (défauts ci-dessous).
+# RECO_SEED_LIMIT  : nombre d'artistes « seeds » (ton top) qui pilotent la reco.
+# RECO_PER_SEED    : voisins demandés à Last.fm par seed.
+# RECO_LIMIT       : taille max de la liste finale.
+RECO_SEED_LIMIT=25
+RECO_PER_SEED=20
+RECO_LIMIT=50
+###< Recommandations d'artistes ###
+
 ###> Strawberry ###
 # Path to strawberry.db inside the container. Empty = disabled.
 STRAWBERRY_DB_PATH=

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -18,3 +18,4 @@ framework:
             'App\Message\RematchMessage': async
             'App\Message\SuggestAliasesMusicBrainzMessage': async
             'App\Message\GeneratePlaylistsMessage': async
+            'App\Message\ComputeRecommendationsMessage': async

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -22,6 +22,10 @@ parameters:
     env(LIDARR_METADATA_PROFILE_ID): '0'
     env(LIDARR_MONITOR): 'all'
     env(LIDARR_SEARCH_ON_ADD): 'true'
+    # Artist recommendations (optional; inactive until LASTFM_API_KEY etc. set).
+    env(RECO_SEED_LIMIT): '25'
+    env(RECO_PER_SEED): '20'
+    env(RECO_LIMIT): '50'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -64,6 +68,9 @@ parameters:
     playlist.hitparade.weeks: '%env(int:PLAYLIST_HITPARADE_WEEKS)%'
     playlist.hitparade.per_week: '%env(int:PLAYLIST_HITPARADE_PER_WEEK)%'
     playlist.discoveries.days: '%env(int:PLAYLIST_DISCOVERIES_DAYS)%'
+    reco.seed_limit: '%env(int:RECO_SEED_LIMIT)%'
+    reco.per_seed: '%env(int:RECO_PER_SEED)%'
+    reco.limit: '%env(int:RECO_LIMIT)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -88,6 +95,8 @@ services:
             tags: ['app.notifier_driver']
         App\Playlist\PlaylistDefinitionInterface:
             tags: ['app.playlist_definition']
+        App\Recommendation\RecommendationSourceInterface:
+            tags: ['app.recommendation_source']
 
     App\:
         resource: '../src/'
@@ -265,6 +274,17 @@ services:
             $metadataProfileId: '%lidarr.metadata_profile_id%'
             $monitor: '%lidarr.monitor%'
             $searchOnAdd: '%lidarr.search_on_add%'
+
+    App\Recommendation\LastFmRecommendationSource:
+        arguments:
+            $apiKey: '%lastfm.api_key%'
+            $perSeedLimit: '%reco.per_seed%'
+
+    App\Recommendation\RecommendationEngine:
+        arguments:
+            $sources: !tagged_iterator app.recommendation_source
+            $seedLimit: '%reco.seed_limit%'
+            $defaultLimit: '%reco.limit%'
 
     App\Twig\ScrobbleLinksExtension:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -59,6 +59,9 @@
         <env name="PLAYLIST_HITPARADE_WEEKS" value="52"/>
         <env name="PLAYLIST_HITPARADE_PER_WEEK" value="3"/>
         <env name="PLAYLIST_DISCOVERIES_DAYS" value="30"/>
+        <env name="RECO_SEED_LIMIT" value="25"/>
+        <env name="RECO_PER_SEED" value="20"/>
+        <env name="RECO_LIMIT" value="50"/>
     </php>
 
     <testsuites>

--- a/src/Command/ComputeRecommendationsCommand.php
+++ b/src/Command/ComputeRecommendationsCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Recommendation\RecommendationEngine;
+use App\Recommendation\RecommendationResult;
+use App\Recommendation\RecommendationStore;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Compute the artist recommendations snapshot from my listening.
+ *
+ *   app:recommendations:compute [--limit=50] [--dry-run]
+ *
+ * `--dry-run` prints the ranked list without saving the snapshot or touching
+ * Lidarr (adding artists stays a manual, per-artist action in the UI).
+ */
+#[AsCommand(
+    name: 'app:recommendations:compute',
+    description: 'Compute personalized artist recommendations (Last.fm / ListenBrainz) for the review page.',
+)]
+class ComputeRecommendationsCommand extends Command
+{
+    /** MusicBrainz rate-limits at 1 req/s per UA — stay just under. */
+    private const MB_THROTTLE_MICROSECONDS = 1_100_000;
+
+    public function __construct(
+        private readonly RecommendationEngine $engine,
+        private readonly RecommendationStore $store,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum number of recommendations to keep.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print the ranked list without saving the snapshot.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $limitOpt = $input->getOption('limit');
+        $limit = is_numeric($limitOpt) ? max(1, (int) $limitOpt) : null;
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $io->title($dryRun ? 'Recommandations [dry-run]' : 'Recommandations');
+
+        $throttle = static function (string $name): void {
+            usleep(self::MB_THROTTLE_MICROSECONDS);
+        };
+
+        try {
+            if ($dryRun) {
+                $result = $this->engine->compute($limit, $throttle);
+            } else {
+                $result = $this->recorder->record(
+                    type: RunHistory::TYPE_RECOMMENDATIONS,
+                    reference: 'compute',
+                    label: 'Calcul des recommandations d\'artistes (CLI)',
+                    action: function () use ($limit, $throttle): RecommendationResult {
+                        $r = $this->engine->compute($limit, $throttle);
+                        $this->store->save($r, new \DateTimeImmutable());
+
+                        return $r;
+                    },
+                    extractMetrics: static fn (RecommendationResult $r): array => ['recommandations' => $r->count()],
+                );
+            }
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $this->printResult($io, $result);
+
+        return Command::SUCCESS;
+    }
+
+    private function printResult(SymfonyStyle $io, RecommendationResult $result): void
+    {
+        if ($result->count() === 0) {
+            $io->warning('Aucune recommandation (vérifiez LASTFM_API_KEY / LISTENBRAINZ_USER et votre historique).');
+            return;
+        }
+
+        $rows = [];
+        foreach ($result->recommendations as $rank => $r) {
+            $rows[] = [
+                $rank + 1,
+                $r->name,
+                $r->mbid ?? '—',
+                number_format($r->score, 1),
+                implode(', ', $r->sources),
+                implode(', ', array_slice($r->seeds, 0, 3)),
+            ];
+        }
+        $io->table(['#', 'artiste', 'mbid', 'score', 'sources', 'seeds'], $rows);
+        $io->success(sprintf(
+            '%d recommandation(s) — %d seeds, %d candidats, %d lookups MBID.',
+            $result->count(),
+            $result->seedCount,
+            $result->rawCandidates,
+            $result->mbidLookups,
+        ));
+    }
+}

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -25,6 +25,7 @@ class RunHistory
     public const TYPE_STRAWBERRY_REMATCH = 'strawberry-rematch';
     public const TYPE_STATS = 'stats';
     public const TYPE_PLAYLIST_GENERATE = 'playlist-generate';
+    public const TYPE_RECOMMENDATIONS = 'recommendations';
     public const TYPE_BACKUP_PURGE = 'backup-purge';
     public const TYPE_HISTORY_PURGE = 'history-purge';
 

--- a/src/Message/ComputeRecommendationsMessage.php
+++ b/src/Message/ComputeRecommendationsMessage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Message;
+
+/**
+ * Async request to (re)compute the artist recommendations snapshot. Handled
+ * by the Messenger worker because it fans out across Last.fm / ListenBrainz /
+ * MusicBrainz (rate-limited), which is too slow for a web request. The result
+ * is persisted by {@see \App\Recommendation\RecommendationStore} for the
+ * review UI to display.
+ */
+final class ComputeRecommendationsMessage
+{
+    public function __construct(
+        public readonly ?int $limit = null,
+    ) {
+    }
+}

--- a/src/MessageHandler/ComputeRecommendationsMessageHandler.php
+++ b/src/MessageHandler/ComputeRecommendationsMessageHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\ComputeRecommendationsMessage;
+use App\Recommendation\RecommendationEngine;
+use App\Recommendation\RecommendationResult;
+use App\Recommendation\RecommendationStore;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
+
+/**
+ * Worker-side handler for {@see ComputeRecommendationsMessage}: runs the
+ * engine (throttling MusicBrainz lookups), saves the snapshot for the review
+ * UI, and records a RunHistory entry so the outcome surfaces on the history
+ * page — like Sync / Rematch / Playlists.
+ */
+#[AsMessageHandler]
+class ComputeRecommendationsMessageHandler
+{
+    /** MusicBrainz rate-limits at 1 req/s per UA — stay just under. */
+    private const MB_THROTTLE_MICROSECONDS = 1_100_000;
+
+    public function __construct(
+        private readonly RecommendationEngine $engine,
+        private readonly RecommendationStore $store,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+    }
+
+    public function __invoke(ComputeRecommendationsMessage $message): void
+    {
+        $this->recorder->record(
+            type: RunHistory::TYPE_RECOMMENDATIONS,
+            reference: 'compute',
+            label: 'Calcul des recommandations d\'artistes',
+            action: function () use ($message): RecommendationResult {
+                $result = $this->engine->compute(
+                    $message->limit,
+                    static function (string $name): void {
+                        usleep(self::MB_THROTTLE_MICROSECONDS);
+                    },
+                );
+                $this->store->save($result, new \DateTimeImmutable());
+
+                return $result;
+            },
+            extractMetrics: static fn (RecommendationResult $r): array => [
+                'recommandations' => $r->count(),
+                'seeds' => $r->seedCount,
+                'candidats' => $r->rawCandidates,
+                'mbid_lookups' => $r->mbidLookups,
+            ],
+        );
+    }
+}

--- a/src/Recommendation/ArtistRecommendation.php
+++ b/src/Recommendation/ArtistRecommendation.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Recommendation;
+
+/**
+ * One recommended artist, aggregated across sources. `mbid` may be null
+ * until resolved (Lidarr needs it to add the artist). `sources` lists which
+ * engines surfaced it (e.g. `['lastfm','listenbrainz']`); `seeds` the
+ * library artists that pulled it (for the « parce que tu écoutes X » UI).
+ */
+final class ArtistRecommendation implements \JsonSerializable
+{
+    /**
+     * @param list<string> $sources
+     * @param list<string> $seeds
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly ?string $mbid,
+        public readonly float $score,
+        public readonly array $sources,
+        public readonly array $seeds,
+    ) {
+    }
+
+    /**
+     * @return array{name: string, mbid: ?string, score: float, sources: list<string>, seeds: list<string>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'mbid' => $this->mbid,
+            'score' => $this->score,
+            'sources' => $this->sources,
+            'seeds' => $this->seeds,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(array $row): self
+    {
+        return new self(
+            (string) ($row['name'] ?? ''),
+            isset($row['mbid']) && $row['mbid'] !== '' ? (string) $row['mbid'] : null,
+            (float) ($row['score'] ?? 0),
+            array_values(array_map('strval', (array) ($row['sources'] ?? []))),
+            array_values(array_map('strval', (array) ($row['seeds'] ?? []))),
+        );
+    }
+}

--- a/src/Recommendation/ArtistSeed.php
+++ b/src/Recommendation/ArtistSeed.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Recommendation;
+
+/**
+ * A « seed » artist from my own listening, fed to the recommendation
+ * sources. `weight` reflects how strongly it should pull recommendations
+ * (volume / loved / recency combined by {@see SeedBuilder}).
+ */
+final class ArtistSeed
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly float $weight,
+        public readonly ?string $mbid = null,
+    ) {
+    }
+}

--- a/src/Recommendation/LastFmRecommendationSource.php
+++ b/src/Recommendation/LastFmRecommendationSource.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace App\Recommendation;
+
+use App\LastFm\LastFmApiException;
+use App\LastFm\LastFmClient;
+
+/**
+ * Last.fm `artist.getSimilar` recommendation source. For each seed artist we
+ * ask Last.fm for its neighbours and accumulate a score = Σ(match × seed
+ * weight): an artist surfaced by several strong seeds floats up. MBIDs come
+ * straight from Last.fm when present (the engine resolves the rest).
+ *
+ * Per-seed failures are swallowed (one dead seed mustn't sink the run); a
+ * missing API key makes the source unconfigured (skipped by the engine).
+ */
+final class LastFmRecommendationSource implements RecommendationSourceInterface
+{
+    public function __construct(
+        private readonly LastFmClient $client,
+        #[\SensitiveParameter]
+        private readonly string $apiKey = '',
+        private readonly int $perSeedLimit = 20,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'lastfm';
+    }
+
+    public function isConfigured(): bool
+    {
+        return trim($this->apiKey) !== '';
+    }
+
+    public function recommend(array $seeds): array
+    {
+        if (!$this->isConfigured()) {
+            return [];
+        }
+
+        /** @var array<string, array{name: string, mbid: ?string, score: float, seed: string}> $acc */
+        $acc = [];
+
+        foreach ($seeds as $seed) {
+            try {
+                $similar = $this->client->artistGetSimilar($this->apiKey, $seed->name, $this->perSeedLimit);
+            } catch (LastFmApiException) {
+                // A bad / unknown seed name shouldn't abort the whole run.
+                continue;
+            }
+
+            foreach ($similar as $row) {
+                $name = trim($row['name']);
+                if ($name === '') {
+                    continue;
+                }
+                $key = mb_strtolower($name);
+                $contribution = $row['match'] * $seed->weight;
+
+                if (!isset($acc[$key])) {
+                    $acc[$key] = [
+                        'name' => $name,
+                        'mbid' => $row['mbid'],
+                        'score' => 0.0,
+                        'seed' => $seed->name,
+                    ];
+                }
+                $acc[$key]['score'] += $contribution;
+                // Backfill an MBID if a later neighbour carries one.
+                if ($acc[$key]['mbid'] === null && $row['mbid'] !== null) {
+                    $acc[$key]['mbid'] = $row['mbid'];
+                }
+                // Attribute to the strongest seed seen so far.
+                if ($contribution > 0 && $seed->weight > 0) {
+                    $acc[$key]['seed'] = $this->strongerSeed($acc[$key]['seed'], $seed->name, $seeds);
+                }
+            }
+        }
+
+        return array_values($acc);
+    }
+
+    /**
+     * Keep whichever of the two seeds has the higher weight, so the « parce
+     * que tu écoutes X » attribution points at the most relevant library
+     * artist. Falls back to the incumbent when weights can't be compared.
+     *
+     * @param list<ArtistSeed> $seeds
+     */
+    private function strongerSeed(string $current, string $candidate, array $seeds): string
+    {
+        $weights = [];
+        foreach ($seeds as $s) {
+            $weights[$s->name] = $s->weight;
+        }
+
+        return ($weights[$candidate] ?? 0) > ($weights[$current] ?? 0) ? $candidate : $current;
+    }
+}

--- a/src/Recommendation/RecommendationEngine.php
+++ b/src/Recommendation/RecommendationEngine.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Recommendation;
+
+use App\Lidarr\LidarrClient;
+use App\MusicBrainz\MusicBrainzClient;
+use App\MusicBrainz\MusicBrainzException;
+use App\Navidrome\NavidromeRepository;
+
+/**
+ * Aggregates every configured {@see RecommendationSourceInterface} into one
+ * ranked list of artists to (maybe) add to Lidarr.
+ *
+ * Pipeline:
+ *   1. build weighted seeds from my listening ({@see SeedBuilder});
+ *   2. collect raw candidates from each configured source;
+ *   3. merge by normalized name (sum scores, union sources & seeds);
+ *   4. drop artists I already own / seed with / have ignored;
+ *   5. walk the ranked list top-down, resolving a missing MBID via
+ *      MusicBrainz only for the candidates we actually keep, skipping those
+ *      already in Lidarr, until the cap is reached.
+ *
+ * MusicBrainz throttling is the caller's job: pass `$beforeMbQuery` (a sleep)
+ * — MB rate-limits at 1 req/s per UA.
+ */
+class RecommendationEngine
+{
+    /** Minimum MB search score (0-100) we'll trust when resolving an MBID. */
+    private const MIN_MB_SCORE = 85;
+
+    /**
+     * @param iterable<RecommendationSourceInterface> $sources
+     */
+    public function __construct(
+        private readonly iterable $sources,
+        private readonly SeedBuilder $seedBuilder,
+        private readonly NavidromeRepository $navidrome,
+        private readonly MusicBrainzClient $musicBrainz,
+        private readonly LidarrClient $lidarr,
+        private readonly RecommendationStore $store,
+        private readonly int $seedLimit = 25,
+        private readonly int $defaultLimit = 50,
+    ) {
+    }
+
+    /**
+     * @param ?callable(string): void $beforeMbQuery called right before each
+     *                                               MusicBrainz lookup (throttle host)
+     */
+    public function compute(?int $limit = null, ?callable $beforeMbQuery = null): RecommendationResult
+    {
+        $limit = $limit !== null && $limit > 0 ? $limit : $this->defaultLimit;
+
+        $seeds = $this->seedBuilder->build($this->seedLimit);
+        if ($seeds === []) {
+            return new RecommendationResult([], 0, 0, 0);
+        }
+
+        $merged = $this->mergeSources($seeds);
+        $rawCount = count($merged);
+
+        // Exclusion sets (by normalized name).
+        $owned = $this->navidrome->getKnownArtistsNormalized();
+        $ignoredNames = $this->store->ignoredNames();
+        $seedNorms = [];
+        foreach ($seeds as $s) {
+            $seedNorms[NavidromeRepository::normalize($s->name)] = true;
+        }
+
+        // Exclusion sets (by MBID).
+        $lidarrMbids = $this->lidarrExistingMbids();
+        $ignoredMbids = $this->store->ignoredMbids();
+
+        // Rank by aggregated score, strongest first.
+        usort($merged, static fn (array $a, array $b): int => $b['score'] <=> $a['score']);
+
+        $out = [];
+        $mbLookups = 0;
+        foreach ($merged as $cand) {
+            if (count($out) >= $limit) {
+                break;
+            }
+
+            $norm = NavidromeRepository::normalize($cand['name']);
+            if ($norm === '' || isset($owned[$norm]) || isset($seedNorms[$norm]) || isset($ignoredNames[$norm])) {
+                continue;
+            }
+
+            $mbid = $cand['mbid'];
+            if ($mbid === null) {
+                $mbid = $this->resolveMbid($cand['name'], $beforeMbQuery, $mbLookups);
+            }
+
+            if ($mbid !== null && (isset($lidarrMbids[$mbid]) || isset($ignoredMbids[$mbid]))) {
+                continue;
+            }
+
+            $seedsList = array_values(array_unique($cand['seeds']));
+            $sourcesList = array_values(array_unique($cand['sources']));
+            $out[] = new ArtistRecommendation($cand['name'], $mbid, $cand['score'], $sourcesList, $seedsList);
+        }
+
+        return new RecommendationResult($out, count($seeds), $rawCount, $mbLookups);
+    }
+
+    /**
+     * Collect every configured source and fold candidates together by
+     * normalized name: scores add up, sources/seeds union, the first MBID wins.
+     *
+     * @param list<ArtistSeed> $seeds
+     *
+     * @return list<array{name: string, mbid: ?string, score: float, sources: list<string>, seeds: list<string>}>
+     */
+    private function mergeSources(array $seeds): array
+    {
+        /** @var array<string, array{name: string, mbid: ?string, score: float, sources: list<string>, seeds: list<string>}> $acc */
+        $acc = [];
+
+        foreach ($this->sources as $source) {
+            if (!$source->isConfigured()) {
+                continue;
+            }
+            foreach ($source->recommend($seeds) as $row) {
+                $name = trim($row['name']);
+                $norm = NavidromeRepository::normalize($name);
+                if ($norm === '') {
+                    continue;
+                }
+                if (!isset($acc[$norm])) {
+                    $acc[$norm] = ['name' => $name, 'mbid' => null, 'score' => 0.0, 'sources' => [], 'seeds' => []];
+                }
+                $acc[$norm]['score'] += $row['score'];
+                $acc[$norm]['sources'][] = $source->getName();
+                if ($row['seed'] !== '') {
+                    $acc[$norm]['seeds'][] = $row['seed'];
+                }
+                if ($acc[$norm]['mbid'] === null && $row['mbid'] !== null && $row['mbid'] !== '') {
+                    $acc[$norm]['mbid'] = $row['mbid'];
+                }
+            }
+        }
+
+        return array_values($acc);
+    }
+
+    /**
+     * Resolve an MBID for a name via MusicBrainz, accepting only a confident
+     * top hit. Returns null on no match, low score, or a transient MB error
+     * (a missing MBID just means « can't add to Lidarr yet », not a failure).
+     *
+     * @param ?callable(string): void $beforeMbQuery
+     */
+    private function resolveMbid(string $name, ?callable $beforeMbQuery, int &$mbLookups): ?string
+    {
+        if ($beforeMbQuery !== null) {
+            $beforeMbQuery($name);
+        }
+        ++$mbLookups;
+
+        try {
+            $candidates = $this->musicBrainz->searchArtist($name, 3);
+        } catch (MusicBrainzException) {
+            return null;
+        }
+
+        $best = $candidates[0] ?? null;
+        if ($best === null || $best->score < self::MIN_MB_SCORE) {
+            return null;
+        }
+
+        return $best->mbid;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private function lidarrExistingMbids(): array
+    {
+        if (!$this->lidarr->isConfigured()) {
+            return [];
+        }
+        try {
+            return $this->lidarr->existingArtistMbids();
+        } catch (\Throwable) {
+            // Lidarr unreachable shouldn't sink the whole recommendation run;
+            // worst case we recommend an artist already present (the add is
+            // idempotent on Lidarr's side anyway).
+            return [];
+        }
+    }
+}

--- a/src/Recommendation/RecommendationResult.php
+++ b/src/Recommendation/RecommendationResult.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Recommendation;
+
+/**
+ * Outcome of one {@see RecommendationEngine::compute()} run: the ranked
+ * recommendations plus a few counters for the RunHistory metrics / CLI
+ * report (how many seeds drove it, how many raw candidates were merged,
+ * how many MBIDs we had to resolve via MusicBrainz).
+ */
+final class RecommendationResult
+{
+    /**
+     * @param list<ArtistRecommendation> $recommendations ranked, capped, MBID-resolved
+     */
+    public function __construct(
+        public readonly array $recommendations,
+        public readonly int $seedCount = 0,
+        public readonly int $rawCandidates = 0,
+        public readonly int $mbidLookups = 0,
+    ) {
+    }
+
+    public function count(): int
+    {
+        return count($this->recommendations);
+    }
+}

--- a/src/Recommendation/RecommendationSourceInterface.php
+++ b/src/Recommendation/RecommendationSourceInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Recommendation;
+
+/**
+ * A recommendation engine plugin (Last.fm similar, ListenBrainz…), tagged
+ * `app.recommendation_source` and aggregated by {@see RecommendationEngine}
+ * via a tagged iterator. Mirrors the Notifier / Playlist plugin pattern.
+ */
+interface RecommendationSourceInterface
+{
+    /** Stable id, lowercase (e.g. "lastfm", "listenbrainz"). */
+    public function getName(): string;
+
+    /** False when the source lacks its config (API key / username) — skipped. */
+    public function isConfigured(): bool;
+
+    /**
+     * Produce raw recommendations from my seed artists. Scores are
+     * source-relative (the engine normalizes/merges across sources).
+     *
+     * @param list<ArtistSeed> $seeds
+     *
+     * @return list<array{name: string, mbid: ?string, score: float, seed: string}>
+     */
+    public function recommend(array $seeds): array;
+}

--- a/src/Recommendation/RecommendationStore.php
+++ b/src/Recommendation/RecommendationStore.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace App\Recommendation;
+
+use App\Navidrome\NavidromeRepository;
+use App\Repository\SettingRepository;
+
+/**
+ * Persists the recommendation snapshot and the « ignored » set in the
+ * key/value `setting` table — so the review UI shows the last computed list
+ * without recomputing, and dismissed artists never resurface.
+ *
+ * Keys:
+ *   - `recommendations.snapshot`  → JSON {generated_at, items: [...]}
+ *   - `recommendations.ignored`   → JSON {mbids: [...], names: [...norm]}
+ */
+class RecommendationStore
+{
+    private const KEY_SNAPSHOT = 'recommendations.snapshot';
+    private const KEY_IGNORED = 'recommendations.ignored';
+
+    public function __construct(
+        private readonly SettingRepository $settings,
+    ) {
+    }
+
+    public function save(RecommendationResult $result, \DateTimeImmutable $generatedAt): void
+    {
+        $payload = [
+            'generated_at' => $generatedAt->format(\DateTimeInterface::ATOM),
+            'items' => array_map(static fn (ArtistRecommendation $r): array => $r->jsonSerialize(), $result->recommendations),
+        ];
+        $this->settings->set(self::KEY_SNAPSHOT, json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
+     * The last saved snapshot, or null when none was computed yet.
+     *
+     * @return array{generated_at: ?string, items: list<ArtistRecommendation>}|null
+     */
+    public function load(): ?array
+    {
+        $raw = $this->settings->get(self::KEY_SNAPSHOT, '');
+        if ($raw === '') {
+            return null;
+        }
+
+        try {
+            /** @var array<string, mixed> $decoded */
+            $decoded = json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        $items = [];
+        foreach ((array) ($decoded['items'] ?? []) as $row) {
+            if (is_array($row)) {
+                $items[] = ArtistRecommendation::fromArray($row);
+            }
+        }
+
+        return [
+            'generated_at' => isset($decoded['generated_at']) ? (string) $decoded['generated_at'] : null,
+            'items' => $items,
+        ];
+    }
+
+    /**
+     * Mark an artist as ignored so the engine drops it from future runs.
+     * Both the MBID (Lidarr's key) and the normalized name are stored so a
+     * recommendation lacking an MBID can still be dismissed.
+     */
+    public function ignore(?string $mbid, string $name): void
+    {
+        $set = $this->ignoredRaw();
+        if ($mbid !== null && $mbid !== '') {
+            $set['mbids'][$mbid] = true;
+        }
+        $norm = NavidromeRepository::normalize($name);
+        if ($norm !== '') {
+            $set['names'][$norm] = true;
+        }
+        $this->settings->set(self::KEY_IGNORED, json_encode([
+            'mbids' => array_keys($set['mbids']),
+            'names' => array_keys($set['names']),
+        ], \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE));
+    }
+
+    /** @return array<string, true> ignored MBIDs as a lookup set */
+    public function ignoredMbids(): array
+    {
+        return $this->ignoredRaw()['mbids'];
+    }
+
+    /** @return array<string, true> ignored normalized names as a lookup set */
+    public function ignoredNames(): array
+    {
+        return $this->ignoredRaw()['names'];
+    }
+
+    /**
+     * @return array{mbids: array<string, true>, names: array<string, true>}
+     */
+    private function ignoredRaw(): array
+    {
+        $raw = $this->settings->get(self::KEY_IGNORED, '');
+        $mbids = [];
+        $names = [];
+        if ($raw !== '') {
+            try {
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode($raw, true, 512, \JSON_THROW_ON_ERROR);
+                foreach ((array) ($decoded['mbids'] ?? []) as $m) {
+                    $m = (string) $m;
+                    if ($m !== '') {
+                        $mbids[$m] = true;
+                    }
+                }
+                foreach ((array) ($decoded['names'] ?? []) as $n) {
+                    $n = (string) $n;
+                    if ($n !== '') {
+                        $names[$n] = true;
+                    }
+                }
+            } catch (\JsonException) {
+                // Corrupt setting → treat as empty ignored set.
+            }
+        }
+
+        return ['mbids' => $mbids, 'names' => $names];
+    }
+}

--- a/src/Recommendation/SeedBuilder.php
+++ b/src/Recommendation/SeedBuilder.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Recommendation;
+
+use App\Navidrome\NavidromeRepository;
+
+/**
+ * Builds the weighted set of « seed » artists from my own listening, combining
+ * three signals (all from Navidrome):
+ *   - top artists by all-time play volume,
+ *   - recent artists (current calendar year) — a recency boost,
+ *   - loved/starred artists — the strongest taste signal.
+ *
+ * Artists are deduped by normalized name (weights summed) and the top
+ * `$limit` returned. No external calls here — cheap, runs inline.
+ */
+class SeedBuilder
+{
+    private const RECENT_BOOST = 1.5;
+    private const LOVED_BONUS_PER_TRACK = 10.0;
+
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+    ) {
+    }
+
+    /**
+     * @return list<ArtistSeed>
+     */
+    public function build(int $limit): array
+    {
+        /** @var array<string, array{name: string, weight: float}> $acc */
+        $acc = [];
+
+        // Top all-time (weight = play volume).
+        foreach ($this->navidrome->getTopArtistsWithDates(null, null, null, max($limit, 50)) as $row) {
+            $this->add($acc, (string) $row['artist'], (float) $row['plays']);
+        }
+
+        // Recent (current calendar year) — boosted.
+        $year = (int) (new \DateTimeImmutable())->format('Y');
+        foreach ($this->navidrome->getTopArtistsWithDates($year, null, null, max($limit, 50)) as $row) {
+            $this->add($acc, (string) $row['artist'], (float) $row['plays'] * self::RECENT_BOOST);
+        }
+
+        // Loved/starred — strong, flat-ish bonus per loved track.
+        $lovedCounts = [];
+        foreach ($this->navidrome->iterateStarredMediaFiles() as $r) {
+            $artist = (string) ($r['artist'] ?? '');
+            if ($artist !== '') {
+                $lovedCounts[$artist] = ($lovedCounts[$artist] ?? 0) + 1;
+            }
+        }
+        foreach ($lovedCounts as $artist => $count) {
+            $this->add($acc, $artist, $count * self::LOVED_BONUS_PER_TRACK);
+        }
+
+        usort($acc, static fn (array $a, array $b): int => $b['weight'] <=> $a['weight']);
+
+        $seeds = [];
+        foreach (array_slice(array_values($acc), 0, $limit) as $s) {
+            $seeds[] = new ArtistSeed($s['name'], $s['weight']);
+        }
+
+        return $seeds;
+    }
+
+    /**
+     * @param array<string, array{name: string, weight: float}> $acc
+     */
+    private function add(array &$acc, string $artist, float $weight): void
+    {
+        $artist = trim($artist);
+        if ($artist === '') {
+            return;
+        }
+        $key = NavidromeRepository::normalize($artist);
+        if ($key === '') {
+            return;
+        }
+        if (!isset($acc[$key])) {
+            $acc[$key] = ['name' => $artist, 'weight' => 0.0];
+        }
+        $acc[$key]['weight'] += $weight;
+    }
+}

--- a/tests/MessageHandler/ComputeRecommendationsMessageHandlerTest.php
+++ b/tests/MessageHandler/ComputeRecommendationsMessageHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\MessageHandler;
+
+use App\Entity\RunHistory;
+use App\Message\ComputeRecommendationsMessage;
+use App\MessageHandler\ComputeRecommendationsMessageHandler;
+use App\Recommendation\ArtistRecommendation;
+use App\Recommendation\RecommendationEngine;
+use App\Recommendation\RecommendationResult;
+use App\Recommendation\RecommendationStore;
+use App\Service\RunHistoryRecorder;
+use PHPUnit\Framework\TestCase;
+
+class ComputeRecommendationsMessageHandlerTest extends TestCase
+{
+    public function testComputesAndSavesSnapshot(): void
+    {
+        $result = new RecommendationResult([
+            new ArtistRecommendation('Aphex Twin', 'mbid-aphex', 13.0, ['lastfm'], ['Radiohead']),
+        ], seedCount: 5, rawCandidates: 40, mbidLookups: 2);
+
+        $engine = $this->createMock(RecommendationEngine::class);
+        $engine->expects($this->once())->method('compute')->willReturn($result);
+
+        $store = $this->createMock(RecommendationStore::class);
+        $store->expects($this->once())->method('save')->with($result, $this->isInstanceOf(\DateTimeImmutable::class));
+
+        $recorder = $this->createMock(RunHistoryRecorder::class);
+        $recorder->method('record')->willReturnCallback(
+            static fn (string $type, string $ref, string $label, callable $action) => $action(new RunHistory($type, $ref, $label)),
+        );
+
+        $handler = new ComputeRecommendationsMessageHandler($engine, $store, $recorder);
+        $handler(new ComputeRecommendationsMessage());
+    }
+}

--- a/tests/Recommendation/LastFmRecommendationSourceTest.php
+++ b/tests/Recommendation/LastFmRecommendationSourceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\LastFm\LastFmApiException;
+use App\LastFm\LastFmClient;
+use App\Recommendation\ArtistSeed;
+use App\Recommendation\LastFmRecommendationSource;
+use PHPUnit\Framework\TestCase;
+
+class LastFmRecommendationSourceTest extends TestCase
+{
+    public function testUnconfiguredWithoutApiKey(): void
+    {
+        $source = new LastFmRecommendationSource($this->createMock(LastFmClient::class), '');
+        $this->assertFalse($source->isConfigured());
+        $this->assertSame([], $source->recommend([new ArtistSeed('X', 1.0)]));
+        $this->assertSame('lastfm', $source->getName());
+    }
+
+    public function testAccumulatesScoreByMatchTimesSeedWeight(): void
+    {
+        $client = $this->createMock(LastFmClient::class);
+        $client->method('artistGetSimilar')->willReturnCallback(
+            static function (string $apiKey, string $artist): array {
+                if ($artist === 'Radiohead') {
+                    return [
+                        ['name' => 'Thom Yorke', 'mbid' => 'mbid-thom', 'match' => 1.0, 'url' => ''],
+                        ['name' => 'Portishead', 'mbid' => null, 'match' => 0.5, 'url' => ''],
+                    ];
+                }
+
+                // Aphex Twin also surfaces Portishead.
+                return [
+                    ['name' => 'Portishead', 'mbid' => 'mbid-porti', 'match' => 0.4, 'url' => ''],
+                ];
+            },
+        );
+
+        $source = new LastFmRecommendationSource($client, 'key');
+        $rows = $source->recommend([
+            new ArtistSeed('Radiohead', 10.0),
+            new ArtistSeed('Aphex Twin', 5.0),
+        ]);
+
+        $byName = [];
+        foreach ($rows as $r) {
+            $byName[$r['name']] = $r;
+        }
+
+        // Thom Yorke: 1.0 × 10 = 10.
+        $this->assertEqualsWithDelta(10.0, $byName['Thom Yorke']['score'], 0.001);
+        // Portishead: 0.5×10 + 0.4×5 = 7.0, MBID backfilled from the 2nd hit.
+        $this->assertEqualsWithDelta(7.0, $byName['Portishead']['score'], 0.001);
+        $this->assertSame('mbid-porti', $byName['Portishead']['mbid']);
+        // Strongest seed wins attribution (Radiohead weight 10 > Aphex 5).
+        $this->assertSame('Radiohead', $byName['Portishead']['seed']);
+    }
+
+    public function testSwallowsPerSeedApiErrors(): void
+    {
+        $client = $this->createMock(LastFmClient::class);
+        $client->method('artistGetSimilar')->willReturnCallback(
+            static function (string $apiKey, string $artist): array {
+                if ($artist === 'Bad Seed') {
+                    throw new LastFmApiException(6, 'unknown artist');
+                }
+
+                return [['name' => 'Good Match', 'mbid' => null, 'match' => 1.0, 'url' => '']];
+            },
+        );
+
+        $source = new LastFmRecommendationSource($client, 'key');
+        $rows = $source->recommend([
+            new ArtistSeed('Bad Seed', 1.0),
+            new ArtistSeed('Good Seed', 1.0),
+        ]);
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('Good Match', $rows[0]['name']);
+    }
+}

--- a/tests/Recommendation/RecommendationEngineTest.php
+++ b/tests/Recommendation/RecommendationEngineTest.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\Lidarr\LidarrClient;
+use App\MusicBrainz\MusicBrainzArtistCandidate;
+use App\MusicBrainz\MusicBrainzClient;
+use App\Navidrome\NavidromeRepository;
+use App\Recommendation\ArtistSeed;
+use App\Recommendation\RecommendationEngine;
+use App\Recommendation\RecommendationSourceInterface;
+use App\Recommendation\RecommendationStore;
+use PHPUnit\Framework\TestCase;
+
+class RecommendationEngineTest extends TestCase
+{
+    public function testMergesRanksExcludesAndResolvesMbids(): void
+    {
+        $seedBuilder = $this->seedBuilderReturning([new ArtistSeed('Radiohead', 10.0)]);
+
+        $sourceA = $this->source('lastfm', [
+            ['name' => 'Aphex Twin', 'mbid' => 'mbid-aphex', 'score' => 10.0, 'seed' => 'Radiohead'],
+            ['name' => 'Owned Artist', 'mbid' => null, 'score' => 8.0, 'seed' => 'Radiohead'],
+            ['name' => 'In Lidarr Artist', 'mbid' => null, 'score' => 6.0, 'seed' => 'Radiohead'],
+            ['name' => 'Boards of Canada', 'mbid' => null, 'score' => 5.0, 'seed' => 'Radiohead'],
+        ]);
+        $sourceB = $this->source('listenbrainz', [
+            ['name' => 'Aphex Twin', 'mbid' => null, 'score' => 3.0, 'seed' => 'Radiohead'],
+            ['name' => 'Ignored Artist', 'mbid' => null, 'score' => 20.0, 'seed' => 'Radiohead'],
+        ]);
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getKnownArtistsNormalized')
+            ->willReturn([NavidromeRepository::normalize('Owned Artist') => true]);
+
+        $mb = $this->createMock(MusicBrainzClient::class);
+        $mb->method('searchArtist')->willReturnCallback(
+            static function (string $name): array {
+                if ($name === 'Boards of Canada') {
+                    return [new MusicBrainzArtistCandidate('mbid-boc', 'Boards of Canada', 90, [])];
+                }
+                if ($name === 'In Lidarr Artist') {
+                    return [new MusicBrainzArtistCandidate('mbid-inlidarr', 'In Lidarr Artist', 95, [])];
+                }
+
+                return [];
+            },
+        );
+
+        $lidarr = $this->createMock(LidarrClient::class);
+        $lidarr->method('isConfigured')->willReturn(true);
+        $lidarr->method('existingArtistMbids')->willReturn(['mbid-inlidarr' => true]);
+
+        $store = $this->createMock(RecommendationStore::class);
+        $store->method('ignoredNames')->willReturn([NavidromeRepository::normalize('Ignored Artist') => true]);
+        $store->method('ignoredMbids')->willReturn([]);
+
+        $engine = new RecommendationEngine(
+            [$sourceA, $sourceB],
+            $seedBuilder,
+            $navidrome,
+            $mb,
+            $lidarr,
+            $store,
+            seedLimit: 25,
+            defaultLimit: 50,
+        );
+
+        $throttleCalls = 0;
+        $result = $engine->compute(null, function () use (&$throttleCalls): void {
+            ++$throttleCalls;
+        });
+
+        $names = array_map(static fn ($r) => $r->name, $result->recommendations);
+        // Owned / ignored / already-in-Lidarr dropped; the rest ranked by score.
+        $this->assertSame(['Aphex Twin', 'Boards of Canada'], $names);
+
+        $aphex = $result->recommendations[0];
+        $this->assertEqualsWithDelta(13.0, $aphex->score, 0.001); // 10 + 3
+        $this->assertSame('mbid-aphex', $aphex->mbid);
+        $this->assertSame(['lastfm', 'listenbrainz'], $aphex->sources);
+
+        $boc = $result->recommendations[1];
+        $this->assertSame('mbid-boc', $boc->mbid); // resolved via MusicBrainz
+
+        // Two MB lookups (Boards of Canada + In Lidarr Artist); throttle hit each.
+        $this->assertSame(2, $result->mbidLookups);
+        $this->assertSame(2, $throttleCalls);
+        $this->assertSame(1, $result->seedCount);
+    }
+
+    public function testSkipsUnconfiguredSourcesAndCapsToLimit(): void
+    {
+        $seedBuilder = $this->seedBuilderReturning([new ArtistSeed('Seed', 1.0)]);
+
+        $configured = $this->source('lastfm', [
+            ['name' => 'Alpha', 'mbid' => 'm-a', 'score' => 9.0, 'seed' => 'Seed'],
+            ['name' => 'Beta', 'mbid' => 'm-b', 'score' => 8.0, 'seed' => 'Seed'],
+        ]);
+
+        $unconfigured = $this->createMock(RecommendationSourceInterface::class);
+        $unconfigured->method('isConfigured')->willReturn(false);
+        $unconfigured->expects($this->never())->method('recommend');
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getKnownArtistsNormalized')->willReturn([]);
+
+        $lidarr = $this->createMock(LidarrClient::class);
+        $lidarr->method('isConfigured')->willReturn(false);
+
+        $store = $this->createMock(RecommendationStore::class);
+        $store->method('ignoredNames')->willReturn([]);
+        $store->method('ignoredMbids')->willReturn([]);
+
+        $engine = new RecommendationEngine(
+            [$configured, $unconfigured],
+            $seedBuilder,
+            $navidrome,
+            $this->createMock(MusicBrainzClient::class),
+            $lidarr,
+            $store,
+        );
+
+        $result = $engine->compute(1);
+
+        $this->assertCount(1, $result->recommendations);
+        $this->assertSame('Alpha', $result->recommendations[0]->name);
+    }
+
+    public function testEmptySeedsShortCircuits(): void
+    {
+        $seedBuilder = $this->seedBuilderReturning([]);
+        $source = $this->createMock(RecommendationSourceInterface::class);
+        $source->expects($this->never())->method('recommend');
+
+        $engine = new RecommendationEngine(
+            [$source],
+            $seedBuilder,
+            $this->createMock(NavidromeRepository::class),
+            $this->createMock(MusicBrainzClient::class),
+            $this->createMock(LidarrClient::class),
+            $this->createMock(RecommendationStore::class),
+        );
+
+        $result = $engine->compute();
+        $this->assertSame(0, $result->count());
+    }
+
+    /**
+     * @param list<ArtistSeed> $seeds
+     */
+    private function seedBuilderReturning(array $seeds): \App\Recommendation\SeedBuilder
+    {
+        $builder = $this->createMock(\App\Recommendation\SeedBuilder::class);
+        $builder->method('build')->willReturn($seeds);
+
+        return $builder;
+    }
+
+    /**
+     * @param list<array{name: string, mbid: ?string, score: float, seed: string}> $rows
+     */
+    private function source(string $name, array $rows): RecommendationSourceInterface
+    {
+        $source = $this->createMock(RecommendationSourceInterface::class);
+        $source->method('getName')->willReturn($name);
+        $source->method('isConfigured')->willReturn(true);
+        $source->method('recommend')->willReturn($rows);
+
+        return $source;
+    }
+}

--- a/tests/Recommendation/RecommendationStoreTest.php
+++ b/tests/Recommendation/RecommendationStoreTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\Recommendation\ArtistRecommendation;
+use App\Recommendation\RecommendationResult;
+use App\Recommendation\RecommendationStore;
+use App\Repository\SettingRepository;
+use PHPUnit\Framework\TestCase;
+
+class RecommendationStoreTest extends TestCase
+{
+    /**
+     * A stateful SettingRepository stand-in backed by an array, so save/load
+     * and ignore round-trip realistically.
+     *
+     * @param array<string, string> $store
+     */
+    private function settings(array &$store): SettingRepository
+    {
+        $repo = $this->createMock(SettingRepository::class);
+        $repo->method('get')->willReturnCallback(
+            static function (string $key, string $default = '') use (&$store): string {
+                return $store[$key] ?? $default;
+            },
+        );
+        $repo->method('set')->willReturnCallback(
+            static function (string $key, string $value) use (&$store): void {
+                $store[$key] = $value;
+            },
+        );
+
+        return $repo;
+    }
+
+    public function testSaveAndLoadRoundTrips(): void
+    {
+        $store = [];
+        $settings = $this->settings($store);
+        $subject = new RecommendationStore($settings);
+
+        $result = new RecommendationResult([
+            new ArtistRecommendation('Aphex Twin', 'mbid-aphex', 13.0, ['lastfm'], ['Radiohead']),
+            new ArtistRecommendation('Boards of Canada', null, 5.0, ['lastfm'], ['Radiohead']),
+        ]);
+        $at = new \DateTimeImmutable('2026-06-28T10:00:00+00:00');
+
+        $subject->save($result, $at);
+        $loaded = $subject->load();
+
+        $this->assertNotNull($loaded);
+        $this->assertSame('2026-06-28T10:00:00+00:00', $loaded['generated_at']);
+        $this->assertCount(2, $loaded['items']);
+        $this->assertSame('Aphex Twin', $loaded['items'][0]->name);
+        $this->assertSame('mbid-aphex', $loaded['items'][0]->mbid);
+        $this->assertNull($loaded['items'][1]->mbid);
+    }
+
+    public function testLoadReturnsNullWhenEmpty(): void
+    {
+        $store = [];
+        $this->assertNull((new RecommendationStore($this->settings($store)))->load());
+    }
+
+    public function testIgnorePersistsMbidAndNormalizedName(): void
+    {
+        $store = [];
+        $subject = new RecommendationStore($this->settings($store));
+
+        $subject->ignore('mbid-x', 'The Prodigy');
+        $subject->ignore(null, 'Justice'); // no MBID → name only
+
+        $mbids = $subject->ignoredMbids();
+        $names = $subject->ignoredNames();
+
+        $this->assertArrayHasKey('mbid-x', $mbids);
+        $this->assertArrayHasKey(\App\Navidrome\NavidromeRepository::normalize('The Prodigy'), $names);
+        $this->assertArrayHasKey(\App\Navidrome\NavidromeRepository::normalize('Justice'), $names);
+        $this->assertCount(1, $mbids);
+    }
+}

--- a/tests/Recommendation/SeedBuilderTest.php
+++ b/tests/Recommendation/SeedBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\Navidrome\NavidromeRepository;
+use App\Recommendation\ArtistSeed;
+use App\Recommendation\SeedBuilder;
+use PHPUnit\Framework\TestCase;
+
+class SeedBuilderTest extends TestCase
+{
+    public function testCombinesTopRecentAndLovedWeights(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+
+        // First arg null → all-time top; non-null → recent (current year).
+        $navidrome->method('getTopArtistsWithDates')->willReturnCallback(
+            static function (?int $year) {
+                if ($year === null) {
+                    return [
+                        ['artist' => 'Radiohead', 'plays' => 100],
+                        ['artist' => 'Aphex Twin', 'plays' => 40],
+                    ];
+                }
+
+                return [['artist' => 'Radiohead', 'plays' => 10]]; // recent boost ×1.5
+            },
+        );
+
+        $navidrome->method('iterateStarredMediaFiles')->willReturnCallback(
+            static function (): \Generator {
+                yield ['artist' => 'Aphex Twin'];
+                yield ['artist' => 'Aphex Twin'];
+                yield ['artist' => 'Boards of Canada'];
+            },
+        );
+
+        $seeds = (new SeedBuilder($navidrome))->build(10);
+
+        $byName = [];
+        foreach ($seeds as $s) {
+            $this->assertInstanceOf(ArtistSeed::class, $s);
+            $byName[$s->name] = $s->weight;
+        }
+
+        // Radiohead: 100 (all-time) + 10×1.5 (recent) = 115.
+        $this->assertEqualsWithDelta(115.0, $byName['Radiohead'], 0.001);
+        // Aphex Twin: 40 (all-time) + 2 loved ×10 = 60.
+        $this->assertEqualsWithDelta(60.0, $byName['Aphex Twin'], 0.001);
+        // Boards of Canada: 1 loved ×10 = 10.
+        $this->assertEqualsWithDelta(10.0, $byName['Boards of Canada'], 0.001);
+
+        // Ranked by weight, strongest first.
+        $this->assertSame('Radiohead', $seeds[0]->name);
+        $this->assertSame('Aphex Twin', $seeds[1]->name);
+    }
+
+    public function testDedupesByNormalizedNameAndRespectsLimit(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('getTopArtistsWithDates')->willReturnCallback(
+            static function (?int $year) {
+                if ($year === null) {
+                    return [
+                        ['artist' => 'The Beatles', 'plays' => 50],
+                        ['artist' => 'the beatles', 'plays' => 30], // same normalized
+                        ['artist' => 'Pink Floyd', 'plays' => 20],
+                    ];
+                }
+
+                return [];
+            },
+        );
+        $navidrome->method('iterateStarredMediaFiles')->willReturnCallback(
+            static fn (): \Generator => yield from [],
+        );
+
+        $seeds = (new SeedBuilder($navidrome))->build(1);
+
+        // Limit honoured.
+        $this->assertCount(1, $seeds);
+        // The two Beatles spellings merged to 80 → top seed.
+        $this->assertSame('The Beatles', $seeds[0]->name);
+        $this->assertEqualsWithDelta(80.0, $seeds[0]->weight, 0.001);
+    }
+}


### PR DESCRIPTION
## Objectif

PR B du chantier « recommandations d'artistes → Lidarr ». Met en place le **moteur de recommandation** (source Last.fm) qui produit une liste classée d'artistes à ajouter, persistée en snapshot pour la future page de revue (PR D). **Aucun ajout automatique** : le moteur ne fait que calculer/classer.

Construit sur la PR A (`LidarrClient`, #223) déjà mergée.

## Ce que ça fait

Pattern plugin via services taggés `app.recommendation_source` (comme `Notifier` / `Playlist`) :

- **`SeedBuilder`** — agrège mes « seeds » pondérés depuis Navidrome : top all-time (volume), récents de l'année (boost ×1.5), loved/starred (bonus par piste). Dédup par nom normalisé, poids sommés.
- **`LastFmRecommendationSource`** — pour chaque seed → `artist.getSimilar`, score accumulé = Σ(`match` × poids du seed). MBID depuis Last.fm quand présent. Inactive sans `LASTFM_API_KEY`.
- **`RecommendationEngine`** — fusionne les sources par nom normalisé (scores additionnés, sources/seeds unionnés), **exclut** les artistes possédés (`getKnownArtistsNormalized`), mes seeds, les « ignorés » (Setting) et ceux **déjà dans Lidarr** (`existingArtistMbids`). Résout le MBID manquant via **MusicBrainz** (throttlé 1 req/s) uniquement pour le haut du classement, puis classe et cap.
- **`RecommendationStore`** — snapshot (`recommendations.snapshot`) + set « ignorés » (`recommendations.ignored`) dans la table `setting` existante (pas de migration).
- **Async** — `ComputeRecommendationsMessage` + handler routé `async`, enveloppé `RunHistoryRecorder` (nouveau `RunHistory::TYPE_RECOMMENDATIONS`), throttle MusicBrainz.
- **CLI** — `app:recommendations:compute [--limit] [--dry-run]` ; `--dry-run` imprime le classement sans écrire le snapshot.

## Configuration

Trois variables **optionnelles** (défauts au niveau paramètre, un déploiement existant boote sans édition de `.env`) :

| Variable | Défaut | Rôle |
|---|---|---|
| `RECO_SEED_LIMIT` | 25 | nombre de seeds qui pilotent la reco |
| `RECO_PER_SEED` | 20 | voisins demandés à Last.fm par seed |
| `RECO_LIMIT` | 50 | taille max de la liste finale |

## Tests

- `SeedBuilderTest` — combinaison des 3 signaux + dédup + limite.
- `LastFmRecommendationSourceTest` — score `match × poids`, backfill MBID, erreurs par seed absorbées, source inactive sans clé.
- `RecommendationEngineTest` — fusion/tri, exclusions (possédé/seed/ignoré/Lidarr), résolution MBID via MusicBrainz, cap, throttle, sources non configurées ignorées.
- `RecommendationStoreTest` — round-trip snapshot, set ignorés (MBID + nom normalisé).
- `ComputeRecommendationsMessageHandlerTest` — compute + save + record.

`composer ci` vert : **256 tests**, phpcs clean, phpstan niveau 6 au baseline (10, aucune des nouvelles classes).

## Hors périmètre (PRs suivantes)

- **PR C** — source ListenBrainz (recos personnalisées) comme 2ᵉ source.
- **PR D** — page de revue `/recommendations` + bouton « Ajouter à Lidarr » 1 clic + « Ignorer ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_