### PR TITLE
ci(twig): lint de syntaxe des templates Twig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,22 @@ jobs:
           composer-options: --prefer-dist
       - run: vendor/bin/phpunit --colors=always
 
+  twig-lint:
+    name: Twig lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+          extensions: pdo_sqlite, intl
+      - uses: ramsey/composer-install@v3
+        with:
+          composer-options: --prefer-dist
+      - run: php bin/lint-twig.php
+
   docker-build:
     name: Docker image build (validation)
     runs-on: ubuntu-latest
@@ -81,7 +97,7 @@ jobs:
   docker-publish:
     name: Docker image publish
     runs-on: ubuntu-latest
-    needs: [phpcs, phpstan, tests, docker-build]
+    needs: [phpcs, phpstan, tests, twig-lint, docker-build]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +145,7 @@ jobs:
     # notification reflects the WHOLE run's outcome. Scoped to the develop
     # branch only: no notification on PRs, main, or tags. `always()` keeps
     # it running after a failed job; the ref check gates the branch.
-    needs: [phpcs, phpstan, tests, docker-build, docker-publish]
+    needs: [phpcs, phpstan, tests, twig-lint, docker-build, docker-publish]
     if: ${{ always() && github.ref == 'refs/heads/develop' }}
     steps:
       - name: Compute overall status

--- a/bin/lint-twig.php
+++ b/bin/lint-twig.php
@@ -1,0 +1,64 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Standalone Twig syntax linter for the templates/ directory.
+ *
+ * Why not `bin/console lint:twig` ? That command boots the Symfony kernel
+ * (and therefore needs env vars / a compiled container), which is brittle in
+ * CI and in the dev container. This linter only needs the Twig library: it
+ * tokenizes + parses every template, which is exactly the stage that catches
+ * structural errors — duplicate `{% block %}` definitions, unclosed tags,
+ * bad `{% %}` nesting, etc. (the class of bug that 500'd every page once).
+ *
+ * Unknown functions/filters (path, csrf_token, app, our custom Twig
+ * extensions…) are stubbed so they are NOT reported — we only care about
+ * syntax here, not runtime symbol resolution.
+ *
+ * Exit code: 0 when all templates parse, 1 otherwise (CI-friendly).
+ */
+
+require __DIR__ . '/../vendor/autoload.php';
+
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\Source;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+$templatesDir = __DIR__ . '/../templates';
+
+$env = new Environment(new FilesystemLoader($templatesDir), ['cache' => false]);
+$env->registerUndefinedFunctionCallback(static fn (string $name): TwigFunction => new TwigFunction($name, static fn (mixed ...$args): string => ''));
+$env->registerUndefinedFilterCallback(static fn (string $name): TwigFilter => new TwigFilter($name, static fn (mixed $value = null, mixed ...$args): mixed => $value));
+
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($templatesDir, FilesystemIterator::SKIP_DOTS));
+
+$checked = 0;
+$errors = [];
+foreach ($iterator as $file) {
+    if (!$file->isFile() || !str_ends_with($file->getFilename(), '.twig')) {
+        continue;
+    }
+    $name = ltrim(str_replace($templatesDir, '', $file->getPathname()), '/');
+    ++$checked;
+    try {
+        $env->parse($env->tokenize(new Source((string) file_get_contents($file->getPathname()), $name)));
+    } catch (\Twig\Error\SyntaxError $e) {
+        $errors[] = sprintf('%s :: %s', $name, $e->getMessage());
+    }
+}
+
+if ($errors !== []) {
+    fwrite(\STDERR, "Twig syntax errors:\n");
+    foreach ($errors as $error) {
+        fwrite(\STDERR, '  x ' . $error . "\n");
+    }
+    fwrite(\STDERR, sprintf("\n%d template(s) checked, %d error(s).\n", $checked, count($errors)));
+    exit(1);
+}
+
+fwrite(\STDOUT, sprintf("OK - %d Twig templates parsed, no syntax error.\n", $checked));
+exit(0);

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,9 @@
         "phpstan": "phpstan analyse --memory-limit=512M",
         "phpcs": "phpcs",
         "phpcbf": "phpcbf",
+        "lint-twig": "@php bin/lint-twig.php",
         "ci": [
+            "@lint-twig",
             "@phpcs",
             "@phpstan",
             "@test"


### PR DESCRIPTION
## Objectif

Ajouter un **lint de syntaxe Twig** à la CI, pour attraper en amont les erreurs de gabarit (bloc dupliqué, balise non fermée, mauvais imbriquement `{% %}`) — exactement la classe de bug qui avait mis l'app en 500 sur toutes les pages après la refonte UI.

## Pourquoi un linter autonome plutôt que `bin/console lint:twig`

`lint:twig` boote le kernel Symfony (variables d'env, conteneur compilé), ce qui est fragile en CI et ne fonctionne pas dans le conteneur de dev (« Symfony Runtime is missing »). Le linter proposé ne dépend que de la **librairie Twig** : il tokenize + parse chaque template, c'est-à-dire précisément l'étape qui lève les erreurs structurelles. Les fonctions/filtres inconnus (`path`, `csrf_token`, extensions maison…) sont stubés → on ne valide que la syntaxe, pas la résolution des symboles runtime. Déterministe, rapide, sans dépendance d'environnement.

## Changements

- **`bin/lint-twig.php`** — parcourt `templates/`, parse chaque `.twig`, sort en code 1 si erreur (sinon 0).
- **`composer.json`** — script `lint-twig`, placé **en tête** de `composer ci`.
- **`.github/workflows/ci.yml`** — nouveau job « Twig lint », ajouté aux `needs` de `docker-publish` et `notify`.

## Vérification

```
$ php bin/lint-twig.php
OK - 31 Twig templates parsed, no syntax error.
```

Workflow YAML et `composer.json` validés. (Test négatif fait pendant le hotfix : sur la version à bloc `body` dupliqué, le parseur remontait bien « The block 'body' has already been defined ».)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_