### PR TITLE
feat(playlists): « Très vieilles pépites » + « Pépites oubliées » en aléatoire

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -111,7 +111,8 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 # Slugs disponibles : retour-en-arriere, top-du-mois, top-all-time,
 #                     pepites-oubliees, coups-de-coeur, kickstart,
 #                     happy-birthday, hit-parade, top-de-lannee,
-#                     decouvertes-recentes, fideles-compagnons, mix-semaine
+#                     decouvertes-recentes, fideles-compagnons, mix-semaine,
+#                     tres-vieilles-pepites
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
@@ -123,6 +124,9 @@ PLAYLIST_RETOUR_PER_YEAR=10
 # of silence (no play) before a track counts as « forgotten ».
 PLAYLIST_PEPITES_MIN_PLAYS=5
 PLAYLIST_PEPITES_SILENCE_MONTHS=12
+# « Très vieilles pépites » — même logique, mais silence beaucoup plus long
+# (par défaut 60 mois ≈ 5 ans). Réutilise PLAYLIST_PEPITES_MIN_PLAYS.
+PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS=60
 # « Happy birthday » — jour anniversaire (mois / jour) dont on tire au
 # hasard les morceaux les plus écoutés, toutes années confondues.
 PLAYLIST_BIRTHDAY_MONTH=5

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,6 +10,7 @@ parameters:
     env(PLAYLIST_RETOUR_PER_YEAR): '10'
     env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
     env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
+    env(PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS): '60'
     env(PLAYLIST_BIRTHDAY_MONTH): '5'
     env(PLAYLIST_BIRTHDAY_DAY): '22'
     env(PLAYLIST_HITPARADE_WEEKS): '52'
@@ -75,6 +76,7 @@ parameters:
     playlist.retour.per_year: '%env(int:PLAYLIST_RETOUR_PER_YEAR)%'
     playlist.pepites.min_plays: '%env(int:PLAYLIST_PEPITES_MIN_PLAYS)%'
     playlist.pepites.silence_months: '%env(int:PLAYLIST_PEPITES_SILENCE_MONTHS)%'
+    playlist.tres_vieilles_pepites.silence_months: '%env(int:PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS)%'
     playlist.birthday.month: '%env(int:PLAYLIST_BIRTHDAY_MONTH)%'
     playlist.birthday.day: '%env(int:PLAYLIST_BIRTHDAY_DAY)%'
     playlist.hitparade.weeks: '%env(int:PLAYLIST_HITPARADE_WEEKS)%'
@@ -191,6 +193,12 @@ services:
         arguments:
             $minPlays: '%playlist.pepites.min_plays%'
             $silenceMonths: '%playlist.pepites.silence_months%'
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\TresVieillesPepitesDefinition:
+        arguments:
+            $minPlays: '%playlist.pepites.min_plays%'
+            $silenceMonths: '%playlist.tres_vieilles_pepites.silence_months%'
             $limit: '%playlists.default_limit%'
 
     App\Playlist\Definition\MixSemaineDefinition:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -54,6 +54,7 @@
         <env name="PLAYLIST_RETOUR_PER_YEAR" value="10"/>
         <env name="PLAYLIST_PEPITES_MIN_PLAYS" value="5"/>
         <env name="PLAYLIST_PEPITES_SILENCE_MONTHS" value="12"/>
+        <env name="PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS" value="60"/>
         <env name="PLAYLIST_BIRTHDAY_MONTH" value="5"/>
         <env name="PLAYLIST_BIRTHDAY_DAY" value="22"/>
         <env name="PLAYLIST_HITPARADE_WEEKS" value="52"/>

--- a/src/Playlist/Definition/TresVieillesPepitesDefinition.php
+++ b/src/Playlist/Definition/TresVieillesPepitesDefinition.php
@@ -7,37 +7,37 @@ use App\Playlist\PlaylistContext;
 use App\Playlist\PlaylistDefinitionInterface;
 
 /**
- * « Pépites oubliées » — tracks heavily played in the past (≥ minPlays)
- * but silent for at least `silenceMonths`. Reuses
- * {@see NavidromeRepository::getSongsLovedAndForgotten()} then shuffles the
- * result for a serendipitous random rediscovery.
+ * « Très vieilles pépites » — même logique que « Pépites oubliées » mais avec
+ * un silence bien plus long (par défaut 60 mois ≈ 5 ans) : des morceaux jadis
+ * écoutés (≥ minPlays) plus rejoués depuis des années. Mélangé en aléatoire.
  */
-final class PepitesOublieesDefinition implements PlaylistDefinitionInterface
+final class TresVieillesPepitesDefinition implements PlaylistDefinitionInterface
 {
     public function __construct(
         private readonly NavidromeRepository $navidrome,
         private readonly int $minPlays = 5,
-        private readonly int $silenceMonths = 12,
+        private readonly int $silenceMonths = 60,
         private readonly int $limit = 50,
     ) {
     }
 
     public function getSlug(): string
     {
-        return 'pepites-oubliees';
+        return 'tres-vieilles-pepites';
     }
 
     public function getName(): string
     {
-        return 'Pépites oubliées';
+        return 'Très vieilles pépites';
     }
 
     public function getDescription(): string
     {
         return sprintf(
-            'Morceaux écoutés au moins %d fois mais plus joués depuis %d mois, en aléatoire.',
+            'Morceaux écoutés au moins %d fois mais plus joués depuis %d mois (≈ %d ans), en aléatoire.',
             $this->minPlays,
             $this->silenceMonths,
+            (int) round($this->silenceMonths / 12),
         );
     }
 

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -10,6 +10,7 @@ use App\Playlist\Definition\HappyBirthdayDefinition;
 use App\Playlist\Definition\HitParadeDefinition;
 use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
+use App\Playlist\Definition\TresVieillesPepitesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
 use App\Playlist\Definition\TopDeLanneeDefinition;
 use App\Playlist\Definition\TopDuMoisDefinition;
@@ -63,6 +64,25 @@ class DefinitionsTest extends TestCase
 
         $def = new PepitesOublieesDefinition($navidrome, minPlays: 5, silenceMonths: 12, limit: 50);
         $this->assertSame(['mf-old'], $def->build($this->ctx('2026-06-27')));
+    }
+
+    public function testTresVieillesPepitesUsesLongerSilenceCutoff(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        $navidrome->expects($this->once())
+            ->method('getSongsLovedAndForgotten')
+            ->with(
+                5,
+                // 60 months before 2026-06-27 → 2021-06-27.
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2021-06-27'),
+                50,
+            )
+            ->willReturn(['mf-ancient']);
+
+        $def = new TresVieillesPepitesDefinition($navidrome, minPlays: 5, silenceMonths: 60, limit: 50);
+
+        $this->assertSame('tres-vieilles-pepites', $def->getSlug());
+        $this->assertSame(['mf-ancient'], $def->build($this->ctx('2026-06-27')));
     }
 
     public function testCoupsDeCoeurCollectsStarredAndCapsAtLimit(): void


### PR DESCRIPTION
## Objectif

- **« Pépites oubliées »** : la trier en **aléatoire**.
- Nouvelle playlist **« Très vieilles pépites »** : même logique, mais pour les morceaux plus rejoués depuis **plus de 5 ans**, en aléatoire.

## Changements

- `PepitesOublieesDefinition` : `shuffle()` du résultat (au lieu de l'ordre play-count desc / dernier-joué asc). Description mise à jour (« en aléatoire »).
- **`TresVieillesPepitesDefinition`** (nouvelle, slug `tres-vieilles-pepites`, « Très vieilles pépites ») : réutilise `getSongsLovedAndForgotten` avec un silence par défaut de **60 mois (≈ 5 ans)**, mélangée. Réutilise `PLAYLIST_PEPITES_MIN_PLAYS` et la limite par défaut ; silence configurable via `PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS` (défaut 60).
- Auto-découverte par le tag plugin ; câblage `services.yaml` + défauts, `.env.dist` (+ slug documenté), `phpunit.xml.dist`.

## Vérification

- Test du cutoff (60 mois → 2021-06-27 pour un `now` au 2026-06-27) + slug stable. Le test « pépites oubliées » reste vert (1 élément → shuffle sans effet).
- `composer ci` : **291 tests** verts, phpcs clean, phpstan au baseline. **Twig lint** vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_