### PR TITLE
feat(reco): source ListenBrainz (recommandations personnalisées)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -75,6 +75,14 @@ LIDARR_SEARCH_ON_ADD=true
 RECO_SEED_LIMIT=25
 RECO_PER_SEED=20
 RECO_LIMIT=50
+# Source ListenBrainz (recommandations personnalisées, en plus de Last.fm).
+# Inactive tant que LISTENBRAINZ_USER est vide. Le token est optionnel
+# (ne sert qu'à relever les quotas de l'API publique).
+# RECO_LISTENBRAINZ_COUNT : nb de recordings recommandés à récupérer.
+LISTENBRAINZ_USER=
+LISTENBRAINZ_BASE_URL=https://api.listenbrainz.org
+LISTENBRAINZ_TOKEN=
+RECO_LISTENBRAINZ_COUNT=100
 ###< Recommandations d'artistes ###
 
 ###> Strawberry ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -26,6 +26,10 @@ parameters:
     env(RECO_SEED_LIMIT): '25'
     env(RECO_PER_SEED): '20'
     env(RECO_LIMIT): '50'
+    env(RECO_LISTENBRAINZ_COUNT): '100'
+    env(LISTENBRAINZ_USER): ''
+    env(LISTENBRAINZ_BASE_URL): 'https://api.listenbrainz.org'
+    env(LISTENBRAINZ_TOKEN): ''
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -71,6 +75,10 @@ parameters:
     reco.seed_limit: '%env(int:RECO_SEED_LIMIT)%'
     reco.per_seed: '%env(int:RECO_PER_SEED)%'
     reco.limit: '%env(int:RECO_LIMIT)%'
+    reco.listenbrainz_count: '%env(int:RECO_LISTENBRAINZ_COUNT)%'
+    listenbrainz.user: '%env(LISTENBRAINZ_USER)%'
+    listenbrainz.base_url: '%env(LISTENBRAINZ_BASE_URL)%'
+    listenbrainz.token: '%env(LISTENBRAINZ_TOKEN)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -285,6 +293,16 @@ services:
             $sources: !tagged_iterator app.recommendation_source
             $seedLimit: '%reco.seed_limit%'
             $defaultLimit: '%reco.limit%'
+
+    App\Recommendation\ListenBrainzClient:
+        arguments:
+            $user: '%listenbrainz.user%'
+            $baseUrl: '%listenbrainz.base_url%'
+            $token: '%listenbrainz.token%'
+
+    App\Recommendation\ListenBrainzRecommendationSource:
+        arguments:
+            $count: '%reco.listenbrainz_count%'
 
     App\Twig\ScrobbleLinksExtension:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -62,6 +62,10 @@
         <env name="RECO_SEED_LIMIT" value="25"/>
         <env name="RECO_PER_SEED" value="20"/>
         <env name="RECO_LIMIT" value="50"/>
+        <env name="RECO_LISTENBRAINZ_COUNT" value="100"/>
+        <env name="LISTENBRAINZ_USER" value=""/>
+        <env name="LISTENBRAINZ_BASE_URL" value="https://api.listenbrainz.org"/>
+        <env name="LISTENBRAINZ_TOKEN" value=""/>
     </php>
 
     <testsuites>

--- a/src/Recommendation/ListenBrainzClient.php
+++ b/src/Recommendation/ListenBrainzClient.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Recommendation;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Thin ListenBrainz client for the recommendation source. Two endpoints:
+ *
+ *   - GET /1/cf/recommendation/user/{user}/recording  → personalized
+ *     « recordings you might like » (collaborative filtering), each with a
+ *     score. Public; a user token only raises rate limits.
+ *   - GET /1/metadata/recording?recording_mbids=…&inc=artist → resolves each
+ *     recording MBID to its artist MBID(s) + names (Lidarr indexes by artist
+ *     MBID, so this is what makes a recording recommendation actionable).
+ *
+ * The class only fetches + decodes; aggregation lives in the source.
+ */
+class ListenBrainzClient
+{
+    public const DEFAULT_BASE_URL = 'https://api.listenbrainz.org';
+
+    /** Metadata lookups are chunked to keep URLs/requests reasonable. */
+    private const METADATA_CHUNK = 50;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $user = '',
+        private readonly string $baseUrl = self::DEFAULT_BASE_URL,
+        #[\SensitiveParameter]
+        private readonly string $token = '',
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return trim($this->user) !== '';
+    }
+
+    /**
+     * Personalized recommended recordings for the configured user, newest
+     * model first. Returns an empty list when LB has no recommendations yet
+     * (HTTP 204 / empty payload).
+     *
+     * @return list<array{recording_mbid: string, score: float}>
+     */
+    public function recommendedRecordings(int $count): array
+    {
+        if (!$this->isConfigured()) {
+            return [];
+        }
+
+        $url = sprintf('%s/1/cf/recommendation/user/%s/recording', rtrim($this->baseUrl, '/'), rawurlencode($this->user));
+        $payload = $this->get($url, ['count' => max(1, $count)]);
+
+        $mbids = $payload['payload']['mbids'] ?? [];
+        if (!is_array($mbids)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($mbids as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            $mbid = trim((string) ($row['recording_mbid'] ?? ''));
+            if ($mbid === '') {
+                continue;
+            }
+            $out[] = ['recording_mbid' => $mbid, 'score' => (float) ($row['score'] ?? 0)];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Resolve recording MBIDs to their artists in batches.
+     *
+     * @param list<string> $recordingMbids
+     *
+     * @return array<string, list<array{mbid: string, name: string}>> recording MBID → its artists
+     */
+    public function resolveArtists(array $recordingMbids): array
+    {
+        $recordingMbids = array_values(array_unique(array_filter($recordingMbids, static fn (string $m): bool => $m !== '')));
+        if ($recordingMbids === []) {
+            return [];
+        }
+
+        $out = [];
+        foreach (array_chunk($recordingMbids, self::METADATA_CHUNK) as $chunk) {
+            $payload = $this->get(rtrim($this->baseUrl, '/') . '/1/metadata/recording', [
+                'recording_mbids' => implode(',', $chunk),
+                'inc' => 'artist',
+            ]);
+
+            foreach ($payload as $recordingMbid => $meta) {
+                if (!is_string($recordingMbid) || !is_array($meta)) {
+                    continue;
+                }
+                $artists = $meta['artist']['artists'] ?? [];
+                if (!is_array($artists)) {
+                    continue;
+                }
+                $resolved = [];
+                foreach ($artists as $artist) {
+                    if (!is_array($artist)) {
+                        continue;
+                    }
+                    $mbid = trim((string) ($artist['artist_mbid'] ?? ''));
+                    $name = trim((string) ($artist['name'] ?? ''));
+                    if ($mbid !== '' && $name !== '') {
+                        $resolved[] = ['mbid' => $mbid, 'name' => $name];
+                    }
+                }
+                if ($resolved !== []) {
+                    $out[$recordingMbid] = $resolved;
+                }
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, scalar> $query
+     *
+     * @return array<mixed>
+     */
+    private function get(string $url, array $query): array
+    {
+        $headers = ['Accept' => 'application/json'];
+        if (trim($this->token) !== '') {
+            $headers['Authorization'] = 'Token ' . $this->token;
+        }
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'query' => $query,
+                'headers' => $headers,
+                'timeout' => 20,
+            ]);
+            $status = $response->getStatusCode();
+            if ($status === 204) {
+                return [];
+            }
+            if ($status >= 400) {
+                throw new ListenBrainzException(sprintf('ListenBrainz HTTP %d on %s', $status, $url));
+            }
+
+            /** @var array<mixed> $body */
+            $body = $response->toArray(false);
+        } catch (ListenBrainzException $e) {
+            throw $e;
+        } catch (ExceptionInterface $e) {
+            throw new ListenBrainzException(sprintf('ListenBrainz request failed: %s', $e->getMessage()), 0, $e);
+        }
+
+        return $body;
+    }
+}

--- a/src/Recommendation/ListenBrainzException.php
+++ b/src/Recommendation/ListenBrainzException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\Recommendation;
+
+/** Thrown when the ListenBrainz API errors (HTTP / transport / bad JSON). */
+class ListenBrainzException extends \RuntimeException
+{
+}

--- a/src/Recommendation/ListenBrainzRecommendationSource.php
+++ b/src/Recommendation/ListenBrainzRecommendationSource.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Recommendation;
+
+/**
+ * ListenBrainz recommendation source. Unlike Last.fm (seed → similar), LB's
+ * recommendations are already personalized for the user server-side, so the
+ * seeds are ignored: we fetch the user's recommended recordings, resolve each
+ * to its artist(s), and aggregate scores by artist.
+ *
+ * Raw LB scores are small cosine-like floats (~0-1); they're scaled by
+ * {@see self::SCORE_SCALE} so a strong LB pick weighs comparably to a Last.fm
+ * match × seed-weight when the engine sums sources together.
+ */
+final class ListenBrainzRecommendationSource implements RecommendationSourceInterface
+{
+    /** Bring LB's ~0-1 scores onto the same order of magnitude as Last.fm's. */
+    private const SCORE_SCALE = 100.0;
+
+    public function __construct(
+        private readonly ListenBrainzClient $client,
+        private readonly int $count = 100,
+    ) {
+    }
+
+    public function getName(): string
+    {
+        return 'listenbrainz';
+    }
+
+    public function isConfigured(): bool
+    {
+        return $this->client->isConfigured();
+    }
+
+    public function recommend(array $seeds): array
+    {
+        if (!$this->isConfigured()) {
+            return [];
+        }
+
+        try {
+            $recordings = $this->client->recommendedRecordings($this->count);
+        } catch (ListenBrainzException) {
+            return [];
+        }
+        if ($recordings === []) {
+            return [];
+        }
+
+        $scoreByRecording = [];
+        foreach ($recordings as $rec) {
+            $scoreByRecording[$rec['recording_mbid']] = $rec['score'];
+        }
+
+        try {
+            $artistsByRecording = $this->client->resolveArtists(array_keys($scoreByRecording));
+        } catch (ListenBrainzException) {
+            return [];
+        }
+
+        /** @var array<string, array{name: string, mbid: string, score: float}> $acc */
+        $acc = [];
+        foreach ($artistsByRecording as $recordingMbid => $artists) {
+            $score = ($scoreByRecording[$recordingMbid] ?? 0.0) * self::SCORE_SCALE;
+            foreach ($artists as $artist) {
+                $mbid = $artist['mbid'];
+                if (!isset($acc[$mbid])) {
+                    $acc[$mbid] = ['name' => $artist['name'], 'mbid' => $mbid, 'score' => 0.0];
+                }
+                $acc[$mbid]['score'] += $score;
+            }
+        }
+
+        $out = [];
+        foreach ($acc as $row) {
+            $out[] = ['name' => $row['name'], 'mbid' => $row['mbid'], 'score' => $row['score'], 'seed' => ''];
+        }
+
+        return $out;
+    }
+}

--- a/tests/Recommendation/ListenBrainzClientTest.php
+++ b/tests/Recommendation/ListenBrainzClientTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\Recommendation\ListenBrainzClient;
+use App\Recommendation\ListenBrainzException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class ListenBrainzClientTest extends TestCase
+{
+    public function testIsConfiguredRequiresUser(): void
+    {
+        $http = new MockHttpClient([]);
+        $this->assertFalse((new ListenBrainzClient($http, ''))->isConfigured());
+        $this->assertTrue((new ListenBrainzClient($http, 'alice'))->isConfigured());
+    }
+
+    public function testRecommendedRecordingsReturnsEmptyWhenUnconfigured(): void
+    {
+        $client = new ListenBrainzClient(new MockHttpClient([]), '');
+        $this->assertSame([], $client->recommendedRecordings(10));
+    }
+
+    public function testRecommendedRecordingsParsesPayloadAndSendsToken(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = [$method, $url, $options];
+
+            return new MockResponse(json_encode([
+                'payload' => [
+                    'mbids' => [
+                        ['recording_mbid' => 'rec-1', 'score' => 0.9],
+                        ['recording_mbid' => 'rec-2', 'score' => 0.4],
+                        ['score' => 0.1], // no mbid → skipped
+                    ],
+                ],
+            ], \JSON_THROW_ON_ERROR));
+        });
+
+        $client = new ListenBrainzClient($http, 'alice', ListenBrainzClient::DEFAULT_BASE_URL, 'tok-123');
+        $recs = $client->recommendedRecordings(50);
+
+        $this->assertSame([
+            ['recording_mbid' => 'rec-1', 'score' => 0.9],
+            ['recording_mbid' => 'rec-2', 'score' => 0.4],
+        ], $recs);
+
+        [$method, $url, $options] = $captured;
+        $this->assertSame('GET', $method);
+        $this->assertStringContainsString('/1/cf/recommendation/user/alice/recording', $url);
+        $this->assertStringContainsString('count=50', $url);
+        $this->assertContains('Authorization: Token tok-123', $options['headers']);
+    }
+
+    public function testResolveArtistsParsesMetadata(): void
+    {
+        $http = new MockHttpClient(function (string $method, string $url): MockResponse {
+            return new MockResponse(json_encode([
+                'rec-1' => [
+                    'artist' => [
+                        'name' => 'A & B',
+                        'artists' => [
+                            ['artist_mbid' => 'art-a', 'name' => 'A'],
+                            ['artist_mbid' => 'art-b', 'name' => 'B'],
+                        ],
+                    ],
+                ],
+                'rec-2' => [
+                    'artist' => ['artists' => [['artist_mbid' => 'art-c', 'name' => 'C']]],
+                ],
+            ], \JSON_THROW_ON_ERROR));
+        });
+
+        $client = new ListenBrainzClient($http, 'alice');
+        $resolved = $client->resolveArtists(['rec-1', 'rec-2', '', 'rec-1']);
+
+        $this->assertSame([
+            ['mbid' => 'art-a', 'name' => 'A'],
+            ['mbid' => 'art-b', 'name' => 'B'],
+        ], $resolved['rec-1']);
+        $this->assertSame([['mbid' => 'art-c', 'name' => 'C']], $resolved['rec-2']);
+    }
+
+    public function testNoContentReturnsEmpty(): void
+    {
+        $http = new MockHttpClient([new MockResponse('', ['http_code' => 204])]);
+        $client = new ListenBrainzClient($http, 'alice');
+        $this->assertSame([], $client->recommendedRecordings(10));
+    }
+
+    public function testHttpErrorIsWrapped(): void
+    {
+        $http = new MockHttpClient([new MockResponse('nope', ['http_code' => 500])]);
+        $client = new ListenBrainzClient($http, 'alice');
+
+        $this->expectException(ListenBrainzException::class);
+        $this->expectExceptionMessage('HTTP 500');
+        $client->recommendedRecordings(10);
+    }
+}

--- a/tests/Recommendation/ListenBrainzRecommendationSourceTest.php
+++ b/tests/Recommendation/ListenBrainzRecommendationSourceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Recommendation;
+
+use App\Recommendation\ArtistSeed;
+use App\Recommendation\ListenBrainzClient;
+use App\Recommendation\ListenBrainzException;
+use App\Recommendation\ListenBrainzRecommendationSource;
+use PHPUnit\Framework\TestCase;
+
+class ListenBrainzRecommendationSourceTest extends TestCase
+{
+    public function testInactiveWithoutUser(): void
+    {
+        $client = $this->createMock(ListenBrainzClient::class);
+        $client->method('isConfigured')->willReturn(false);
+        $client->expects($this->never())->method('recommendedRecordings');
+
+        $source = new ListenBrainzRecommendationSource($client);
+        $this->assertFalse($source->isConfigured());
+        $this->assertSame([], $source->recommend([new ArtistSeed('X', 1.0)]));
+        $this->assertSame('listenbrainz', $source->getName());
+    }
+
+    public function testAggregatesScoreByArtistMbid(): void
+    {
+        $client = $this->createMock(ListenBrainzClient::class);
+        $client->method('isConfigured')->willReturn(true);
+        $client->method('recommendedRecordings')->willReturn([
+            ['recording_mbid' => 'rec-1', 'score' => 0.5],
+            ['recording_mbid' => 'rec-2', 'score' => 0.2],
+        ]);
+        $client->method('resolveArtists')->willReturn([
+            // Both recordings belong to artist A → scores accumulate.
+            'rec-1' => [['mbid' => 'art-a', 'name' => 'Artist A']],
+            'rec-2' => [
+                ['mbid' => 'art-a', 'name' => 'Artist A'],
+                ['mbid' => 'art-b', 'name' => 'Artist B'],
+            ],
+        ]);
+
+        $rows = (new ListenBrainzRecommendationSource($client))->recommend([]);
+
+        $byMbid = [];
+        foreach ($rows as $r) {
+            $byMbid[$r['mbid']] = $r;
+        }
+
+        // Artist A: (0.5 + 0.2) × 100 = 70; Artist B: 0.2 × 100 = 20.
+        $this->assertEqualsWithDelta(70.0, $byMbid['art-a']['score'], 0.001);
+        $this->assertEqualsWithDelta(20.0, $byMbid['art-b']['score'], 0.001);
+        $this->assertSame('Artist A', $byMbid['art-a']['name']);
+        // No library seed drove these — LB recs are globally personalized.
+        $this->assertSame('', $byMbid['art-a']['seed']);
+    }
+
+    public function testApiErrorYieldsEmptyList(): void
+    {
+        $client = $this->createMock(ListenBrainzClient::class);
+        $client->method('isConfigured')->willReturn(true);
+        $client->method('recommendedRecordings')->willThrowException(new ListenBrainzException('boom'));
+
+        $this->assertSame([], (new ListenBrainzRecommendationSource($client))->recommend([]));
+    }
+}


### PR DESCRIPTION
## Objectif

PR C du chantier « recommandations d'artistes → Lidarr ». Ajoute **ListenBrainz** comme 2ᵉ source de recommandation, en complément de Last.fm (PR B, #224). Contrairement à Last.fm (seed → similaires), les recommandations ListenBrainz sont **déjà personnalisées côté serveur** pour ton compte.

Branchée automatiquement : la source implémente `RecommendationSourceInterface` → taggée `app.recommendation_source` → fusionnée par le `RecommendationEngine` existant (badge `sources` = `['lastfm','listenbrainz']`).

## Ce que ça fait

- **`ListenBrainzClient`** — deux endpoints de l'API publique :
  - `GET /1/cf/recommendation/user/{user}/recording` → recordings recommandés (collaborative filtering), chacun avec un score ;
  - `GET /1/metadata/recording?recording_mbids=…&inc=artist` (par batch de 50) → résout chaque recording en **artist MBID(s) + noms** (Lidarr indexe par MBID artiste, donc indispensable pour rendre la reco actionnable).
  - Token optionnel (`Authorization: Token …`, relève seulement les quotas). `204` / payload vide → liste vide.
- **`ListenBrainzRecommendationSource`** — agrège les scores **par `artist_mbid`** (les seeds sont ignorés : LB personnalise côté serveur). Les scores LB (~0-1) sont mis à l'échelle (×100) pour peser comme un `match` Last.fm × poids de seed quand l'engine somme les sources. Inactive tant que `LISTENBRAINZ_USER` est vide. Erreurs API absorbées → liste vide.

## Configuration (toutes optionnelles, défauts au niveau paramètre)

| Variable | Défaut | Rôle |
|---|---|---|
| `LISTENBRAINZ_USER` | *(vide)* | nom d'utilisateur LB — **active la source** |
| `LISTENBRAINZ_BASE_URL` | `https://api.listenbrainz.org` | base API |
| `LISTENBRAINZ_TOKEN` | *(vide)* | token optionnel (quotas) |
| `RECO_LISTENBRAINZ_COUNT` | 100 | nb de recordings recommandés récupérés |

## Tests

- `ListenBrainzClientTest` (`MockHttpClient`) — parsing recos + envoi du token, batch metadata → artistes, `204` → vide, erreur HTTP enveloppée, inactif sans user.
- `ListenBrainzRecommendationSourceTest` — agrégation par artist_mbid (scores cumulés ×100), inactif sans user, erreur API → vide.

`composer ci` vert : **265 tests**, phpcs clean, phpstan niveau 6 au baseline (10, aucune des nouvelles classes).

## Hors périmètre (PR suivante)

- **PR D** — page de revue `/recommendations` (snapshot, badges sources/seeds) + bouton « Ajouter à Lidarr » 1 clic + « Ignorer ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_