### PR TITLE
feat(reco): page de revue + ajout à Lidarr en 1 clic

### DIFF
--- a/src/Controller/RecommendationController.php
+++ b/src/Controller/RecommendationController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Controller;
+
+use App\Lidarr\LidarrClient;
+use App\Lidarr\LidarrException;
+use App\Message\ComputeRecommendationsMessage;
+use App\Recommendation\ListenBrainzClient;
+use App\Recommendation\RecommendationStore;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Routing\Attribute\Route;
+
+/**
+ * Review page for the artist recommendations snapshot (computed by the
+ * engine / CLI / async job). Lets me add a recommended artist to Lidarr in
+ * one click, or dismiss it so it never resurfaces. Adding is always a manual,
+ * per-artist action — never automatic — because an add triggers downloads.
+ */
+class RecommendationController extends AbstractController
+{
+    #[Route('/recommendations', name: 'app_recommendations_index', methods: ['GET'])]
+    public function index(
+        RecommendationStore $store,
+        LidarrClient $lidarr,
+        ListenBrainzClient $listenBrainz,
+    ): Response {
+        $snapshot = $store->load();
+
+        return $this->render('recommendations/index.html.twig', [
+            'generatedAt' => $snapshot['generated_at'] ?? null,
+            'recommendations' => $snapshot['items'] ?? [],
+            'lidarrConfigured' => $lidarr->isConfigured(),
+            'listenBrainzConfigured' => $listenBrainz->isConfigured(),
+        ]);
+    }
+
+    #[Route('/recommendations/refresh', name: 'app_recommendations_refresh', methods: ['POST'])]
+    public function refresh(Request $request, MessageBusInterface $bus): Response
+    {
+        if (!$this->isCsrfTokenValid('recommendations_refresh', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $bus->dispatch(new ComputeRecommendationsMessage());
+        $this->addFlash('success', 'Calcul des recommandations lancé en arrière-plan.');
+
+        return $this->redirectToRoute('app_history');
+    }
+
+    #[Route('/recommendations/add', name: 'app_recommendations_add', methods: ['POST'])]
+    public function add(Request $request, LidarrClient $lidarr, RecommendationStore $store): Response
+    {
+        if (!$this->isCsrfTokenValid('recommendations_add', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $mbid = trim((string) $request->request->get('mbid'));
+        $name = trim((string) $request->request->get('name'));
+        if ($mbid === '') {
+            $this->addFlash('error', 'MBID manquant — impossible d\'ajouter cet artiste à Lidarr.');
+
+            return $this->redirectToRoute('app_recommendations_index');
+        }
+
+        try {
+            $lidarr->addArtist($mbid);
+            $store->removeFromSnapshot($mbid, $name);
+            $this->addFlash('success', sprintf('« %s » ajouté à Lidarr.', $name !== '' ? $name : $mbid));
+        } catch (LidarrException $e) {
+            $this->addFlash('error', sprintf('Échec de l\'ajout à Lidarr : %s', $e->getMessage()));
+        }
+
+        return $this->redirectToRoute('app_recommendations_index');
+    }
+
+    #[Route('/recommendations/ignore', name: 'app_recommendations_ignore', methods: ['POST'])]
+    public function ignore(Request $request, RecommendationStore $store): Response
+    {
+        if (!$this->isCsrfTokenValid('recommendations_ignore', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $mbid = trim((string) $request->request->get('mbid'));
+        $name = trim((string) $request->request->get('name'));
+        if ($name === '' && $mbid === '') {
+            throw $this->createNotFoundException('Recommandation inconnue.');
+        }
+
+        $store->ignore($mbid !== '' ? $mbid : null, $name);
+        $store->removeFromSnapshot($mbid !== '' ? $mbid : null, $name);
+        $this->addFlash('success', sprintf('« %s » ignoré — il ne réapparaîtra plus.', $name !== '' ? $name : $mbid));
+
+        return $this->redirectToRoute('app_recommendations_index');
+    }
+}

--- a/src/Recommendation/RecommendationStore.php
+++ b/src/Recommendation/RecommendationStore.php
@@ -66,6 +66,38 @@ class RecommendationStore
     }
 
     /**
+     * Drop one artist from the current snapshot (e.g. just added to Lidarr or
+     * ignored) so the review page stops showing it without a full recompute.
+     * Matches by MBID when given, else by normalized name. No-op when there's
+     * no snapshot yet.
+     */
+    public function removeFromSnapshot(?string $mbid, string $name): void
+    {
+        $loaded = $this->load();
+        if ($loaded === null) {
+            return;
+        }
+
+        $norm = NavidromeRepository::normalize($name);
+        $kept = array_values(array_filter($loaded['items'], static function (ArtistRecommendation $r) use ($mbid, $norm): bool {
+            if ($mbid !== null && $mbid !== '' && $r->mbid === $mbid) {
+                return false;
+            }
+            if (($mbid === null || $mbid === '') && $norm !== '' && NavidromeRepository::normalize($r->name) === $norm) {
+                return false;
+            }
+
+            return true;
+        }));
+
+        $payload = [
+            'generated_at' => $loaded['generated_at'],
+            'items' => array_map(static fn (ArtistRecommendation $r): array => $r->jsonSerialize(), $kept),
+        ];
+        $this->settings->set(self::KEY_SNAPSHOT, json_encode($payload, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_UNICODE));
+    }
+
+    /**
      * Mark an artist as ignored so the engine drops it from future runs.
      * Both the MBID (Lidarr's key) and the normalized name are stored so a
      * recommendation lacking an MBID can still be dismissed.

--- a/templates/_navbar.html.twig
+++ b/templates/_navbar.html.twig
@@ -44,6 +44,7 @@
             { label: 'Unmatched', route: 'app_strawberry_unmatched' },
         ]},
     ]},
+    { type: 'link', label: 'Recommandations', route: 'app_recommendations_index' },
     { type: 'link', label: 'Stats', route: 'app_stats' },
     { type: 'link', label: 'Historique', route: 'app_history' },
     { type: 'link', label: 'Aide', route: 'app_help' },

--- a/templates/recommendations/index.html.twig
+++ b/templates/recommendations/index.html.twig
@@ -1,0 +1,113 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Recommandations d'artistes{% endblock %}
+
+{% block body %}
+    <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
+        <div>
+            <h1 class="text-2xl font-semibold">Recommandations d'artistes</h1>
+            <p class="text-sm text-slate-500">
+                Artistes similaires à ce que tu écoutes (Last.fm{{ listenBrainzConfigured ? ' + ListenBrainz' : '' }}),
+                à ajouter à Lidarr en un clic.
+                {% if generatedAt %}
+                    Dernier calcul : {{ generatedAt|date('Y-m-d H:i') }}.
+                {% endif %}
+            </p>
+        </div>
+        <form method="post" action="{{ path('app_recommendations_refresh') }}">
+            <input type="hidden" name="_token" value="{{ csrf_token('recommendations_refresh') }}">
+            <button type="submit"
+                    class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-4 py-1.5 rounded-sm text-sm font-medium">
+                ↻ Rafraîchir
+            </button>
+        </form>
+    </div>
+
+    {% if not lidarrConfigured %}
+        <div class="bg-sky-50 border border-sky-200 text-sky-800 rounded-sm p-3 text-sm mb-4">
+            Lidarr n'est pas configuré (clé API) — l'ajout 1 clic est désactivé, mais les liens
+            « ⇗ Lidarr » restent disponibles si <code>LIDARR_URL</code> est défini.
+        </div>
+    {% endif %}
+
+    {% if recommendations is empty %}
+        <div class="bg-slate-50 border border-slate-200 text-slate-700 rounded-sm p-6 text-center text-sm">
+            Aucune recommandation pour l'instant.
+            Clique sur <span class="font-medium">↻ Rafraîchir</span> pour lancer un calcul
+            (vérifie que <code>LASTFM_API_KEY</code>{{ listenBrainzConfigured ? '' : ' / LISTENBRAINZ_USER' }} est configuré).
+        </div>
+    {% else %}
+        <div class="bg-white shadow-sm rounded-sm overflow-hidden">
+            <table class="w-full text-sm">
+                <thead class="bg-slate-100 text-xs uppercase text-slate-500">
+                    <tr>
+                        <th class="px-3 py-2 text-left w-px">#</th>
+                        <th class="px-3 py-2 text-left">Artiste</th>
+                        <th class="px-3 py-2 text-left">Sources</th>
+                        <th class="px-3 py-2 text-right">Score</th>
+                        <th class="px-3 py-2 text-right">Actions</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y">
+                    {% for r in recommendations %}
+                        <tr class="hover:bg-slate-50">
+                            <td class="px-3 py-2 text-slate-400 tabular-nums">{{ loop.index }}</td>
+                            <td class="px-3 py-2">
+                                <div class="font-medium">{{ r.name }}</div>
+                                {% if r.seeds is not empty %}
+                                    <div class="text-xs text-slate-500">
+                                        parce que tu écoutes {{ r.seeds|slice(0, 3)|join(', ') }}
+                                    </div>
+                                {% endif %}
+                                {% if not r.mbid %}
+                                    <div class="text-xs text-amber-600">MBID introuvable — ajout Lidarr indisponible</div>
+                                {% endif %}
+                            </td>
+                            <td class="px-3 py-2">
+                                {% for s in r.sources %}
+                                    <span class="inline-block bg-slate-100 text-slate-600 px-2 py-0.5 rounded-sm text-xs mr-1">{{ s }}</span>
+                                {% endfor %}
+                            </td>
+                            <td class="px-3 py-2 text-right tabular-nums text-slate-600">{{ r.score|number_format(1) }}</td>
+                            <td class="px-3 py-2">
+                                <div class="flex items-center justify-end gap-2">
+                                    {% if lidarrConfigured and r.mbid %}
+                                        <form method="post" action="{{ path('app_recommendations_add') }}"
+                                              onsubmit="return confirm('Ajouter « {{ r.name|e('js') }} » à Lidarr ? (déclenche une recherche / téléchargement)');">
+                                            <input type="hidden" name="_token" value="{{ csrf_token('recommendations_add') }}">
+                                            <input type="hidden" name="mbid" value="{{ r.mbid }}">
+                                            <input type="hidden" name="name" value="{{ r.name }}">
+                                            <button type="submit"
+                                                    class="bg-[#F2A93C] hover:bg-[#e6982f] text-[#15243A] px-3 py-1 rounded-sm text-xs font-medium">
+                                                + Ajouter à Lidarr
+                                            </button>
+                                        </form>
+                                    {% elseif lidarr_artist_url(r.name) %}
+                                        <a href="{{ lidarr_artist_url(r.name) }}" target="_blank" rel="noopener"
+                                           class="border border-[#F2A93C] text-[#15243A] hover:bg-[#FCEFD8] px-3 py-1 rounded-sm text-xs font-medium">
+                                            ⇗ Lidarr
+                                        </a>
+                                    {% endif %}
+                                    <form method="post" action="{{ path('app_recommendations_ignore') }}">
+                                        <input type="hidden" name="_token" value="{{ csrf_token('recommendations_ignore') }}">
+                                        <input type="hidden" name="mbid" value="{{ r.mbid }}">
+                                        <input type="hidden" name="name" value="{{ r.name }}">
+                                        <button type="submit"
+                                                class="text-slate-500 hover:text-slate-800 px-3 py-1 rounded-sm text-xs"
+                                                title="Ne plus recommander cet artiste">
+                                            ✕ Ignorer
+                                        </button>
+                                    </form>
+                                </div>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        <p class="mt-3 text-xs text-slate-400">
+            « Ajouter à Lidarr » crée l'artiste (monitoré, recherche lancée selon ta config Lidarr).
+            « Ignorer » le retire définitivement des futures recommandations.
+        </p>
+    {% endif %}
+{% endblock %}

--- a/tests/Recommendation/RecommendationStoreTest.php
+++ b/tests/Recommendation/RecommendationStoreTest.php
@@ -62,6 +62,49 @@ class RecommendationStoreTest extends TestCase
         $this->assertNull((new RecommendationStore($this->settings($store)))->load());
     }
 
+    public function testRemoveFromSnapshotByMbidPreservesGeneratedAt(): void
+    {
+        $store = [];
+        $subject = new RecommendationStore($this->settings($store));
+        $subject->save(new RecommendationResult([
+            new ArtistRecommendation('Aphex Twin', 'mbid-aphex', 13.0, ['lastfm'], []),
+            new ArtistRecommendation('Boards of Canada', 'mbid-boc', 5.0, ['lastfm'], []),
+        ]), new \DateTimeImmutable('2026-06-28T10:00:00+00:00'));
+
+        $subject->removeFromSnapshot('mbid-aphex', 'Aphex Twin');
+
+        $loaded = $subject->load();
+        $this->assertNotNull($loaded);
+        $this->assertSame('2026-06-28T10:00:00+00:00', $loaded['generated_at']);
+        $this->assertCount(1, $loaded['items']);
+        $this->assertSame('Boards of Canada', $loaded['items'][0]->name);
+    }
+
+    public function testRemoveFromSnapshotByNameWhenNoMbid(): void
+    {
+        $store = [];
+        $subject = new RecommendationStore($this->settings($store));
+        $subject->save(new RecommendationResult([
+            new ArtistRecommendation('Some Artist', null, 4.0, ['listenbrainz'], []),
+            new ArtistRecommendation('Keep Me', null, 3.0, ['listenbrainz'], []),
+        ]), new \DateTimeImmutable('2026-06-28T10:00:00+00:00'));
+
+        $subject->removeFromSnapshot(null, 'some artist'); // normalized match
+
+        $loaded = $subject->load();
+        $this->assertNotNull($loaded);
+        $this->assertCount(1, $loaded['items']);
+        $this->assertSame('Keep Me', $loaded['items'][0]->name);
+    }
+
+    public function testRemoveFromSnapshotNoOpWithoutSnapshot(): void
+    {
+        $store = [];
+        $subject = new RecommendationStore($this->settings($store));
+        $subject->removeFromSnapshot('mbid-x', 'X'); // must not throw
+        $this->assertNull($subject->load());
+    }
+
     public function testIgnorePersistsMbidAndNormalizedName(): void
     {
         $store = [];


### PR DESCRIPTION
## Objectif

PR D — dernière brique du chantier « recommandations d'artistes → Lidarr ». Ajoute la **page de revue** `/recommendations` qui affiche le snapshot calculé (PR B/C) et permet d'**ajouter un artiste à Lidarr en 1 clic** ou de l'**ignorer**. Conformément à la décision initiale : **pas d'auto-add** — l'ajout est toujours une action manuelle par artiste (il déclenche des téléchargements).

Construit sur PR A (`LidarrClient`, #223), PR B (moteur + store, #224), PR C (ListenBrainz, #225), toutes mergées.

## Ce que ça fait

- **`RecommendationController`** :
  - `GET /recommendations` — affiche le snapshot (artistes classés, score, badges sources `lastfm`/`listenbrainz`, « parce que tu écoutes … » via les seeds, date du dernier calcul). Signale si Lidarr n'est pas configuré.
  - `POST /recommendations/refresh` (CSRF) — dispatch `ComputeRecommendationsMessage` (async), redirige vers l'historique.
  - `POST /recommendations/add` (CSRF) — `LidarrClient::addArtist(mbid)`, flash succès/erreur, retire l'artiste du snapshot.
  - `POST /recommendations/ignore` (CSRF) — persiste l'ignoré (Setting) **et** retire du snapshot (par MBID, sinon par nom pour les recos sans MBID résolu).
- **`RecommendationStore::removeFromSnapshot()`** — retire un artiste du snapshot courant (par MBID sinon nom normalisé) en conservant la date, sans recalcul.
- **Template** charté (boutons orange `#F2A93C`) : bouton « + Ajouter à Lidarr » quand Lidarr est configuré **et** le MBID connu ; sinon repli sur le lien profond existant « ⇗ Lidarr » (`lidarr_artist_url`). Bouton « ✕ Ignorer » toujours disponible.
- **Navbar** : nouveau lien « Recommandations » (desktop + mobile, source unique partagée).

## Tests

Le projet ne teste pas les contrôleurs (pas de boot kernel dans le conteneur de dev) ; la logique nouvelle non-triviale (`removeFromSnapshot`) est couverte côté service :

- `RecommendationStoreTest` — retrait par MBID (préserve `generated_at`), retrait par nom normalisé quand pas de MBID, no-op sans snapshot.

`composer ci` vert : **268 tests**, phpcs clean, phpstan niveau 6 au baseline (10, aucune des nouvelles classes).

## Vérification déploiement

Configurer `LIDARR_API_KEY` (+ dossier/profil) et `LISTENBRAINZ_USER` ; `app:recommendations:compute` (ou « ↻ Rafraîchir ») remplit le snapshot ; sur `/recommendations`, « + Ajouter à Lidarr » crée l'artiste dans Lidarr. (`bin/console` ne boote pas dans le conteneur de dev — vérif réelle côté déploiement.)

## Chantier complet

A (`LidarrClient`) → B (moteur Last.fm + snapshot/CLI) → C (ListenBrainz) → **D (UI + 1 clic)**. Fin du périmètre validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_