### PR TITLE
fix(ui): base.html.twig — bloc « body » défini une seule fois (500 partout)

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -17,6 +17,8 @@
 </head>
 <body>
 
+{# Le bloc `body` est défini UNE seule fois ; seul l'enrobage (shell connecté
+   vs. login centré) est conditionnel — ouverture/fermeture scindées autour. #}
 {% if app.user %}
 <div class="app" id="app-shell">
     {% include '_sidebar.html.twig' %}
@@ -33,6 +35,12 @@
         </header>
 
         <div class="page-content">
+{% else %}
+    {# Hors session (login) : pas de shell, contenu centré. #}
+    <div style="min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;">
+        <div style="width:100%; max-width:380px;">
+{% endif %}
+
             {% for type, messages in app.flashes %}
                 {% for message in messages %}
                     <div class="flash flash--{{ type == 'success' ? 'success' : (type == 'error' ? 'error' : 'info') }}">{{ message }}</div>
@@ -40,6 +48,8 @@
             {% endfor %}
 
             {% block body %}{% endblock %}
+
+{% if app.user %}
         </div>
     </main>
 </div>
@@ -56,15 +66,6 @@
     })();
 </script>
 {% else %}
-    {# Hors session (login) : pas de shell, contenu centré. #}
-    <div style="min-height:100vh; display:flex; align-items:center; justify-content:center; padding:24px;">
-        <div style="width:100%; max-width:380px;">
-            {% for type, messages in app.flashes %}
-                {% for message in messages %}
-                    <div class="flash flash--{{ type == 'success' ? 'success' : (type == 'error' ? 'error' : 'info') }}" style="margin-bottom:14px;">{{ message }}</div>
-                {% endfor %}
-            {% endfor %}
-            {% block body %}{% endblock %}
         </div>
     </div>
 {% endif %}


### PR DESCRIPTION
## Problème

Régression de la refonte UI (#229) : l'app plantait au démarrage sur **toutes** les pages —

```
Twig\Error\SyntaxError: The block 'body' has already been defined line 42 in "base.html.twig" at line 67.
```

`{% block body %}` était défini dans les **deux** branches `{% if app.user %}` (shell sidebar) **et** `{% else %}` (login centré). Twig interdit de définir deux fois le même bloc dans un template, même dans des branches `if`/`else` distinctes → erreur de compilation, donc 500 partout.

## Correctif

`base.html.twig` uniquement : le bloc `body` n'est désormais défini **qu'une seule fois**. Seul le **markup d'enrobage** reste conditionnel (shell connecté vs. login centré), l'ouverture/fermeture étant scindée autour du bloc unique. La boucle des messages flash est partagée (rendue une fois).

## Vérification

Comme `bin/console` ne boote pas dans le conteneur de dev, j'ai parsé **les 31 templates** directement avec le parseur Twig (fonctions/filtres Symfony stubés) — c'est précisément ce qui détecte « block already defined » et les balises non fermées :

```
Checked 31 templates, 0 syntax error(s).
```

`base.html.twig` ne déclenche plus l'erreur, et aucun autre template n'a de problème structurel. Aucun changement PHP (`composer ci` inchangé).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_