### PR TITLE
feat(stats): courbe d'évolution du taux de couverture Last.fm → Navidrome

### DIFF
--- a/src/Service/DisparityStatsService.php
+++ b/src/Service/DisparityStatsService.php
@@ -37,14 +37,15 @@ class DisparityStatsService
      * @return array{
      *     anchor_month: ?string,
      *     by_month: list<array{month: string, lastfm: int, navidrome: int, gap: int, coverage_pct: int}>,
-     *     by_year: list<array{year: string, lastfm: int, navidrome: int, gap: int, coverage_pct: int}>
+     *     by_year: list<array{year: string, lastfm: int, navidrome: int, gap: int, coverage_pct: int}>,
+     *     coverage_series: list<array{month: string, lastfm: int, navidrome: int, gap: int, coverage_pct: int}>
      * }
      */
     public function compute(?string $user = null): array
     {
         $anchor = $this->navidrome->getFirstScrobbleMonth();
         if ($anchor === null) {
-            return ['anchor_month' => null, 'by_month' => [], 'by_year' => []];
+            return ['anchor_month' => null, 'by_month' => [], 'by_year' => [], 'coverage_series' => []];
         }
 
         $resolvedUser = $user !== null && $user !== '' ? $user : ($this->defaultUser !== '' ? $this->defaultUser : null);
@@ -64,6 +65,9 @@ class DisparityStatsService
             'anchor_month' => $anchor,
             'by_month' => $byMonth,
             'by_year' => $this->aggregateByYear($months),
+            // Full chronological series (oldest → newest) for the coverage
+            // evolution chart — unlike by_month, not filtered/sorted by gap.
+            'coverage_series' => $months,
         ];
     }
 

--- a/templates/navidrome/unmatched_stats.html.twig
+++ b/templates/navidrome/unmatched_stats.html.twig
@@ -8,6 +8,37 @@
 {% endblock %}
 
 {% block body %}
+    {# Évolution du taux de couverture Last.fm → Navidrome (série chronologique) #}
+    {% set cov = disparity.coverage_series ?? [] %}
+    {% if cov|length >= 2 %}
+        <div class="card">
+            <div class="row between wrap mb-12">
+                <div class="card__title mb-0">Évolution du taux de couverture Last.fm → Navidrome</div>
+                <div class="mono fs-12 t-teal">actuel · {{ (cov|last).coverage_pct }} %</div>
+            </div>
+            {% set n = cov|length %}
+            {% set pad = 12 %}
+            {% set pts = '' %}
+            {% for row in cov %}
+                {% set x = (loop.index0 / (n - 1) * 600)|round(2) %}
+                {% set y = (pad + (1 - row.coverage_pct / 100) * (120 - 2 * pad))|round(2) %}
+                {% set pts = pts ~ x ~ ',' ~ y ~ ' ' %}
+            {% endfor %}
+            <svg viewBox="0 0 600 120" preserveAspectRatio="none" class="chart-area" style="height:160px;">
+                <line x1="0" y1="{{ pad }}" x2="600" y2="{{ pad }}" stroke="var(--surface-3)"></line>
+                <line x1="0" y1="60" x2="600" y2="60" stroke="var(--surface-3)"></line>
+                <line x1="0" y1="{{ 120 - pad }}" x2="600" y2="{{ 120 - pad }}" stroke="var(--surface-3)"></line>
+                <polyline fill="none" stroke="var(--teal)" stroke-width="2" vector-effect="non-scaling-stroke"
+                          stroke-linejoin="round" stroke-linecap="round" points="{{ pts|trim }}"></polyline>
+            </svg>
+            <div class="axis">
+                <span>{{ (cov|first).month }}</span>
+                <span class="faint">100 % en haut · 0 % en bas</span>
+                <span>{{ (cov|last).month }}</span>
+            </div>
+        </div>
+    {% endif %}
+
     {% if total == 0 %}
         <div class="empty-state">Aucun scrobble non matché 🎉</div>
     {% else %}

--- a/tests/Service/DisparityStatsServiceTest.php
+++ b/tests/Service/DisparityStatsServiceTest.php
@@ -35,6 +35,29 @@ class DisparityStatsServiceTest extends TestCase
         $this->assertSame([], $r['by_year']);
     }
 
+    public function testCoverageSeriesIsChronologicalAndFull(): void
+    {
+        $service = $this->makeService(
+            '2024-01',
+            [
+                ['month' => '2024-03', 'plays' => 300],
+                ['month' => '2024-01', 'plays' => 100],
+                ['month' => '2024-02', 'plays' => 500],
+            ],
+            [
+                ['month' => '2024-01', 'plays' => 100], // 100 % — kept in series (dropped from by_month)
+                ['month' => '2024-02', 'plays' => 50],  // 10 %
+                ['month' => '2024-03', 'plays' => 200], // 67 %
+            ],
+        );
+
+        $series = $service->compute()['coverage_series'];
+
+        // Chronological (oldest → newest) and includes the 100 %-covered month.
+        $this->assertSame(['2024-01', '2024-02', '2024-03'], array_column($series, 'month'));
+        $this->assertSame([100, 10, 67], array_column($series, 'coverage_pct'));
+    }
+
     public function testTopMonthsSortedByGapDesc(): void
     {
         $service = $this->makeService(


### PR DESCRIPTION
## Objectif

Visualiser **l'évolution du taux de couverture Last.fm → Navidrome** (part des écoutes Last.fm couvertes par la bibliothèque) sous forme de **courbe**, sur l'écran « Stats non-matchés » (où vit déjà la disparité).

## Changements

- **`DisparityStatsService::compute()`** expose une nouvelle clé `coverage_series` : la série **mensuelle complète, en ordre chronologique** (oldest → newest). Elle était déjà calculée en interne (`mergeByMonth`) ; `by_month` n'en montrait qu'un top filtré/trié par écart — pas adapté à une courbe.
- **`templates/navidrome/unmatched_stats.html.twig`** : courbe SVG inline rendue côté serveur (cohérente avec le reste, zéro lib JS), **échelle fixe 0-100 %** avec lignes de repère 0/50/100, affichée dès 2 points de données. En-tête : taux actuel + bornes de période.

Placée en tête de l'écran, donc visible même quand tout est matché actuellement (la couverture historique reste pertinente).

## Tests / vérif

- `DisparityStatsServiceTest` : nouveau cas — `coverage_series` chronologique et **complet** (un mois couvert à 100 %, absent de `by_month`, est bien présent dans la série).
- `composer ci` : **290 tests** verts, phpcs clean, phpstan au baseline. **Twig lint** vert (32 templates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_