### PR TITLE
feat(sync): backups « checkpoint » intermédiaires pendant les longs runs

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -29,6 +29,10 @@ NAVIDROME_PASSWORD=
 NAVIDROME_CONTAINER_NAME=
 NAVIDROME_STOP_TIMEOUT_SECONDS=60
 NAVIDROME_STOP_WAIT_CEILING_SECONDS=30
+# Intervalle (s) entre deux backups « checkpoint » de navidrome.db pendant un
+# run de sync/rematch long : limite la perte en cas d'échec tardif (si ton
+# wrapper restaure le dernier backup). 0 = à chaque batch, négatif = désactivé.
+NAVIDROME_SYNC_BACKUP_INTERVAL_SECONDS=600
 ###< Navidrome ###
 
 ###> Last.fm ###

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,9 @@ parameters:
     env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
     env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
     env(PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS): '60'
+    # Sync/rematch : intervalle (s) entre deux backups « checkpoint » pendant
+    # un run long. 0 = à chaque batch, négatif = désactivé. Défaut 10 min.
+    env(NAVIDROME_SYNC_BACKUP_INTERVAL_SECONDS): '600'
     env(PLAYLIST_BIRTHDAY_MONTH): '5'
     env(PLAYLIST_BIRTHDAY_DAY): '22'
     env(PLAYLIST_HITPARADE_WEEKS): '52'
@@ -53,6 +56,7 @@ parameters:
     navidrome.container_name: '%env(NAVIDROME_CONTAINER_NAME)%'
     navidrome.container_stop_timeout: '%env(int:NAVIDROME_STOP_TIMEOUT_SECONDS)%'
     navidrome.container_stop_wait_ceiling: '%env(int:NAVIDROME_STOP_WAIT_CEILING_SECONDS)%'
+    navidrome.sync.backup_interval_seconds: '%env(int:NAVIDROME_SYNC_BACKUP_INTERVAL_SECONDS)%'
     lastfm.user: '%env(LASTFM_USER)%'
     lastfm.api_key: '%env(LASTFM_API_KEY)%'
     lastfm.api_secret: '%env(LASTFM_API_SECRET)%'
@@ -250,6 +254,10 @@ services:
         arguments:
             $dbPath: '%navidrome.db_path%'
             $userName: '%navidrome.user%'
+
+    App\Navidrome\NavidromeSyncService:
+        arguments:
+            $backupIntervalSeconds: '%navidrome.sync.backup_interval_seconds%'
 
     App\Subsonic\SubsonicClient:
         arguments:

--- a/src/Navidrome/NavidromeSyncReport.php
+++ b/src/Navidrome/NavidromeSyncReport.php
@@ -12,4 +12,6 @@ final class NavidromeSyncReport
     public int $skipped = 0;
     public bool $dryRun = false;
     public ?string $backupPath = null;
+    /** Number of intermediate (checkpoint) backups taken during the run. */
+    public int $intermediateBackups = 0;
 }

--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -23,6 +23,11 @@ use Doctrine\ORM\EntityManagerInterface;
  * Navidrome commit, so a crash between the two steps leaves the scrobble_sync
  * row in `pending` and will be retried on the next run (dedup via
  * scrobbleExistsNear).
+ *
+ * Long runs additionally take periodic « checkpoint » backups every
+ * `$backupIntervalSeconds` (WAL checkpoint + fresh snapshot). A deployment
+ * whose wrapper restores the latest backup on failure then only loses the
+ * work since the last checkpoint instead of the whole run.
  */
 class NavidromeSyncService
 {
@@ -34,6 +39,8 @@ class NavidromeSyncService
         private readonly NavidromeRepository $navidrome,
         private readonly NavidromeDbBackup $backup,
         private readonly EntityManagerInterface $em,
+        private readonly int $backupIntervalSeconds = 600,
+        private readonly int $batchSize = self::BATCH_SIZE,
     ) {
     }
 
@@ -56,6 +63,7 @@ class NavidromeSyncService
 
         $userId = $this->navidrome->resolveUserId();
         $backupTaken = false;
+        $lastBackupAt = 0;
 
         /** @var list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch */
         $batch = [];
@@ -95,13 +103,15 @@ class NavidromeSyncService
                     ];
                 }
 
-                if (!$dryRun && count($batch) >= self::BATCH_SIZE) {
+                if (!$dryRun && count($batch) >= $this->batchSize) {
                     if (!$backupTaken) {
                         $report->backupPath = $this->backup->backup();
                         $backupTaken = true;
+                        $lastBackupAt = time();
                     }
                     $this->flushBatch($batch, $userId, $run);
                     $batch = [];
+                    $this->maybeIntermediateBackup($report, $lastBackupAt);
                 }
 
                 if ($progress !== null && $report->considered % 50 === 0) {
@@ -112,6 +122,7 @@ class NavidromeSyncService
             if (!$dryRun && $batch !== []) {
                 if (!$backupTaken) {
                     $report->backupPath = $this->backup->backup();
+                    $lastBackupAt = time();
                 }
                 $this->flushBatch($batch, $userId, $run);
             }
@@ -125,6 +136,31 @@ class NavidromeSyncService
         }
 
         return $report;
+    }
+
+    /**
+     * Take a « checkpoint » backup if at least `$backupIntervalSeconds` have
+     * elapsed since the last one. Called right after a committed batch flush,
+     * so the WAL is checkpoint-truncated into the main DB first to make the
+     * snapshot self-contained. A negative interval disables it; `0` backs up
+     * after every batch. Updates `$lastBackupAt` in place.
+     */
+    private function maybeIntermediateBackup(NavidromeSyncReport $report, int &$lastBackupAt): void
+    {
+        if ($this->backupIntervalSeconds < 0 || $lastBackupAt === 0) {
+            return;
+        }
+        if ((time() - $lastBackupAt) < $this->backupIntervalSeconds) {
+            return;
+        }
+
+        $this->navidrome->walCheckpointTruncate();
+        $path = $this->backup->backup();
+        if ($path !== null) {
+            $report->backupPath = $path;
+            $report->intermediateBackups++;
+        }
+        $lastBackupAt = time();
     }
 
     /**

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -243,6 +243,54 @@ class NavidromeSyncServiceTest extends TestCase
         $this->assertTrue(isset($detached[$scrobble]), 'Scrobble must be detached (otherwise toIterable() leaks them on long runs)');
     }
 
+    public function testIntermediateCheckpointBackupsAreTakenDuringLongRuns(): void
+    {
+        // Two matched scrobbles, batchSize 1 → two in-loop flushes; interval 0
+        // → a checkpoint backup after every flush. Expect the initial backup
+        // plus one checkpoint per flush.
+        $s1 = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-01-01 12:00:00');
+        $s2 = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-02-15 09:00:00');
+        $sync1 = new ScrobbleSync($s1, ScrobbleSync::TARGET_NAVIDROME);
+        $sync2 = new ScrobbleSync($s2, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(2);
+        $syncRepo->method('streamPending')->willReturnCallback(function () use ($sync1, $sync2): \Generator {
+            yield $sync1;
+            yield $sync2;
+        });
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturn(MatchResult::matched('mf-1', 'couple', null));
+
+        $backupCalls = 0;
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturnCallback(function () use (&$backupCalls): string {
+            return '/tmp/fake.backup-' . (++$backupCalls);
+        });
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService(
+            $syncRepo,
+            $matcher,
+            $ndRepo,
+            $backup,
+            $em,
+            backupIntervalSeconds: 0,
+            batchSize: 1,
+        );
+        $report = $service->process();
+
+        $this->assertSame(2, $report->matched);
+        $this->assertSame(2, $report->intermediateBackups, 'one checkpoint backup per flush');
+        $this->assertSame(3, $backupCalls, 'initial backup + 2 checkpoints');
+    }
+
     private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
     {
         return new Scrobble(


### PR DESCRIPTION
## Problème

Un run de sync/rematch long ne prenait **qu'un seul backup** (avant la 1ʳᵉ écriture). En cas d'échec tardif, un wrapper qui restaure le dernier backup perdait donc **tout** le travail — cas vécu : ~3 h de rematch annulées par une erreur API Last.fm en toute fin de course.

(Le rollback est dans le wrapper externe, qui restaure le backup le plus récent ; le service committe déjà par batch, mais le restore d'un backup unique pris au début efface ces commits.)

## Correctif

`NavidromeSyncService` prend désormais des **backups intermédiaires périodiques** : toutes les `NAVIDROME_SYNC_BACKUP_INTERVAL_SECONDS` (**défaut 600 s**), après un batch committé, on fait un **WAL checkpoint** (pour un snapshot auto-suffisant) puis un backup frais. La rétention de `NavidromeDbBackup` borne le nombre de fichiers, et le dernier backup reflète l'état récent → **la perte est plafonnée à un intervalle** au lieu du run entier.

- `0` = backup après chaque batch ; valeur négative = désactivé.
- `NavidromeSyncReport::$intermediateBackups` (compteur, exposé dans les métriques de run).
- `batchSize` rendu injectable (testabilité + réglage fin).
- Config : param `services.yaml` + défaut `env(...)` (boot sans la var) + `.env.dist`.

## Vérification

- Test déterministe : `backupIntervalSeconds=0`, `batchSize=1`, 2 scrobbles matchés → backup initial + **1 checkpoint par flush** (`intermediateBackups=2`, `backup()` appelé 3×).
- `composer ci` : **292 tests** verts, phpcs clean, phpstan au baseline. **Twig lint** vert.

## Note

Cause racine de l'incident = une erreur Last.fm transitoire (`track.getInfo` « Response body is empty ») qui fait crasher tout le run. Si tu veux, je peux en complément rendre le matcher **résilient** à ces erreurs ponctuelles (la marquer non-matchée et continuer au lieu d'abandonner) — ça éviterait carrément le rollback. Dis-moi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_