### PR TITLE
feat(playlists): « Mix de la semaine » (Discover Weekly via AudioMuse-AI)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -111,7 +111,7 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # Slugs disponibles : retour-en-arriere, top-du-mois, top-all-time,
 #                     pepites-oubliees, coups-de-coeur, kickstart,
 #                     happy-birthday, hit-parade, top-de-lannee,
-#                     decouvertes-recentes, fideles-compagnons
+#                     decouvertes-recentes, fideles-compagnons, mix-semaine
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
@@ -133,7 +133,24 @@ PLAYLIST_HITPARADE_WEEKS=52
 PLAYLIST_HITPARADE_PER_WEEK=3
 # « Découvertes récentes » — fenêtre (jours) sur la 1ʳᵉ écoute d'un morceau.
 PLAYLIST_DISCOVERIES_DAYS=30
+# « Mix de la semaine » (façon Discover Weekly, via AudioMuse-AI) :
+#   SEED_DAYS  = fenêtre récente d'où partent tes morceaux les + écoutés ;
+#   SEED_COUNT = nombre de ces morceaux « seeds » ;
+#   PER_SEED   = similaires demandés à AudioMuse par seed ;
+#   MAX_PLAYS  = seuil « peu ou pas écouté » pour les similaires retenus.
+# Nécessite AUDIOMUSE_BASE_URL (bloc AudioMuse-AI ci-dessous).
+PLAYLIST_MIX_SEED_DAYS=7
+PLAYLIST_MIX_SEED_COUNT=15
+PLAYLIST_MIX_PER_SEED=20
+PLAYLIST_MIX_MAX_PLAYS=5
 ###< Playlists ###
+
+###> AudioMuse-AI ###
+# Instance AudioMuse-AI (analyse sonique) pour la playlist « Mix de la
+# semaine ». Vide = playlist inactive. Clé API optionnelle (selon ton déploiement).
+AUDIOMUSE_BASE_URL=
+AUDIOMUSE_API_KEY=
+###< AudioMuse-AI ###
 
 ###> Notifications ###
 NOTIFY_DRIVERS=

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -30,6 +30,14 @@ parameters:
     env(LISTENBRAINZ_USER): ''
     env(LISTENBRAINZ_BASE_URL): 'https://api.listenbrainz.org'
     env(LISTENBRAINZ_TOKEN): ''
+    # AudioMuse-AI (analyse sonique) — playlist « Mix de la semaine ».
+    # Inactive tant que AUDIOMUSE_BASE_URL est vide ; clé API optionnelle.
+    env(AUDIOMUSE_BASE_URL): ''
+    env(AUDIOMUSE_API_KEY): ''
+    env(PLAYLIST_MIX_SEED_DAYS): '7'
+    env(PLAYLIST_MIX_SEED_COUNT): '15'
+    env(PLAYLIST_MIX_PER_SEED): '20'
+    env(PLAYLIST_MIX_MAX_PLAYS): '5'
 
     app.auth_user: '%env(APP_AUTH_USER)%'
     app.auth_password: '%env(APP_AUTH_PASSWORD)%'
@@ -79,6 +87,12 @@ parameters:
     listenbrainz.user: '%env(LISTENBRAINZ_USER)%'
     listenbrainz.base_url: '%env(LISTENBRAINZ_BASE_URL)%'
     listenbrainz.token: '%env(LISTENBRAINZ_TOKEN)%'
+    audiomuse.base_url: '%env(AUDIOMUSE_BASE_URL)%'
+    audiomuse.api_key: '%env(AUDIOMUSE_API_KEY)%'
+    playlist.mix.seed_days: '%env(int:PLAYLIST_MIX_SEED_DAYS)%'
+    playlist.mix.seed_count: '%env(int:PLAYLIST_MIX_SEED_COUNT)%'
+    playlist.mix.per_seed: '%env(int:PLAYLIST_MIX_PER_SEED)%'
+    playlist.mix.max_plays: '%env(int:PLAYLIST_MIX_MAX_PLAYS)%'
     notify.drivers: '%env(NOTIFY_DRIVERS)%'
     notify.on: '%env(NOTIFY_ON)%'
     notify.gotify.url: '%env(NOTIFY_GOTIFY_URL)%'
@@ -177,6 +191,14 @@ services:
         arguments:
             $minPlays: '%playlist.pepites.min_plays%'
             $silenceMonths: '%playlist.pepites.silence_months%'
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\MixSemaineDefinition:
+        arguments:
+            $seedDays: '%playlist.mix.seed_days%'
+            $seedCount: '%playlist.mix.seed_count%'
+            $perSeed: '%playlist.mix.per_seed%'
+            $maxFamiliarPlays: '%playlist.mix.max_plays%'
             $limit: '%playlists.default_limit%'
 
     App\Service\BackupService:
@@ -299,6 +321,11 @@ services:
             $user: '%listenbrainz.user%'
             $baseUrl: '%listenbrainz.base_url%'
             $token: '%listenbrainz.token%'
+
+    App\AudioMuse\AudioMuseClient:
+        arguments:
+            $baseUrl: '%audiomuse.base_url%'
+            $apiKey: '%audiomuse.api_key%'
 
     App\Recommendation\ListenBrainzRecommendationSource:
         arguments:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -66,6 +66,12 @@
         <env name="LISTENBRAINZ_USER" value=""/>
         <env name="LISTENBRAINZ_BASE_URL" value="https://api.listenbrainz.org"/>
         <env name="LISTENBRAINZ_TOKEN" value=""/>
+        <env name="AUDIOMUSE_BASE_URL" value=""/>
+        <env name="AUDIOMUSE_API_KEY" value=""/>
+        <env name="PLAYLIST_MIX_SEED_DAYS" value="7"/>
+        <env name="PLAYLIST_MIX_SEED_COUNT" value="15"/>
+        <env name="PLAYLIST_MIX_PER_SEED" value="20"/>
+        <env name="PLAYLIST_MIX_MAX_PLAYS" value="5"/>
     </php>
 
     <testsuites>

--- a/src/AudioMuse/AudioMuseClient.php
+++ b/src/AudioMuse/AudioMuseClient.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\AudioMuse;
+
+use Symfony\Contracts\HttpClient\Exception\ExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * Thin client for a self-hosted AudioMuse-AI instance, which performs sonic
+ * analysis of the library and can return sonically similar tracks.
+ *
+ * We only use the « instant mix » endpoint:
+ *   GET /api/similar_tracks?item_id=…&n=… → {"similar_songs":[{item_id, …, distance}]}
+ *
+ * Crucially, AudioMuse-AI indexes the library through the Navidrome/Subsonic
+ * API, so the `item_id` it returns IS the Navidrome media_file id — usable
+ * directly as a playlist song id, no remapping needed.
+ *
+ * The optional API key is sent as `X-API-Key` only when set (some AudioMuse
+ * deployments are unauthenticated). `isConfigured()` is true as soon as a
+ * base URL is provided.
+ */
+class AudioMuseClient
+{
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly string $baseUrl = '',
+        #[\SensitiveParameter]
+        private readonly string $apiKey = '',
+    ) {
+    }
+
+    public function isConfigured(): bool
+    {
+        return trim($this->baseUrl) !== '';
+    }
+
+    /**
+     * Sonically similar tracks for a seed media_file id, closest first.
+     * `eliminate_duplicates` caps repeats of the same artist so the result
+     * spreads across the library rather than clustering on one act.
+     *
+     * @return list<array{item_id: string, distance: float}>
+     */
+    public function similarTracks(string $itemId, int $n): array
+    {
+        if (!$this->isConfigured()) {
+            throw new AudioMuseException('AudioMuse base URL is not set (AUDIOMUSE_BASE_URL).');
+        }
+
+        $payload = $this->get('/api/similar_tracks', [
+            'item_id' => $itemId,
+            'n' => max(1, $n),
+            'eliminate_duplicates' => 'true',
+        ]);
+
+        $songs = $payload['similar_songs'] ?? [];
+        if (!is_array($songs)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($songs as $song) {
+            if (!is_array($song)) {
+                continue;
+            }
+            $id = trim((string) ($song['item_id'] ?? ''));
+            if ($id === '') {
+                continue;
+            }
+            $out[] = ['item_id' => $id, 'distance' => (float) ($song['distance'] ?? 0)];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, scalar> $query
+     *
+     * @return array<mixed>
+     */
+    private function get(string $path, array $query): array
+    {
+        $headers = ['Accept' => 'application/json'];
+        if (trim($this->apiKey) !== '') {
+            $headers['X-API-Key'] = $this->apiKey;
+        }
+
+        $url = rtrim($this->baseUrl, '/') . $path;
+
+        try {
+            $response = $this->httpClient->request('GET', $url, [
+                'query' => $query,
+                'headers' => $headers,
+                'timeout' => 30,
+            ]);
+            $status = $response->getStatusCode();
+            if ($status >= 400) {
+                throw new AudioMuseException(sprintf('AudioMuse GET %s returned HTTP %d.', $path, $status));
+            }
+
+            /** @var array<mixed> $body */
+            $body = $response->toArray(false);
+        } catch (AudioMuseException $e) {
+            throw $e;
+        } catch (ExceptionInterface $e) {
+            throw new AudioMuseException(sprintf('AudioMuse GET %s failed: %s', $path, $e->getMessage()), 0, $e);
+        }
+
+        return $body;
+    }
+}

--- a/src/AudioMuse/AudioMuseException.php
+++ b/src/AudioMuse/AudioMuseException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace App\AudioMuse;
+
+/** Thrown when the AudioMuse-AI API errors (HTTP / transport / bad JSON). */
+class AudioMuseException extends \RuntimeException
+{
+}

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -2147,6 +2147,59 @@ class NavidromeRepository
     }
 
     /**
+     * Lifetime play count per media_file id for the configured user, for an
+     * arbitrary set of ids. Every requested id is present in the result —
+     * **0 when never played** — so callers can filter on familiarity without
+     * worrying about missing keys.
+     *
+     * Counts real plays from the scrobbles table when available (Navidrome
+     * ≥ 0.55); otherwise falls back to `annotation.play_count` (a single
+     * lifetime counter per track, all versions).
+     *
+     * @param string[] $ids
+     *
+     * @return array<string, int> media_file id => play count (0 if unplayed)
+     */
+    public function getPlayCountsByMediaFileId(array $ids): array
+    {
+        $counts = [];
+        foreach ($ids as $id) {
+            $counts[(string) $id] = 0;
+        }
+        if ($counts === []) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $idList = array_keys($counts);
+        $placeholders = implode(',', array_fill(0, count($idList), '?'));
+
+        if ($this->hasScrobblesTable()) {
+            $sql = sprintf(
+                'SELECT media_file_id AS id, COUNT(*) AS plays
+                 FROM scrobbles
+                 WHERE user_id = ? AND media_file_id IN (%s)
+                 GROUP BY media_file_id',
+                $placeholders,
+            );
+        } else {
+            $sql = sprintf(
+                "SELECT item_id AS id, play_count AS plays
+                 FROM annotation
+                 WHERE user_id = ? AND item_type = 'media_file' AND item_id IN (%s)",
+                $placeholders,
+            );
+        }
+
+        $rows = $this->connection()->fetchAllAssociative($sql, [$userId, ...$idList]);
+        foreach ($rows as $r) {
+            $counts[(string) $r['id']] = (int) $r['plays'];
+        }
+
+        return $counts;
+    }
+
+    /**
      * Given a list of media_file ids, return those that no longer exist
      * in the Navidrome library (file was removed/moved/renamed). Useful
      * for detecting « dead » entries inside a Subsonic playlist.

--- a/src/Playlist/Definition/MixSemaineDefinition.php
+++ b/src/Playlist/Definition/MixSemaineDefinition.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\AudioMuse\AudioMuseClient;
+use App\AudioMuse\AudioMuseException;
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Mix de la semaine » — une playlist façon Discover Weekly de Spotify,
+ * appuyée sur l'analyse sonique d'AudioMuse-AI.
+ *
+ * Recette : on part des morceaux les plus écoutés des 7 derniers jours
+ * (les « seeds »), on demande à AudioMuse-AI des morceaux soniquement
+ * proches, on ne garde que ceux que l'on a peu ou pas écoutés, puis on
+ * mélange seeds et découvertes à parts ~égales.
+ *
+ * Inactive (playlist vide) tant qu'AudioMuse n'est pas configuré ; un seed
+ * qu'AudioMuse n'a pas (encore) analysé est simplement ignoré.
+ */
+final class MixSemaineDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly AudioMuseClient $audioMuse,
+        private readonly int $seedDays = 7,
+        private readonly int $seedCount = 15,
+        private readonly int $perSeed = 20,
+        private readonly int $maxFamiliarPlays = 5,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'mix-semaine';
+    }
+
+    public function getName(): string
+    {
+        return 'Mix de la semaine';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Tes morceaux des %d derniers jours mélangés à des titres soniquement proches '
+            . '(AudioMuse-AI) que tu as peu ou pas écoutés (≤ %d écoutes).',
+            $this->seedDays,
+            $this->maxFamiliarPlays,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        if (!$this->audioMuse->isConfigured()) {
+            return [];
+        }
+
+        // Seeds: most-played tracks of the last N days (already ordered by
+        // play volume desc on the window).
+        $from = $context->now->modify(sprintf('-%d days', $this->seedDays));
+        $seeds = $this->navidrome->topTracksInWindow($from, $context->now, $this->seedCount);
+        if ($seeds === []) {
+            return [];
+        }
+        $seedSet = array_fill_keys($seeds, true);
+
+        // Gather sonically similar candidates across all seeds.
+        /** @var array<string, array{count: int, distance: float}> $candidates */
+        $candidates = [];
+        foreach ($seeds as $seedId) {
+            try {
+                $similar = $this->audioMuse->similarTracks($seedId, $this->perSeed);
+            } catch (AudioMuseException) {
+                // Seed not analysed / transient error — skip it, keep the rest.
+                continue;
+            }
+            foreach ($similar as $row) {
+                $id = $row['item_id'];
+                if (isset($seedSet[$id])) {
+                    continue; // never recommend a seed back to itself
+                }
+                if (!isset($candidates[$id])) {
+                    $candidates[$id] = ['count' => 0, 'distance' => $row['distance']];
+                }
+                $candidates[$id]['count']++;
+                $candidates[$id]['distance'] = min($candidates[$id]['distance'], $row['distance']);
+            }
+        }
+
+        // Familiarity filter: keep only little/never-played candidates.
+        $discoveries = $this->filterByFamiliarity(array_keys($candidates));
+        $candidates = array_intersect_key($candidates, array_fill_keys($discoveries, true));
+
+        // Rank discoveries: most cross-referenced first, then closest.
+        uksort($candidates, static function (string $a, string $b) use ($candidates): int {
+            return $candidates[$b]['count'] <=> $candidates[$a]['count']
+                ?: $candidates[$a]['distance'] <=> $candidates[$b]['distance'];
+        });
+        $rankedDiscoveries = array_keys($candidates);
+
+        // ~50/50 mix (favour discoveries on the odd one), then shuffle.
+        $nDisc = (int) ceil($this->limit / 2);
+        $nSeeds = $this->limit - $nDisc;
+        $mix = array_merge(
+            array_slice($seeds, 0, $nSeeds),
+            array_slice($rankedDiscoveries, 0, $nDisc),
+        );
+        shuffle($mix);
+
+        // Drop any ids that vanished from the library, cap to the limit.
+        $missing = array_fill_keys($this->navidrome->filterMissingMediaFileIds($mix), true);
+        $mix = array_values(array_filter($mix, static fn (string $id): bool => !isset($missing[$id])));
+
+        return array_slice($mix, 0, $this->limit);
+    }
+
+    /**
+     * Keep only ids played at most `$maxFamiliarPlays` times (0 = never).
+     *
+     * @param string[] $ids
+     *
+     * @return string[]
+     */
+    private function filterByFamiliarity(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+        $counts = $this->navidrome->getPlayCountsByMediaFileId($ids);
+
+        return array_values(array_filter(
+            $ids,
+            fn (string $id): bool => ($counts[$id] ?? 0) <= $this->maxFamiliarPlays,
+        ));
+    }
+}

--- a/tests/AudioMuse/AudioMuseClientTest.php
+++ b/tests/AudioMuse/AudioMuseClientTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Tests\AudioMuse;
+
+use App\AudioMuse\AudioMuseClient;
+use App\AudioMuse\AudioMuseException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+class AudioMuseClientTest extends TestCase
+{
+    public function testIsConfiguredRequiresBaseUrl(): void
+    {
+        $http = new MockHttpClient([]);
+        $this->assertFalse((new AudioMuseClient($http, ''))->isConfigured());
+        $this->assertTrue((new AudioMuseClient($http, 'http://am:8000'))->isConfigured());
+    }
+
+    public function testSimilarTracksThrowsWhenUnconfigured(): void
+    {
+        $client = new AudioMuseClient(new MockHttpClient([]), '');
+
+        $this->expectException(AudioMuseException::class);
+        $this->expectExceptionMessage('not set');
+        $client->similarTracks('mf-a', 10);
+    }
+
+    public function testSimilarTracksParsesAndSendsParamsAndKey(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = [$method, $url, $options];
+
+            return new MockResponse(json_encode([
+                'similar_songs' => [
+                    ['item_id' => 'mf-b', 'title' => 'B', 'author' => 'X', 'distance' => 0.12],
+                    ['item_id' => 'mf-c', 'distance' => 0.34],
+                    ['title' => 'no id'], // skipped
+                ],
+            ], \JSON_THROW_ON_ERROR));
+        });
+
+        $client = new AudioMuseClient($http, 'http://am:8000/', 'secret-key');
+        $similar = $client->similarTracks('mf-a', 25);
+
+        $this->assertSame([
+            ['item_id' => 'mf-b', 'distance' => 0.12],
+            ['item_id' => 'mf-c', 'distance' => 0.34],
+        ], $similar);
+
+        [$method, $url, $options] = $captured;
+        $this->assertSame('GET', $method);
+        $this->assertStringContainsString('/api/similar_tracks', $url);
+        $this->assertStringContainsString('item_id=mf-a', $url);
+        $this->assertStringContainsString('n=25', $url);
+        $this->assertStringContainsString('eliminate_duplicates=true', $url);
+        $this->assertContains('X-API-Key: secret-key', $options['headers']);
+    }
+
+    public function testNoApiKeyHeaderWhenUnset(): void
+    {
+        $captured = [];
+        $http = new MockHttpClient(function (string $method, string $url, array $options) use (&$captured): MockResponse {
+            $captured = $options;
+
+            return new MockResponse(json_encode(['similar_songs' => []], \JSON_THROW_ON_ERROR));
+        });
+
+        (new AudioMuseClient($http, 'http://am:8000'))->similarTracks('mf-a', 5);
+
+        foreach ($captured['headers'] as $h) {
+            $this->assertStringStartsNotWith('X-API-Key', $h);
+        }
+    }
+
+    public function testHttpErrorIsWrapped(): void
+    {
+        $http = new MockHttpClient([new MockResponse('boom', ['http_code' => 500])]);
+        $client = new AudioMuseClient($http, 'http://am:8000');
+
+        $this->expectException(AudioMuseException::class);
+        $this->expectExceptionMessage('HTTP 500');
+        $client->similarTracks('mf-a', 5);
+    }
+}

--- a/tests/Navidrome/NavidromePlayCountsTest.php
+++ b/tests/Navidrome/NavidromePlayCountsTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Navidrome;
+
+use App\Navidrome\NavidromeRepository;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration test for getPlayCountsByMediaFileId(): lifetime play count per
+ * media_file id, 0 for never-played, with a scrobbles path and an
+ * annotation-only fallback.
+ */
+class NavidromePlayCountsTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanup as $path) {
+            foreach ([$path, $path . '-wal', $path . '-shm'] as $f) {
+                if (file_exists($f)) {
+                    unlink($f);
+                }
+            }
+        }
+    }
+
+    public function testCountsFromScrobblesAndZeroForNeverPlayed(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-pc-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a', 'A', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b', 'B', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-c', 'C', 'Artist');
+
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-a', '2024-01-01 09:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-a', '2024-01-02 09:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-a', '2024-01-03 09:00:00');
+        NavidromeFixtureFactory::insertScrobble($conn, 'user-1', 'mf-b', '2024-01-01 10:00:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        // mf-c never played, mf-x not even in library → both 0; all keys present.
+        $counts = $repo->getPlayCountsByMediaFileId(['mf-a', 'mf-b', 'mf-c', 'mf-x']);
+
+        $this->assertSame(['mf-a' => 3, 'mf-b' => 1, 'mf-c' => 0, 'mf-x' => 0], $counts);
+    }
+
+    public function testFallsBackToAnnotationPlayCount(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-pc-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: false);
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-a', 'A', 'Artist');
+        NavidromeFixtureFactory::insertTrack($conn, 'mf-b', 'B', 'Artist');
+        NavidromeFixtureFactory::insertAnnotation($conn, 'user-1', 'mf-a', 7, '2024-01-03 09:00:00');
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $counts = $repo->getPlayCountsByMediaFileId(['mf-a', 'mf-b']);
+
+        $this->assertSame(['mf-a' => 7, 'mf-b' => 0], $counts);
+    }
+
+    public function testEmptyInputReturnsEmpty(): void
+    {
+        $path = sys_get_temp_dir() . '/nd-pc-' . uniqid() . '.db';
+        $this->cleanup[] = $path;
+        $conn = NavidromeFixtureFactory::createDatabase($path, withScrobbles: true);
+        $conn->close();
+
+        $repo = new NavidromeRepository($path, 'admin');
+
+        $this->assertSame([], $repo->getPlayCountsByMediaFileId([]));
+    }
+}

--- a/tests/Playlist/MixSemaineDefinitionTest.php
+++ b/tests/Playlist/MixSemaineDefinitionTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Tests\Playlist;
+
+use App\AudioMuse\AudioMuseClient;
+use App\AudioMuse\AudioMuseException;
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\Definition\MixSemaineDefinition;
+use App\Playlist\PlaylistContext;
+use PHPUnit\Framework\TestCase;
+
+class MixSemaineDefinitionTest extends TestCase
+{
+    private function ctx(): PlaylistContext
+    {
+        return new PlaylistContext(new \DateTimeImmutable('2026-06-29 12:00:00'), 50);
+    }
+
+    public function testReturnsEmptyWhenAudioMuseNotConfigured(): void
+    {
+        $audioMuse = $this->createMock(AudioMuseClient::class);
+        $audioMuse->method('isConfigured')->willReturn(false);
+        $audioMuse->expects($this->never())->method('similarTracks');
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->never())->method('topTracksInWindow');
+
+        $def = new MixSemaineDefinition($navidrome, $audioMuse);
+
+        $this->assertSame('mix-semaine', $def->getSlug());
+        $this->assertSame([], $def->build($this->ctx()));
+    }
+
+    public function testMixesSeedsWithUnfamiliarSimilarTracks(): void
+    {
+        $audioMuse = $this->createMock(AudioMuseClient::class);
+        $audioMuse->method('isConfigured')->willReturn(true);
+        $audioMuse->method('similarTracks')->willReturnCallback(
+            static function (string $itemId): array {
+                if ($itemId === 's1') {
+                    return [
+                        ['item_id' => 'd1', 'distance' => 0.1],
+                        ['item_id' => 'd2', 'distance' => 0.2],
+                        ['item_id' => 's2', 'distance' => 0.05], // a seed → excluded
+                    ];
+                }
+
+                return [
+                    ['item_id' => 'd1', 'distance' => 0.3], // also surfaced by s1
+                    ['item_id' => 'd3', 'distance' => 0.4], // too familiar (10 plays)
+                    ['item_id' => 'fam', 'distance' => 0.5], // too familiar (6 plays)
+                ];
+            },
+        );
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('topTracksInWindow')->willReturn(['s1', 's2']);
+        $navidrome->method('getPlayCountsByMediaFileId')->willReturnCallback(
+            static fn (array $ids): array => array_intersect_key(
+                ['d1' => 0, 'd2' => 3, 'd3' => 10, 'fam' => 6],
+                array_fill_keys($ids, true),
+            ),
+        );
+        $navidrome->method('filterMissingMediaFileIds')->willReturn([]);
+
+        $def = new MixSemaineDefinition($navidrome, $audioMuse, limit: 4);
+        $ids = $def->build($this->ctx());
+
+        sort($ids);
+        // Seeds s1,s2 + unfamiliar discoveries d1,d2. d3 (10 plays) and
+        // fam (6 plays) excluded by the ≤5 familiarity filter.
+        $this->assertSame(['d1', 'd2', 's1', 's2'], $ids);
+    }
+
+    public function testASeedThatErrorsDoesNotAbortTheRest(): void
+    {
+        $audioMuse = $this->createMock(AudioMuseClient::class);
+        $audioMuse->method('isConfigured')->willReturn(true);
+        $audioMuse->method('similarTracks')->willReturnCallback(
+            static function (string $itemId): array {
+                if ($itemId === 'broken') {
+                    throw new AudioMuseException('not analysed');
+                }
+
+                return [['item_id' => 'd1', 'distance' => 0.1]];
+            },
+        );
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('topTracksInWindow')->willReturn(['broken', 'ok']);
+        $navidrome->method('getPlayCountsByMediaFileId')->willReturn(['d1' => 0]);
+        $navidrome->method('filterMissingMediaFileIds')->willReturn([]);
+
+        $def = new MixSemaineDefinition($navidrome, $audioMuse, limit: 10);
+        $ids = $def->build($this->ctx());
+
+        $this->assertContains('d1', $ids); // surfaced by the surviving seed
+    }
+
+    public function testReturnsEmptyWhenNoRecentSeeds(): void
+    {
+        $audioMuse = $this->createMock(AudioMuseClient::class);
+        $audioMuse->method('isConfigured')->willReturn(true);
+        $audioMuse->expects($this->never())->method('similarTracks');
+
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->method('topTracksInWindow')->willReturn([]);
+
+        $def = new MixSemaineDefinition($navidrome, $audioMuse);
+
+        $this->assertSame([], $def->build($this->ctx()));
+    }
+}


### PR DESCRIPTION
## Objectif

Une playlist façon **Discover Weekly** de Spotify, appuyée sur l'analyse sonique d'**AudioMuse-AI**. La recette demandée :

1. **Seeds** = mes morceaux les plus écoutés des **7 derniers jours** ;
2. pour chaque seed → morceaux **soniquement proches** via AudioMuse-AI ;
3. ne garder, parmi eux, que ceux **peu ou pas écoutés (≤ 5 écoutes)** ;
4. **mixer** seeds + découvertes en **~50/50, mélangé**.

S'intègre au système de playlists plugin existant : c'est une simple définition auto-découverte, générable via `app:playlists:generate --slug=mix-semaine` ou l'UI (et incluse dans « Tout (re)générer » si cochée).

## Implémentation

- **`src/AudioMuse/AudioMuseClient.php`** (+ `AudioMuseException`) — nouveau client HTTP, même patron que `LidarrClient`/`ListenBrainzClient` (`HttpClientInterface` autowiré, `baseUrl` + clé API optionnelle envoyée en `X-API-Key`, `isConfigured()`). Méthode `similarTracks(itemId, n)` → `GET /api/similar_tracks?item_id=…&n=…&eliminate_duplicates=true`, parse `similar_songs[]` → `{item_id, distance}`. **Détail clé** : AudioMuse indexe la bibliothèque via l'API Navidrome, donc son `item_id` **est** l'id media_file — utilisable directement comme song id de playlist.
- **`NavidromeRepository::getPlayCountsByMediaFileId(ids)`** — compteurs d'écoute lifetime par id (**0 si jamais joué**, toutes les clés présentes). Compte les scrobbles si dispo (Navidrome ≥ 0.55), sinon repli sur `annotation.play_count`.
- **`src/Playlist/Definition/MixSemaineDefinition.php`** — orchestre : seeds via `topTracksInWindow(now-7j, now)`, agrégation des similaires (hors seeds, dédup, compte de co-occurrence + distance min), filtre familiarité, classement (plus corroborés & proches d'abord), mix ~50/50 puis `shuffle`, nettoyage des ids disparus. Inactive (playlist vide) si AudioMuse non configuré ; un seed non analysé par AudioMuse est ignoré sans casser la génération.

## Configuration (toutes optionnelles, défauts au niveau paramètre)

| Variable | Défaut | Rôle |
|---|---|---|
| `AUDIOMUSE_BASE_URL` | *(vide)* | instance AudioMuse-AI — **active la playlist** |
| `AUDIOMUSE_API_KEY` | *(vide)* | clé optionnelle (selon déploiement) |
| `PLAYLIST_MIX_SEED_DAYS` | 7 | fenêtre récente des seeds |
| `PLAYLIST_MIX_SEED_COUNT` | 15 | nombre de seeds |
| `PLAYLIST_MIX_PER_SEED` | 20 | similaires demandés par seed |
| `PLAYLIST_MIX_MAX_PLAYS` | 5 | seuil « peu ou pas écouté » |

## Tests

- `AudioMuseClientTest` (`MockHttpClient`) — params/URL, header clé seulement si configurée, parsing, `isConfigured()`, HTTP 5xx → exception, non-configuré → exception claire.
- `NavidromePlayCountsTest` (fixtures SQLite) — comptes scrobbles + **0 pour jamais-joué/hors-bibliothèque**, repli annotation, entrée vide.
- `MixSemaineDefinitionTest` (mocks) — seeds exclus des découvertes, filtre familiarité (candidat à 6/10 écoutes exclu), seed en erreur n'interrompt pas, AudioMuse non configuré → `[]`, pas de seeds récents → `[]`.

`composer ci` vert : **280 tests**, phpcs clean, phpstan niveau 6 au baseline (10, aucune des nouvelles classes).

## Vérification déploiement

`AUDIOMUSE_BASE_URL=http://audiomuse:8000` (+ clé si besoin) → `app:playlists:generate --slug=mix-semaine --dry-run` liste un mélange morceaux récents / découvertes proches peu écoutées ; sans la config, le slug apparaît mais produit une playlist vide. (`bin/console` ne boote pas dans le conteneur de dev — vérif réelle côté déploiement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_