### PR TITLE
feat(navidrome): écran « Stats non-matchés » (disparité + priorités + liens)

### DIFF
--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -7,6 +7,7 @@ use App\Message\RematchMessage;
 use App\Message\SuggestAliasesMusicBrainzMessage;
 use App\Message\SyncNavidromeMessage;
 use App\Repository\ScrobbleSyncRepository;
+use App\Service\DisparityStatsService;
 use App\Service\UnmatchedDiagnoser;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -111,6 +112,7 @@ class NavidromeSyncController extends AbstractController
         $perPage = 50;
         $filterArtist = trim((string) $request->query->get('artist', ''));
         $filterTitle = trim((string) $request->query->get('title', ''));
+        $filterPeriod = self::normalizePeriod((string) $request->query->get('period', ''));
 
         $rows = $syncRepo->aggregateUnmatched(
             target: ScrobbleSync::TARGET_NAVIDROME,
@@ -118,6 +120,7 @@ class NavidromeSyncController extends AbstractController
             offset: ($page - 1) * $perPage,
             filterArtist: $filterArtist !== '' ? $filterArtist : null,
             filterTitle: $filterTitle !== '' ? $filterTitle : null,
+            period: $filterPeriod,
         );
         // Per-row diagnosis is scoped to the current page (worst case 50
         // groups → a handful of cheap SQLite probes each). Cached in
@@ -130,7 +133,7 @@ class NavidromeSyncController extends AbstractController
             );
         }
         unset($row);
-        $total = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME);
+        $total = $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME, $filterPeriod);
 
         return $this->render('navidrome/unmatched.html.twig', [
             'rows' => $rows,
@@ -139,6 +142,30 @@ class NavidromeSyncController extends AbstractController
             'pages' => max(1, (int) ceil($total / $perPage)),
             'filter_artist' => $filterArtist,
             'filter_title' => $filterTitle,
+            'filter_period' => $filterPeriod ?? '',
         ]);
+    }
+
+    #[Route('/navidrome/unmatched/stats', name: 'app_navidrome_unmatched_stats', methods: ['GET'])]
+    public function unmatchedStats(
+        ScrobbleSyncRepository $syncRepo,
+        DisparityStatsService $disparity,
+    ): Response {
+        return $this->render('navidrome/unmatched_stats.html.twig', [
+            'total' => $syncRepo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME),
+            'top_artists' => $syncRepo->topUnmatchedArtists(ScrobbleSync::TARGET_NAVIDROME, 15),
+            'top_albums' => $syncRepo->topUnmatchedAlbums(ScrobbleSync::TARGET_NAVIDROME, 15),
+            'disparity' => $disparity->compute(),
+        ]);
+    }
+
+    /**
+     * Validate a period query param to `YYYY` or `YYYY-MM`, else null.
+     */
+    private static function normalizePeriod(string $period): ?string
+    {
+        $period = trim($period);
+
+        return preg_match('/^\d{4}(-\d{2})?$/', $period) === 1 ? $period : null;
     }
 }

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -102,9 +102,105 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
         );
     }
 
-    public function countUnmatchedForTarget(string $target): int
+    public function countUnmatchedForTarget(string $target, ?string $period = null): int
     {
-        return $this->countByTargetStatus($target, ScrobbleSync::STATUS_UNMATCHED);
+        [$expr] = self::periodClause($period);
+        if ($expr === null) {
+            return $this->countByTargetStatus($target, ScrobbleSync::STATUS_UNMATCHED);
+        }
+
+        return (int) $this->em->getConnection()->fetchOne(
+            'SELECT COUNT(*)
+             FROM scrobble_sync ss
+             JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE ss.target = :target AND ss.status = :status AND ' . $expr,
+            ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED, 'period' => $period],
+        );
+    }
+
+    /**
+     * SQL fragment for filtering scrobbles by a period string — `YYYY` (year)
+     * or `YYYY-MM` (month). `played_at` is a SQLite DATETIME string in the
+     * tools DB, so `strftime` works directly (no 'unixepoch'). Returns [null]
+     * when the period is empty/malformed.
+     *
+     * @return array{0: ?string}
+     */
+    private static function periodClause(?string $period): array
+    {
+        if ($period === null || $period === '') {
+            return [null];
+        }
+        if (preg_match('/^\d{4}-\d{2}$/', $period) === 1) {
+            return ["strftime('%Y-%m', s.played_at) = :period"];
+        }
+        if (preg_match('/^\d{4}$/', $period) === 1) {
+            return ["strftime('%Y', s.played_at) = :period"];
+        }
+
+        return [null];
+    }
+
+    /**
+     * Artists with the most UNMATCHED scrobbles for $target — « where to focus
+     * the matching effort ». Optionally scoped to a period (YYYY / YYYY-MM).
+     *
+     * @return list<array{artist: string, count: int}>
+     */
+    public function topUnmatchedArtists(string $target, int $limit = 15, ?string $period = null): array
+    {
+        $where = ['ss.target = :target', 'ss.status = :status', 's.artist IS NOT NULL', "s.artist != ''"];
+        $params = ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED, 'lim' => $limit];
+        [$expr] = self::periodClause($period);
+        if ($expr !== null) {
+            $where[] = $expr;
+            $params['period'] = $period;
+        }
+
+        /** @var list<array{artist: string, count: int}> */
+        return $this->em->getConnection()->fetchAllAssociative(
+            'SELECT s.artist AS artist, COUNT(*) AS count
+             FROM scrobble_sync ss
+             JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE ' . implode(' AND ', $where) . '
+             GROUP BY s.artist
+             ORDER BY count DESC, s.artist ASC
+             LIMIT :lim',
+            $params,
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
+    }
+
+    /**
+     * Albums with the most UNMATCHED scrobbles for $target. The album's artist
+     * uses `album_artist` when set, else the track artist.
+     *
+     * @return list<array{album: string, artist: string, count: int}>
+     */
+    public function topUnmatchedAlbums(string $target, int $limit = 15, ?string $period = null): array
+    {
+        $where = ['ss.target = :target', 'ss.status = :status', 's.album IS NOT NULL', "s.album != ''"];
+        $params = ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED, 'lim' => $limit];
+        [$expr] = self::periodClause($period);
+        if ($expr !== null) {
+            $where[] = $expr;
+            $params['period'] = $period;
+        }
+
+        /** @var list<array{album: string, artist: string, count: int}> */
+        return $this->em->getConnection()->fetchAllAssociative(
+            "SELECT s.album AS album,
+                    COALESCE(NULLIF(s.album_artist, ''), s.artist) AS artist,
+                    COUNT(*) AS count
+             FROM scrobble_sync ss
+             JOIN scrobbles s ON s.id = ss.scrobble_id
+             WHERE " . implode(' AND ', $where) . '
+             GROUP BY album, artist
+             ORDER BY count DESC, album ASC
+             LIMIT :lim',
+            $params,
+            ['lim' => \Doctrine\DBAL\ParameterType::INTEGER],
+        );
     }
 
     /**
@@ -203,6 +299,7 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
         int $offset = 0,
         ?string $filterArtist = null,
         ?string $filterTitle = null,
+        ?string $period = null,
     ): array {
         $where = ['ss.target = :target', 'ss.status = :status'];
         $params = ['target' => $target, 'status' => ScrobbleSync::STATUS_UNMATCHED];
@@ -214,6 +311,11 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
         if ($filterTitle !== null) {
             $where[] = 'LOWER(s.title) LIKE LOWER(:title)';
             $params['title'] = '%' . $filterTitle . '%';
+        }
+        [$periodExpr] = self::periodClause($period);
+        if ($periodExpr !== null) {
+            $where[] = $periodExpr;
+            $params['period'] = $period;
         }
 
         $params['lim'] = $limit;

--- a/templates/_sidebar.html.twig
+++ b/templates/_sidebar.html.twig
@@ -16,6 +16,7 @@
         { label: 'Import Last.fm',  glyph: '↧', route: 'app_lastfm_import',          match: ['app_lastfm_import'] },
         { label: 'Sync Navidrome',  glyph: '⇄', route: 'app_navidrome_sync',         match: ['app_navidrome_sync'] },
         { label: 'Non-matchés',     glyph: '⚠', route: 'app_navidrome_unmatched',  match: ['app_navidrome_unmatched'] },
+        { label: 'Stats non-matchés', glyph: '▥', route: 'app_navidrome_unmatched_stats', match: ['app_navidrome_unmatched_stats'] },
         { label: 'Alias',           glyph: '⌖', route: 'app_lastfm_alias_index',     match: ['app_lastfm_alias_index', 'app_lastfm_alias_new', 'app_lastfm_alias_edit', 'app_lastfm_artist_alias_index', 'app_lastfm_artist_alias_new', 'app_lastfm_artist_alias_edit'], badge: alias_count() },
         { label: 'Strawberry',      glyph: '♪', route: 'app_strawberry_sync',        match: ['app_strawberry_sync', 'app_strawberry_unmatched'] },
     ]},

--- a/templates/navidrome/stats.html.twig
+++ b/templates/navidrome/stats.html.twig
@@ -196,69 +196,12 @@
     </div>
     {% endif %}
 
-    {# Disparité Last.fm ↔ Navidrome — mois et années où la bibliothèque
-       couvre le moins bien les scrobbles Last.fm. #}
-    {% if data.disparity is defined %}
-    <div class="col">
-        <div class="row between wrap">
-            <div class="card__title mb-0">Disparité Last.fm ↔ Navidrome</div>
-            {% if data.disparity.anchor_month %}
-                <p class="muted mono fs-11 mb-0">
-                    Comparaison depuis {{ data.disparity.anchor_month }} (premier scrobble Navidrome). Triés par écart de plays décroissant.
-                </p>
-            {% endif %}
-        </div>
-        {% if data.disparity.anchor_month is null %}
-            <div class="empty-state">
-                Aucune écoute Navidrome encore — la disparité apparaîtra après le premier sync.
-            </div>
-        {% elseif data.disparity.by_month is empty and data.disparity.by_year is empty %}
-            <div class="empty-state">
-                Aucune disparité significative depuis {{ data.disparity.anchor_month }} 🎉
-            </div>
-        {% else %}
-            <div class="grid grid--2">
-                {% for panel in [
-                    { title: 'Top mois', rows: data.disparity.by_month, label_key: 'month' },
-                    { title: 'Top années', rows: data.disparity.by_year, label_key: 'year' },
-                ] %}
-                    <div class="card" style="padding:0;">
-                        <div class="card__title" style="padding:16px 16px 0;">{{ panel.title }}</div>
-                        {% if panel.rows is empty %}
-                            <div class="empty-state" style="border:none;">—</div>
-                        {% else %}
-                            <table class="data-table data-table--in-card" style="margin-top:8px;">
-                                <thead>
-                                    <tr>
-                                        <th>Période</th>
-                                        <th class="num">Last.fm</th>
-                                        <th class="num">Navidrome</th>
-                                        <th class="num">Écart</th>
-                                        <th class="num">Couverture</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                {% for row in panel.rows %}
-                                    {% set tone = row.coverage_pct >= 80 ? 'success' : (row.coverage_pct >= 40 ? 'warning' : 'warning') %}
-                                    <tr>
-                                        <td class="fw-600">{{ attribute(row, panel.label_key) }}</td>
-                                        <td class="num">{{ row.lastfm|number_format(0, '.', ' ') }}</td>
-                                        <td class="num">{{ row.navidrome|number_format(0, '.', ' ') }}</td>
-                                        <td class="num fw-600 {{ row.coverage_pct < 40 ? 't-orange' : '' }}">{{ row.gap|number_format(0, '.', ' ') }}</td>
-                                        <td class="num">
-                                            <span class="badge badge--{{ tone }}">{{ row.coverage_pct }}%</span>
-                                        </td>
-                                    </tr>
-                                {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    </div>
-                {% endfor %}
-            </div>
-        {% endif %}
+    {# La disparité Last.fm ↔ Navidrome et les priorités de matching ont leur
+       propre écran. #}
+    <div class="banner banner--info row between wrap">
+        <span>Disparité Last.fm ↔ Navidrome et priorités de matching</span>
+        <a href="{{ path('app_navidrome_unmatched_stats') }}" class="link mono fs-12">Stats non-matchés →</a>
     </div>
-    {% endif %}
 
     {# Lectures par mois / semaine / jour #}
     {% set unit = 'lectures' %}

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -29,11 +29,19 @@
             <label>Titre</label>
             <input type="text" name="title" value="{{ filter_title }}" placeholder="Rechercher…" class="input">
         </div>
+        {% if filter_period %}<input type="hidden" name="period" value="{{ filter_period }}">{% endif %}
         <button type="submit" class="btn btn--primary btn--sm" style="align-self:flex-end;">Filtrer</button>
         <a href="{{ path('app_navidrome_unmatched') }}" class="btn btn--ghost btn--sm" style="align-self:flex-end;">Reset</a>
         <a href="{{ path('app_lastfm_alias_index') }}" class="link mono fs-12 ml-auto">Gérer les alias track →</a>
         <a href="{{ path('app_lastfm_artist_alias_index') }}" class="link mono fs-12">Alias artiste →</a>
     </form>
+
+    {% if filter_period %}
+        <div class="row gap-8">
+            <span class="badge badge--accent">période · {{ filter_period }}</span>
+            <a href="{{ path('app_navidrome_unmatched', {artist: filter_artist, title: filter_title}) }}" class="link mono fs-11">✕ retirer le filtre période</a>
+        </div>
+    {% endif %}
 
     {% if rows is empty %}
         <div class="empty-state">Aucun scrobble non matché 🎉</div>
@@ -98,10 +106,10 @@
     </div>
     {% if pages > 1 %}
     <div class="pagination">
-        {% if page > 1 %}<a href="{{ path('app_navidrome_unmatched', {page: page - 1, artist: filter_artist, title: filter_title}) }}">← Préc.</a>{% endif %}
+        {% if page > 1 %}<a href="{{ path('app_navidrome_unmatched', {page: page - 1, artist: filter_artist, title: filter_title, period: filter_period}) }}">← Préc.</a>{% endif %}
         <span class="current">{{ page }}</span>
         <span>/ {{ pages }}</span>
-        {% if page < pages %}<a href="{{ path('app_navidrome_unmatched', {page: page + 1, artist: filter_artist, title: filter_title}) }}">Suiv. →</a>{% endif %}
+        {% if page < pages %}<a href="{{ path('app_navidrome_unmatched', {page: page + 1, artist: filter_artist, title: filter_title, period: filter_period}) }}">Suiv. →</a>{% endif %}
     </div>
     {% endif %}
     {% endif %}

--- a/templates/navidrome/unmatched_stats.html.twig
+++ b/templates/navidrome/unmatched_stats.html.twig
@@ -1,0 +1,135 @@
+{% extends 'base.html.twig' %}
+{% block title %}Stats non-matchés{% endblock %}
+
+{% block page_subtitle %}{{ total|number_format(0, '.', ' ') }} scrobble{{ total != 1 ? 's' : '' }} non matché{{ total != 1 ? 's' : '' }} avec Navidrome{% endblock %}
+
+{% block header_actions %}
+    <a href="{{ path('app_navidrome_unmatched') }}" class="btn btn--outline btn--sm">⚠ Liste des non-matchés</a>
+{% endblock %}
+
+{% block body %}
+    {% if total == 0 %}
+        <div class="empty-state">Aucun scrobble non matché 🎉</div>
+    {% else %}
+
+    {# Où concentrer l'effort : artistes / albums avec le plus de non-matchés #}
+    <div class="grid grid--2">
+        {% set art_max = top_artists is not empty ? top_artists|first.count : 0 %}
+        <div class="card" style="padding:0;">
+            <div class="card__title" style="padding:16px 16px 0;">Artistes à matcher en priorité</div>
+            {% if top_artists is empty %}
+                <div class="empty-state" style="border:none;">—</div>
+            {% else %}
+                <table class="data-table data-table--in-card" style="margin-top:8px;">
+                    <thead><tr><th>Artiste</th><th class="num">Non-matchés</th><th class="right">Action</th></tr></thead>
+                    <tbody>
+                    {% for row in top_artists %}
+                        <tr>
+                            <td>
+                                <div>{{ row.artist }}</div>
+                                <div class="bar-list__track" style="margin-top:5px;">
+                                    <div class="bar-list__fill{{ loop.index0 is odd ? ' bar-list__fill--alt' : '' }}"
+                                         style="width: {{ art_max > 0 ? (row.count / art_max * 100)|round : 0 }}%"></div>
+                                </div>
+                            </td>
+                            <td class="num fw-600">{{ row.count|number_format(0, '.', ' ') }}</td>
+                            <td class="right nowrap">
+                                <a href="{{ path('app_navidrome_unmatched', {artist: row.artist}) }}" class="mono fs-11 t-teal">voir →</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </div>
+
+        {% set alb_max = top_albums is not empty ? top_albums|first.count : 0 %}
+        <div class="card" style="padding:0;">
+            <div class="card__title" style="padding:16px 16px 0;">Albums à matcher en priorité</div>
+            {% if top_albums is empty %}
+                <div class="empty-state" style="border:none;">—</div>
+            {% else %}
+                <table class="data-table data-table--in-card" style="margin-top:8px;">
+                    <thead><tr><th>Album</th><th class="num">Non-matchés</th><th class="right">Action</th></tr></thead>
+                    <tbody>
+                    {% for row in top_albums %}
+                        <tr>
+                            <td>
+                                <div class="cell-track__title">{{ row.album }}</div>
+                                <div class="cell-track__sub">{{ row.artist }}</div>
+                                <div class="bar-list__track" style="margin-top:5px;">
+                                    <div class="bar-list__fill{{ loop.index0 is odd ? ' bar-list__fill--alt' : '' }}"
+                                         style="width: {{ alb_max > 0 ? (row.count / alb_max * 100)|round : 0 }}%"></div>
+                                </div>
+                            </td>
+                            <td class="num fw-600">{{ row.count|number_format(0, '.', ' ') }}</td>
+                            <td class="right nowrap">
+                                <a href="{{ path('app_navidrome_unmatched', {artist: row.artist}) }}" class="mono fs-11 t-teal">voir →</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                    </tbody>
+                </table>
+            {% endif %}
+        </div>
+    </div>
+
+    {# Disparité Last.fm ↔ Navidrome — périodes les moins bien couvertes #}
+    <div class="col">
+        <div class="row between wrap">
+            <div class="card__title mb-0">Disparité Last.fm ↔ Navidrome</div>
+            {% if disparity.anchor_month %}
+                <p class="muted mono fs-11 mb-0">
+                    Comparaison depuis {{ disparity.anchor_month }} (premier scrobble Navidrome). Triés par écart de plays décroissant. Cliquez une période pour filtrer les non-matchés.
+                </p>
+            {% endif %}
+        </div>
+        {% if disparity.anchor_month is null %}
+            <div class="empty-state">Aucune écoute Navidrome encore — la disparité apparaîtra après le premier sync.</div>
+        {% elseif disparity.by_month is empty and disparity.by_year is empty %}
+            <div class="empty-state">Aucune disparité significative depuis {{ disparity.anchor_month }} 🎉</div>
+        {% else %}
+            <div class="grid grid--2">
+                {% for panel in [
+                    { title: 'Top mois', rows: disparity.by_month, label_key: 'month' },
+                    { title: 'Top années', rows: disparity.by_year, label_key: 'year' },
+                ] %}
+                    <div class="card" style="padding:0;">
+                        <div class="card__title" style="padding:16px 16px 0;">{{ panel.title }}</div>
+                        {% if panel.rows is empty %}
+                            <div class="empty-state" style="border:none;">—</div>
+                        {% else %}
+                            <table class="data-table data-table--in-card" style="margin-top:8px;">
+                                <thead>
+                                    <tr>
+                                        <th>Période</th>
+                                        <th class="num">Last.fm</th>
+                                        <th class="num">Navidrome</th>
+                                        <th class="num">Écart</th>
+                                        <th class="num">Couverture</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                {% for row in panel.rows %}
+                                    {% set tone = row.coverage_pct >= 80 ? 'success' : 'warning' %}
+                                    {% set period = attribute(row, panel.label_key) %}
+                                    <tr>
+                                        <td class="fw-600">
+                                            <a href="{{ path('app_navidrome_unmatched', {period: period}) }}" class="link" title="Voir les non-matchés de {{ period }}">{{ period }}</a>
+                                        </td>
+                                        <td class="num">{{ row.lastfm|number_format(0, '.', ' ') }}</td>
+                                        <td class="num">{{ row.navidrome|number_format(0, '.', ' ') }}</td>
+                                        <td class="num fw-600 {{ row.coverage_pct < 40 ? 't-orange' : '' }}">{{ row.gap|number_format(0, '.', ' ') }}</td>
+                                        <td class="num"><span class="badge badge--{{ tone }}">{{ row.coverage_pct }}%</span></td>
+                                    </tr>
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        {% endif %}
+                    </div>
+                {% endfor %}
+            </div>
+        {% endif %}
+    </div>
+    {% endif %}
+{% endblock %}

--- a/tests/Repository/UnmatchedStatsRepositoryTest.php
+++ b/tests/Repository/UnmatchedStatsRepositoryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Tests\Repository;
+
+use App\Entity\ScrobbleSync;
+use App\Repository\ScrobbleSyncRepository;
+use Doctrine\DBAL\DriverManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the "Stats non-matchés" repository helpers: top unmatched artists /
+ * albums and the period (YYYY / YYYY-MM) filtering, against a real in-memory
+ * SQLite connection (raw tables, no kernel).
+ */
+class UnmatchedStatsRepositoryTest extends TestCase
+{
+    private EntityManagerInterface $em;
+    private ScrobbleSyncRepository $repo;
+
+    protected function setUp(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfig([__DIR__ . '/../../src/Entity'], true);
+        $config->setProxyDir(sys_get_temp_dir() . '/nd-orm-proxies');
+        $config->setProxyNamespace('NdTestProxies');
+        $connection = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'memory' => true], $config);
+        $this->em = new EntityManager($connection, $config);
+
+        $connection->executeStatement(<<<'SQL'
+            CREATE TABLE scrobbles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                lastfm_user VARCHAR(255) NOT NULL,
+                artist VARCHAR(255) NOT NULL,
+                title VARCHAR(255) NOT NULL,
+                album VARCHAR(255),
+                album_artist VARCHAR(255),
+                played_at DATETIME NOT NULL
+            )
+        SQL);
+        $connection->executeStatement(<<<'SQL'
+            CREATE TABLE scrobble_sync (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                scrobble_id INTEGER NOT NULL,
+                target VARCHAR(32) NOT NULL,
+                status VARCHAR(16) NOT NULL DEFAULT 'pending'
+            )
+        SQL);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManagerForClass')->willReturn($this->em);
+        $this->repo = new ScrobbleSyncRepository($registry, $this->em);
+
+        // Fixtures: A/X unmatched ×2 (Mar 2024), C unmatched no album (Mar 2024),
+        // B/Y unmatched (May 2023), A/X MATCHED (excluded).
+        $this->scrobble(1, 'A', 'X', '', '2024-03-01 10:00:00');
+        $this->scrobble(2, 'A', 'X', '', '2024-03-15 10:00:00');
+        $this->scrobble(3, 'B', 'Y', 'BB', '2023-05-01 10:00:00');
+        $this->scrobble(4, 'A', 'X', '', '2024-03-20 10:00:00');
+        $this->scrobble(5, 'C', '', '', '2024-03-02 10:00:00');
+        $this->sync(1, ScrobbleSync::STATUS_UNMATCHED);
+        $this->sync(2, ScrobbleSync::STATUS_UNMATCHED);
+        $this->sync(3, ScrobbleSync::STATUS_UNMATCHED);
+        $this->sync(4, ScrobbleSync::STATUS_MATCHED);
+        $this->sync(5, ScrobbleSync::STATUS_UNMATCHED);
+    }
+
+    public function testTopUnmatchedArtistsRanksByCountExcludingMatched(): void
+    {
+        $rows = $this->repo->topUnmatchedArtists(ScrobbleSync::TARGET_NAVIDROME, 10);
+
+        $this->assertSame('A', $rows[0]['artist']);
+        $this->assertSame(2, $rows[0]['count']); // scrobbles 1 & 2; 4 is matched
+        $byArtist = array_column($rows, 'count', 'artist');
+        $this->assertSame(['A' => 2, 'B' => 1, 'C' => 1], $byArtist);
+    }
+
+    public function testTopUnmatchedAlbumsUsesAlbumArtistFallbackAndSkipsEmptyAlbum(): void
+    {
+        $rows = $this->repo->topUnmatchedAlbums(ScrobbleSync::TARGET_NAVIDROME, 10);
+
+        // X (artist A via fallback) count 2 first, then Y (album_artist BB) count 1.
+        // C has no album → excluded.
+        $this->assertSame(['album' => 'X', 'artist' => 'A', 'count' => 2], $rows[0]);
+        $this->assertSame('Y', $rows[1]['album']);
+        $this->assertSame('BB', $rows[1]['artist']);
+        $this->assertCount(2, $rows);
+    }
+
+    public function testCountUnmatchedFilteredByPeriod(): void
+    {
+        $this->assertSame(4, $this->repo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME)); // 1,2,3,5
+        $this->assertSame(3, $this->repo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME, '2024-03')); // 1,2,5
+        $this->assertSame(3, $this->repo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME, '2024')); // 1,2,5
+        $this->assertSame(1, $this->repo->countUnmatchedForTarget(ScrobbleSync::TARGET_NAVIDROME, '2023')); // 3
+    }
+
+    public function testAggregateUnmatchedFilteredByPeriod(): void
+    {
+        $rows = $this->repo->aggregateUnmatched(ScrobbleSync::TARGET_NAVIDROME, 50, 0, null, null, '2023');
+
+        $this->assertCount(1, $rows);
+        $this->assertSame('B', $rows[0]['artist']);
+    }
+
+    private function scrobble(int $id, string $artist, string $album, string $albumArtist, string $playedAt): void
+    {
+        $this->em->getConnection()->executeStatement(
+            'INSERT INTO scrobbles (id, lastfm_user, artist, title, album, album_artist, played_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            [$id, 'alice', $artist, 'Title ' . $id, $album, $albumArtist, $playedAt],
+        );
+    }
+
+    private function sync(int $scrobbleId, string $status): void
+    {
+        $this->em->getConnection()->executeStatement(
+            'INSERT INTO scrobble_sync (scrobble_id, target, status) VALUES (?, ?, ?)',
+            [$scrobbleId, ScrobbleSync::TARGET_NAVIDROME, $status],
+        );
+    }
+}


### PR DESCRIPTION
## Objectif

Sortir la **« Disparité Last.fm ↔ Navidrome »** de la page Stats Navidrome vers un **écran dédié « Stats non-matchés »** (menu, sous « Non-matchés »), et l'enrichir pour savoir **où concentrer l'effort de matching** + naviguer vers les non-matchés pré-filtrés par période.

## Changements

**Nouvel écran** `GET /navidrome/unmatched/stats` (`NavidromeSyncController::unmatchedStats`, template `navidrome/unmatched_stats.html.twig`), ajouté à la sidebar juste sous « Non-matchés ». La page Stats Navidrome ne montre plus les panneaux de disparité — elle renvoie vers ce nouvel écran.

**« Où concentrer l'effort »** — deux cartes :
- **Artistes** avec le plus de scrobbles non-matchés ;
- **Albums** avec le plus de non-matchés (artist = `album_artist` sinon `artist`).

Barres proportionnelles + lien « voir → » vers la liste des non-matchés pré-filtrée par cet artiste. Nouvelles méthodes repo `ScrobbleSyncRepository::topUnmatchedArtists()` / `topUnmatchedAlbums()`.

**Disparité par mois / année** — chaque période est désormais un **lien** vers `/navidrome/unmatched` **pré-filtré sur la période**. Nouveau paramètre `period` (`YYYY` ou `YYYY-MM`) :
- filtrage `strftime` côté repo (`aggregateUnmatched` + `countUnmatchedForTarget`, rétro-compatibles) ;
- sur la liste : chip « période · … ✕ » retirable, et persistance du filtre dans le formulaire et la pagination.

## Tests / vérif

- `UnmatchedStatsRepositoryTest` (SQLite in-memory) : `topUnmatchedArtists` (tri, exclusion des matchés), `topUnmatchedAlbums` (repli album_artist, album vide ignoré), filtrage période sur `countUnmatchedForTarget` et `aggregateUnmatched`.
- `composer ci` : **289 tests** verts, phpcs clean, phpstan au baseline. **Twig lint** (nouveau job CI) vert — 32 templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_