### PR TITLE
fix(rematch): purger les négatifs du cache avant le rematch CLI

### DIFF
--- a/src/Command/RematchCommand.php
+++ b/src/Command/RematchCommand.php
@@ -8,6 +8,7 @@ use App\Entity\RunHistory;
 use App\Entity\ScrobbleSync;
 use App\Navidrome\NavidromeSyncReport;
 use App\Navidrome\NavidromeSyncService;
+use App\Repository\LastFmMatchCacheRepository;
 use App\Repository\ScrobbleSyncRepository;
 use App\Service\RunHistoryRecorder;
 use App\Strawberry\StrawberrySyncReport;
@@ -37,6 +38,7 @@ class RematchCommand extends Command
         private readonly StrawberrySyncService $strawberrySync,
         private readonly RunHistoryRecorder $recorder,
         private readonly NavidromeContainerManager $container,
+        private readonly LastFmMatchCacheRepository $matchCache,
     ) {
         parent::__construct();
     }
@@ -86,8 +88,15 @@ class RematchCommand extends Command
                 reference: 'unmatched',
                 label: $label,
                 action: function (RunHistory $entry) use ($target, $limit, $dryRun): NavidromeSyncReport|StrawberrySyncReport {
-                    $reset = $this->syncRepo->resetUnmatchedToPending($target);
-                    $io = null; // logger only available in progress callback
+                    // Bust the Last.fm match-cache negatives for the couples
+                    // we're about to retry — otherwise the matcher hits its
+                    // own fresh negative entries (TTL 30d) and the rematch is
+                    // a no-op. Positives are preserved. Mirrors
+                    // RematchMessageHandler (the web/async path).
+                    if ($target === ScrobbleSync::TARGET_NAVIDROME) {
+                        $this->matchCache->purgeUnmatchedNegatives($target);
+                    }
+                    $this->syncRepo->resetUnmatchedToPending($target);
                     if ($target === ScrobbleSync::TARGET_NAVIDROME) {
                         return $this->navidromeSync->process(limit: $limit, dryRun: $dryRun, run: $entry);
                     }


### PR DESCRIPTION
## Problème

`bin/console app:scrobbles:rematch` (`RematchCommand`) remettait les non-matchés en *pending* et relançait la cascade, **sans purger d'abord les entrées négatives du cache de matching**. Le matcher retombait donc sur ses propres négatifs frais (TTL 30 j) pour les couples qu'on demande justement de rematcher → le run CLI était quasiment un **no-op**.

Le chemin web/async (`RematchMessageHandler`, déclenché par le bouton « ↻ Rematcher tous ») purgeait déjà ces négatifs — d'où la divergence de comportement entre l'UI et la CLI.

## Correctif

Alignement de la commande sur le handler : **purge des négatifs** du cache (`LastFmMatchCacheRepository::purgeUnmatchedNegatives`, cible `navidrome`) **avant** `resetUnmatchedToPending`, puis sync. Les entrées positives sont conservées (résolutions toujours valides). Nettoyage au passage de deux lignes mortes (`$reset` / `$io` inutilisés).

## Vérification

`composer ci` : **290 tests** verts, phpcs clean, phpstan au baseline. (Le projet n'a pas de harnais de test pour les commandes ; le correctif reproduit à l'identique le comportement du handler, lui déjà couvert.)

Côté usage : après un `app:scrobbles:rematch -t navidrome`, les couples non-matchés sont réellement réévalués (ex. l'album « …vides ? » se matche enfin via le triplet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_