### PR TITLE
feat(stats): historique quotidien de la bibliothèque + graphes d'évolution

### DIFF
--- a/migrations/Version20260629120000.php
+++ b/migrations/Version20260629120000.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20260629120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add stats_history table: one daily measurement of the library size for the evolution chart.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE stats_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                day VARCHAR(10) NOT NULL UNIQUE,
+                tracks INTEGER NOT NULL,
+                artists INTEGER NOT NULL,
+                albums INTEGER NOT NULL,
+                duration_seconds INTEGER NOT NULL,
+                computed_at DATETIME NOT NULL
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE stats_history');
+    }
+}

--- a/src/Entity/StatsHistory.php
+++ b/src/Entity/StatsHistory.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\StatsHistoryRepository;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * One daily measurement of the Navidrome library size, recorded each time the
+ * stats are computed. `day` is unique (one row per calendar day, upserted) so
+ * re-running the compute on the same day refreshes the value rather than
+ * piling up duplicates — giving a clean « une mesure par jour » time series
+ * for the evolution chart.
+ */
+#[ORM\Entity(repositoryClass: StatsHistoryRepository::class)]
+#[ORM\Table(name: 'stats_history')]
+class StatsHistory
+{
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: Types::INTEGER)]
+    private ?int $id = null;
+
+    #[ORM\Column(length: 10, unique: true)]
+    private string $day;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $tracks;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $artists;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $albums;
+
+    #[ORM\Column(type: Types::INTEGER)]
+    private int $durationSeconds;
+
+    #[ORM\Column(type: Types::DATETIME_IMMUTABLE)]
+    private \DateTimeImmutable $computedAt;
+
+    public function __construct(string $day, int $tracks, int $artists, int $albums, int $durationSeconds)
+    {
+        $this->day = $day;
+        $this->tracks = $tracks;
+        $this->artists = $artists;
+        $this->albums = $albums;
+        $this->durationSeconds = $durationSeconds;
+        $this->computedAt = new \DateTimeImmutable();
+    }
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getDay(): string
+    {
+        return $this->day;
+    }
+
+    public function getTracks(): int
+    {
+        return $this->tracks;
+    }
+
+    public function getArtists(): int
+    {
+        return $this->artists;
+    }
+
+    public function getAlbums(): int
+    {
+        return $this->albums;
+    }
+
+    public function getDurationSeconds(): int
+    {
+        return $this->durationSeconds;
+    }
+
+    public function getComputedAt(): \DateTimeImmutable
+    {
+        return $this->computedAt;
+    }
+
+    public function updateCounts(int $tracks, int $artists, int $albums, int $durationSeconds): self
+    {
+        $this->tracks = $tracks;
+        $this->artists = $artists;
+        $this->albums = $albums;
+        $this->durationSeconds = $durationSeconds;
+        $this->computedAt = new \DateTimeImmutable();
+
+        return $this;
+    }
+}

--- a/src/Repository/StatsHistoryRepository.php
+++ b/src/Repository/StatsHistoryRepository.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\StatsHistory;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<StatsHistory>
+ */
+class StatsHistoryRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry, private readonly EntityManagerInterface $em)
+    {
+        parent::__construct($registry, StatsHistory::class);
+    }
+
+    /**
+     * Record (or refresh) the library counts for a given calendar day. The
+     * `day` column is unique, so re-running on the same day updates the
+     * existing row instead of creating a duplicate — « une mesure par jour ».
+     *
+     * @param array{tracks: int, artists: int, albums: int, duration_seconds: int} $counts
+     */
+    public function recordDay(\DateTimeImmutable $day, array $counts): void
+    {
+        $key = $day->format('Y-m-d');
+        $row = $this->findOneBy(['day' => $key]);
+
+        if ($row === null) {
+            $row = new StatsHistory(
+                $key,
+                (int) $counts['tracks'],
+                (int) $counts['artists'],
+                (int) $counts['albums'],
+                (int) $counts['duration_seconds'],
+            );
+            $this->em->persist($row);
+        } else {
+            $row->updateCounts(
+                (int) $counts['tracks'],
+                (int) $counts['artists'],
+                (int) $counts['albums'],
+                (int) $counts['duration_seconds'],
+            );
+        }
+
+        $this->em->flush();
+    }
+
+    /**
+     * The daily measurements, oldest first, capped to the last `$maxDays`
+     * recorded days (for the evolution chart).
+     *
+     * @return list<array{day: string, tracks: int, artists: int, albums: int, duration_seconds: int}>
+     */
+    public function series(int $maxDays = 365): array
+    {
+        /** @var list<StatsHistory> $rows */
+        $rows = $this->createQueryBuilder('h')
+            ->orderBy('h.day', 'DESC')
+            ->setMaxResults(max(1, $maxDays))
+            ->getQuery()
+            ->getResult();
+
+        $rows = array_reverse($rows); // back to ascending (oldest first)
+
+        return array_map(static fn (StatsHistory $h): array => [
+            'day' => $h->getDay(),
+            'tracks' => $h->getTracks(),
+            'artists' => $h->getArtists(),
+            'albums' => $h->getAlbums(),
+            'duration_seconds' => $h->getDurationSeconds(),
+        ], $rows);
+    }
+}

--- a/src/Service/NavidromeStatsService.php
+++ b/src/Service/NavidromeStatsService.php
@@ -4,6 +4,7 @@ namespace App\Service;
 
 use App\Entity\StatsSnapshot;
 use App\Navidrome\NavidromeRepository;
+use App\Repository\StatsHistoryRepository;
 use App\Repository\StatsSnapshotRepository;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -26,6 +27,7 @@ class NavidromeStatsService
         private readonly StatsSnapshotRepository $snapshots,
         private readonly EntityManagerInterface $em,
         private readonly DisparityStatsService $disparity,
+        private readonly StatsHistoryRepository $history,
     ) {
     }
 
@@ -82,6 +84,10 @@ class NavidromeStatsService
             'top_artists_alltime' => $this->navidrome->getTopArtistsWithDates(null, null, null, self::TOP_PAGE_LIMIT),
         ];
 
+        // One daily measurement of the library size for the evolution chart
+        // (upserted per day — see StatsHistoryRepository::recordDay()).
+        $this->history->recordDay(new \DateTimeImmutable('today'), $data['library']);
+
         $snapshot = $this->snapshots->findOneByPeriod(self::SNAPSHOT_KEY);
         if ($snapshot === null) {
             $snapshot = new StatsSnapshot(self::SNAPSHOT_KEY);
@@ -107,8 +113,13 @@ class NavidromeStatsService
             return null;
         }
 
-        /** @var array<string, mixed> */
-        return $snapshot->getData();
+        /** @var array<string, mixed> $data */
+        $data = $snapshot->getData();
+        // Attach the live daily history (read straight from stats_history so
+        // the evolution charts reflect every recorded day, snapshot age aside).
+        $data['library_history'] = $this->history->series();
+
+        return $data;
     }
 
     /**

--- a/templates/navidrome/stats.html.twig
+++ b/templates/navidrome/stats.html.twig
@@ -1,7 +1,62 @@
 {% extends 'base.html.twig' %}
 {% block title %}Stats Navidrome{% endblock %}
 
+{# Format a metric value for display: humanized hours for durations, grouped
+   integer otherwise. #}
+{% macro fmt(v, isDuration) %}
+{%- if isDuration -%}
+    {%- set h = (v // 3600) -%}
+    {%- if h >= 24 -%}{{ (h // 24) }} j {{ (h % 24) }} h{%- else -%}{{ h }} h {{ ((v // 60) % 60) }} min{%- endif -%}
+{%- else -%}
+    {{ v|number_format(0, '.', ' ') }}
+{%- endif -%}
+{% endmacro %}
+
+{# Server-rendered SVG line chart of one library metric over time.
+   `rows` = list of {day, <key>}. No JS / no chart lib — a non-zero baseline
+   (min..max) so slow-moving counts read as an evolution, not flat full bars. #}
+{% macro evo(rows, key, label, color, isDuration) %}
+{% import _self as self %}
+<div class="bg-white shadow-sm rounded-sm p-4">
+    <div class="flex items-baseline justify-between mb-2">
+        <div class="text-sm font-semibold">{{ label }}</div>
+        {% if rows is not empty %}
+            <div class="text-lg font-semibold" style="color: {{ color }}">
+                {{ self.fmt(attribute(rows|last, key), isDuration) }}
+            </div>
+        {% endif %}
+    </div>
+    {% if rows|length < 2 %}
+        <div class="text-xs text-slate-400">L'historique se construit au fil des jours (une mesure par calcul des stats).</div>
+    {% else %}
+        {% set n = rows|length %}
+        {% set vals = rows|map(r => attribute(r, key)) %}
+        {% set min_v = min(vals) %}
+        {% set max_v = max(vals) %}
+        {% set span = max_v - min_v %}
+        {% set pad = 10 %}
+        {% set pts = '' %}
+        {% for r in rows %}
+            {% set v = attribute(r, key) %}
+            {% set x = (loop.index0 / (n - 1) * 600)|round(2) %}
+            {% set y = span > 0 ? (pad + (1 - (v - min_v) / span) * (120 - 2 * pad))|round(2) : 60 %}
+            {% set pts = pts ~ x ~ ',' ~ y ~ ' ' %}
+        {% endfor %}
+        <svg viewBox="0 0 600 120" preserveAspectRatio="none" class="w-full h-24">
+            <polyline fill="none" stroke="{{ color }}" stroke-width="2" vector-effect="non-scaling-stroke"
+                      stroke-linejoin="round" stroke-linecap="round" points="{{ pts|trim }}" />
+        </svg>
+        <div class="flex justify-between text-xs text-slate-400 mt-1">
+            <span>{{ (rows|first).day }}</span>
+            <span>min {{ self.fmt(min_v, isDuration) }} · max {{ self.fmt(max_v, isDuration) }}</span>
+            <span>{{ (rows|last).day }}</span>
+        </div>
+    {% endif %}
+</div>
+{% endmacro %}
+
 {% block body %}
+    {% import _self as ev %}
     <div class="flex items-center justify-between mb-4 flex-wrap gap-3">
         <h1 class="text-2xl font-semibold">Stats Navidrome</h1>
         <div class="flex items-center gap-3">
@@ -64,6 +119,15 @@
             </div>
             <div class="text-xs text-slate-500">{{ data.library.duration_seconds|number_format(0, '.', ' ') }} s</div>
         </div>
+    </div>
+
+    {# Évolution de la bibliothèque (une mesure par jour, à chaque calcul) #}
+    {% set history = data.library_history ?? [] %}
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+        {{ ev.evo(history, 'tracks', 'Évolution — morceaux', '#0ea5e9', false) }}
+        {{ ev.evo(history, 'artists', 'Évolution — artistes', '#22c55e', false) }}
+        {{ ev.evo(history, 'albums', 'Évolution — albums', '#a855f7', false) }}
+        {{ ev.evo(history, 'duration_seconds', 'Évolution — durée totale', '#f59e0b', true) }}
     </div>
 
     {# Écoutes & coups de cœur #}

--- a/tests/Repository/StatsHistoryRepositoryTest.php
+++ b/tests/Repository/StatsHistoryRepositoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\StatsHistory;
+use App\Repository\StatsHistoryRepository;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises StatsHistoryRepository against a real in-memory SQLite ORM
+ * EntityManager (no Symfony kernel) — so the upsert-per-day and ordering
+ * behaviour is validated, not mocked.
+ */
+class StatsHistoryRepositoryTest extends TestCase
+{
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfig([__DIR__ . '/../../src/Entity'], true);
+        $config->setProxyDir(sys_get_temp_dir() . '/nd-orm-proxies');
+        $config->setProxyNamespace('NdTestProxies');
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+        $this->em = new EntityManager($connection, $config);
+
+        $tool = new SchemaTool($this->em);
+        $tool->createSchema([$this->em->getClassMetadata(StatsHistory::class)]);
+    }
+
+    private function repo(): StatsHistoryRepository
+    {
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->em);
+
+        return new StatsHistoryRepository($registry, $this->em);
+    }
+
+    /**
+     * @param array{tracks?: int, artists?: int, albums?: int, duration_seconds?: int} $overrides
+     *
+     * @return array{tracks: int, artists: int, albums: int, duration_seconds: int}
+     */
+    private static function counts(array $overrides = []): array
+    {
+        return $overrides + ['tracks' => 100, 'artists' => 10, 'albums' => 20, 'duration_seconds' => 3600];
+    }
+
+    public function testRecordDayCreatesOneRowPerDayAndUpsertsSameDay(): void
+    {
+        $repo = $this->repo();
+        $day = new \DateTimeImmutable('2026-06-29 08:00:00');
+
+        $repo->recordDay($day, self::counts(['tracks' => 100]));
+        // Same calendar day, later run with a new value → updates, no duplicate.
+        $repo->recordDay($day->setTime(20, 0), self::counts(['tracks' => 142]));
+
+        $this->em->clear();
+        $rows = $repo->findAll();
+        $this->assertCount(1, $rows);
+        $this->assertSame(142, $rows[0]->getTracks());
+        $this->assertSame('2026-06-29', $rows[0]->getDay());
+    }
+
+    public function testSeriesReturnsChronologicalAscending(): void
+    {
+        $repo = $this->repo();
+        $repo->recordDay(new \DateTimeImmutable('2026-06-29'), self::counts(['tracks' => 300, 'duration_seconds' => 9000]));
+        $repo->recordDay(new \DateTimeImmutable('2026-06-27'), self::counts(['tracks' => 100]));
+        $repo->recordDay(new \DateTimeImmutable('2026-06-28'), self::counts(['tracks' => 200, 'artists' => 42]));
+
+        $series = $repo->series();
+
+        $this->assertSame(['2026-06-27', '2026-06-28', '2026-06-29'], array_column($series, 'day'));
+        $this->assertSame([100, 200, 300], array_column($series, 'tracks'));
+        // All four metrics are exposed for the per-metric charts.
+        $this->assertSame(42, $series[1]['artists']);
+        $this->assertSame(9000, $series[2]['duration_seconds']);
+    }
+
+    public function testSeriesCapsToMaxDaysKeepingMostRecent(): void
+    {
+        $repo = $this->repo();
+        foreach (['2026-06-01', '2026-06-02', '2026-06-03'] as $i => $d) {
+            $repo->recordDay(new \DateTimeImmutable($d), self::counts(['tracks' => ($i + 1) * 10]));
+        }
+
+        $series = $repo->series(2);
+
+        // Most recent 2 days, still ascending.
+        $this->assertSame(['2026-06-02', '2026-06-03'], array_column($series, 'day'));
+    }
+}

--- a/tests/Service/NavidromeStatsServiceTest.php
+++ b/tests/Service/NavidromeStatsServiceTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Tests\Service;
+
+use App\Entity\StatsSnapshot;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\StatsHistoryRepository;
+use App\Repository\StatsSnapshotRepository;
+use App\Service\DisparityStatsService;
+use App\Service\NavidromeStatsService;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class NavidromeStatsServiceTest extends TestCase
+{
+    public function testGetAttachesLibraryHistorySeries(): void
+    {
+        $snapshot = new StatsSnapshot(NavidromeStatsService::SNAPSHOT_KEY);
+        $snapshot->setData(['library' => ['tracks' => 100, 'artists' => 10, 'albums' => 20, 'duration_seconds' => 3600]]);
+
+        $snapshots = $this->createMock(StatsSnapshotRepository::class);
+        $snapshots->method('findOneByPeriod')->willReturn($snapshot);
+
+        $series = [
+            ['day' => '2026-06-28', 'tracks' => 90, 'artists' => 9, 'albums' => 18, 'duration_seconds' => 3000],
+            ['day' => '2026-06-29', 'tracks' => 100, 'artists' => 10, 'albums' => 20, 'duration_seconds' => 3600],
+        ];
+        $history = $this->createMock(StatsHistoryRepository::class);
+        $history->method('series')->willReturn($series);
+
+        $service = new NavidromeStatsService(
+            $this->createMock(NavidromeRepository::class),
+            $snapshots,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(DisparityStatsService::class),
+            $history,
+        );
+
+        $data = $service->get();
+
+        $this->assertNotNull($data);
+        $this->assertSame($series, $data['library_history']);
+        // Existing payload still flows through untouched.
+        $this->assertSame(100, $data['library']['tracks']);
+    }
+
+    public function testGetReturnsNullWhenNoSnapshot(): void
+    {
+        $snapshots = $this->createMock(StatsSnapshotRepository::class);
+        $snapshots->method('findOneByPeriod')->willReturn(null);
+
+        $history = $this->createMock(StatsHistoryRepository::class);
+        $history->expects($this->never())->method('series');
+
+        $service = new NavidromeStatsService(
+            $this->createMock(NavidromeRepository::class),
+            $snapshots,
+            $this->createMock(EntityManagerInterface::class),
+            $this->createMock(DisparityStatsService::class),
+            $history,
+        );
+
+        $this->assertNull($service->get());
+    }
+}


### PR DESCRIPTION
## Objectif

Sur la page Stats Navidrome, suivre **l'évolution dans le temps** de la taille de la bibliothèque : une mesure enregistrée chaque jour (au calcul des stats) et un **graphe** par métrique. À la demande, on couvre les **quatre** mesures : morceaux, artistes, albums et durée totale.

Aujourd'hui le calcul n'écrit qu'un snapshot unique écrasé à chaque run — aucune mémoire. On ajoute donc une table datée + des graphes.

## Implémentation

- **Table `stats_history`** (migration `Version20260629120000`) — une ligne par jour (`day` unique), colonnes `tracks / artists / albums / duration_seconds / computed_at`. Entité `StatsHistory` + `StatsHistoryRepository` :
  - `recordDay(day, counts)` — **upsert par jour** : rejouer le calcul le même jour met à jour la ligne au lieu de créer un doublon → « une mesure par jour », le dernier calcul du jour gagne ;
  - `series(maxDays)` — la série triée chronologiquement (ascendant), plafonnée aux N derniers jours.
- **`NavidromeStatsService`** — enregistre la mesure du jour dans `compute()` (`recordDay(today, data.library)`), et attache la série fraîche `library_history` dans `get()` (lecture directe de la table → les graphes reflètent tout l'historique, indépendamment de l'âge du snapshot).
- **Template** (`templates/navidrome/stats.html.twig`) — sous les compteurs « Bibliothèque », une grille de **4 graphes** d'évolution (morceaux, artistes, albums, durée totale). Chaque graphe est une **courbe SVG inline rendue côté serveur** (macro Twig `evo`), sans lib JS — cohérent avec le reste de la page (barres CSS). Base **non nulle** (min..max) pour qu'une valeur élevée qui bouge peu se lise comme une évolution ; étiquettes 1ʳᵉ/dernière date + min/max/valeur courante (durée humanisée). Tant qu'il n'y a qu'un point : note « l'historique se construit au fil des jours ».

Aucune variable d'env, aucun changement de contrôleur (les données passent déjà par `data`), entité auto-mappée + repo autowiré.

## Tests

- `StatsHistoryRepositoryTest` — `EntityManager` SQLite **in-memory** (sans kernel) : `recordDay` crée une ligne ; **rejouer le même jour met à jour sans doublon** ; un autre jour ajoute un point ; `series()` renvoie l'ordre chronologique avec les 4 métriques ; `series(maxDays)` garde les plus récents.
- `NavidromeStatsServiceTest` — `get()` attache bien `library_history` au payload ; renvoie `null` sans snapshot.

`composer ci` : **285 tests** verts, phpcs clean. PHPStan reste au comportement habituel : la seule nouvelle remontée locale est `StatsHistory::$id never assigned` — exactement le même faux positif déjà toléré pour les 8 autres entités (`@GeneratedValue`), résolu en CI où la métadonnée Doctrine est chargée.

## Vérification

Lancer `app:navidrome:stats:compute` (ou « ↻ Recalculer ») → une ligne `stats_history` pour aujourd'hui ; relancer le même jour → toujours une seule ligne (valeur mise à jour) ; le lendemain → 2ᵉ point. Sur `/navidrome/stats`, les 4 courbes apparaissent dès 2 jours d'historique. (L'historique démarre vide et se remplit au fil des calculs — pas de données rétroactives.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_