### PR TITLE
feat(sync): résilience aux erreurs Last.fm transitoires (ne plus tout perdre)

### DIFF
--- a/src/Command/RematchCommand.php
+++ b/src/Command/RematchCommand.php
@@ -109,6 +109,7 @@ class RematchCommand extends Command
                             'matched' => $r->matched,
                             'duplicates' => $r->duplicates,
                             'unmatched' => $r->unmatched,
+                            'api_errors' => $r->apiErrors,
                         ];
                     }
                     return [
@@ -136,6 +137,16 @@ class RematchCommand extends Command
             $matched,
             $unmatched,
         ));
+
+        if ($report instanceof NavidromeSyncReport && $report->apiErrors > 0) {
+            $io->warning(sprintf(
+                '%d scrobble(s) ignoré(s) sur erreur API Last.fm (laissés en pending, relancez pour réessayer).%s',
+                $report->apiErrors,
+                $report->abortedOnApiErrors
+                    ? ' Run interrompu : trop d\'erreurs consécutives (Last.fm indisponible ?).'
+                    : '',
+            ));
+        }
 
         return Command::SUCCESS;
     }

--- a/src/Command/SyncNavidromeCommand.php
+++ b/src/Command/SyncNavidromeCommand.php
@@ -81,6 +81,7 @@ class SyncNavidromeCommand extends Command
                     'duplicates' => $r->duplicates,
                     'unmatched' => $r->unmatched,
                     'skipped' => $r->skipped,
+                    'api_errors' => $r->apiErrors,
                     'backup' => $r->backupPath,
                     'dry_run' => $r->dryRun,
                 ],

--- a/src/LastFm/LastFmClient.php
+++ b/src/LastFm/LastFmClient.php
@@ -360,7 +360,7 @@ class LastFmClient
                     }
                     continue;
                 }
-                throw new \RuntimeException(sprintf(
+                throw new LastFmRequestException(sprintf(
                     'Last.fm API call failed (method=%s page=%s) after %d attempt(s): %s',
                     $params['method'] ?? '?',
                     $params['page'] ?? '?',

--- a/src/LastFm/LastFmRequestException.php
+++ b/src/LastFm/LastFmRequestException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\LastFm;
+
+/**
+ * A Last.fm HTTP request that failed at the transport level (timeout, empty
+ * body, connection reset…) after exhausting the client's retries — as opposed
+ * to {@see LastFmApiException}, which carries a Last.fm API error code.
+ *
+ * Extends \RuntimeException so existing `catch (\RuntimeException)` call sites
+ * keep working; callers that want to treat a transient network blip specially
+ * (e.g. skip one scrobble during a long rematch rather than aborting the whole
+ * run) can catch this narrower type.
+ */
+class LastFmRequestException extends \RuntimeException
+{
+}

--- a/src/MessageHandler/RematchMessageHandler.php
+++ b/src/MessageHandler/RematchMessageHandler.php
@@ -57,7 +57,7 @@ class RematchMessageHandler
                 'considered' => $r->considered,
                 'matched' => $r->matched,
                 'unmatched' => $r->unmatched,
-            ],
+            ] + ($r instanceof NavidromeSyncReport && $r->apiErrors > 0 ? ['api_errors' => $r->apiErrors] : []),
         );
 
         if ($message->target === ScrobbleSync::TARGET_NAVIDROME && $message->autoStop && !$message->dryRun) {

--- a/src/MessageHandler/SyncNavidromeMessageHandler.php
+++ b/src/MessageHandler/SyncNavidromeMessageHandler.php
@@ -39,6 +39,7 @@ class SyncNavidromeMessageHandler
                 'duplicates' => $r->duplicates,
                 'unmatched' => $r->unmatched,
                 'skipped' => $r->skipped,
+                'api_errors' => $r->apiErrors,
                 'dry_run' => $r->dryRun,
             ],
         );

--- a/src/Navidrome/NavidromeSyncReport.php
+++ b/src/Navidrome/NavidromeSyncReport.php
@@ -14,4 +14,8 @@ final class NavidromeSyncReport
     public ?string $backupPath = null;
     /** Number of intermediate (checkpoint) backups taken during the run. */
     public int $intermediateBackups = 0;
+    /** Scrobbles skipped because a Last.fm API call failed (left pending). */
+    public int $apiErrors = 0;
+    /** True when the run stopped early after too many consecutive API errors. */
+    public bool $abortedOnApiErrors = false;
 }

--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -4,6 +4,8 @@ namespace App\Navidrome;
 
 use App\Entity\RunHistory;
 use App\Entity\ScrobbleSync;
+use App\LastFm\LastFmApiException;
+use App\LastFm\LastFmRequestException;
 use App\LastFm\LastFmScrobble;
 use App\LastFm\MatchResult;
 use App\LastFm\ScrobbleMatcher;
@@ -41,6 +43,7 @@ class NavidromeSyncService
         private readonly EntityManagerInterface $em,
         private readonly int $backupIntervalSeconds = 600,
         private readonly int $batchSize = self::BATCH_SIZE,
+        private readonly int $maxConsecutiveApiErrors = 25,
     ) {
     }
 
@@ -64,6 +67,7 @@ class NavidromeSyncService
         $userId = $this->navidrome->resolveUserId();
         $backupTaken = false;
         $lastBackupAt = 0;
+        $consecutiveApiErrors = 0;
 
         /** @var list<array{sync: ScrobbleSync, matchedId: ?string, status: string, strategy: ?string, willInsert: bool}> $batch */
         $batch = [];
@@ -81,7 +85,22 @@ class NavidromeSyncService
                     playedAt: $scrobble->getPlayedAt(),
                 );
 
-                $result = $this->matcher->match($lfmScrobble);
+                try {
+                    $result = $this->matcher->match($lfmScrobble);
+                    $consecutiveApiErrors = 0;
+                } catch (LastFmRequestException | LastFmApiException $e) {
+                    // Transient Last.fm failure (timeout, empty body, rate
+                    // limit…). Don't poison the cache or abort the whole run:
+                    // leave this scrobble pending and move on — it'll be
+                    // retried next time. A burst of consecutive failures means
+                    // Last.fm is down, so stop gracefully (committed work kept).
+                    $report->apiErrors++;
+                    if (++$consecutiveApiErrors >= $this->maxConsecutiveApiErrors) {
+                        $report->abortedOnApiErrors = true;
+                        break;
+                    }
+                    continue;
+                }
 
                 [$status, $matchedId, $strategy, $willInsert] = $this->classify(
                     $result,

--- a/tests/Navidrome/NavidromeSyncServiceTest.php
+++ b/tests/Navidrome/NavidromeSyncServiceTest.php
@@ -291,6 +291,83 @@ class NavidromeSyncServiceTest extends TestCase
         $this->assertSame(3, $backupCalls, 'initial backup + 2 checkpoints');
     }
 
+    public function testTransientLastFmErrorSkipsScrobbleAndContinues(): void
+    {
+        // First scrobble's match() throws a transient Last.fm error → it's
+        // skipped (left pending), the run continues and the second scrobble
+        // still matches and is inserted.
+        $bad = $this->makeScrobble('Flaky Net', 'Timeout', '2024-01-01 12:00:00');
+        $good = $this->makeScrobble('Daft Punk', 'Get Lucky', '2024-02-01 12:00:00');
+        $syncBad = new ScrobbleSync($bad, ScrobbleSync::TARGET_NAVIDROME);
+        $syncGood = new ScrobbleSync($good, ScrobbleSync::TARGET_NAVIDROME);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(2);
+        $syncRepo->method('streamPending')->willReturnCallback(function () use ($syncBad, $syncGood): \Generator {
+            yield $syncBad;
+            yield $syncGood;
+        });
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willReturnCallback(static function (\App\LastFm\LastFmScrobble $s): MatchResult {
+            if ($s->artist === 'Flaky Net') {
+                throw new \App\LastFm\LastFmRequestException('Response body is empty.');
+            }
+
+            return MatchResult::matched('mf-1', 'couple', null);
+        });
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $backup->method('backup')->willReturn(null);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+        $em->method('persist');
+        $em->method('flush');
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em);
+        $report = $service->process();
+
+        $this->assertSame(2, $report->considered);
+        $this->assertSame(1, $report->apiErrors);
+        $this->assertSame(1, $report->matched);
+        $this->assertFalse($report->abortedOnApiErrors);
+
+        $ndConn = DriverManager::getConnection(['driver' => 'pdo_sqlite', 'path' => $this->ndDbPath]);
+        $this->assertSame(1, (int) $ndConn->fetchOne('SELECT COUNT(*) FROM scrobbles'));
+        $ndConn->close();
+    }
+
+    public function testRunAbortsGracefullyAfterTooManyConsecutiveApiErrors(): void
+    {
+        $s1 = $this->makeScrobble('A', 'x', '2024-01-01 12:00:00');
+        $s2 = $this->makeScrobble('B', 'y', '2024-01-02 12:00:00');
+        $s3 = $this->makeScrobble('C', 'z', '2024-01-03 12:00:00');
+        $syncs = array_map(static fn (Scrobble $s) => new ScrobbleSync($s, ScrobbleSync::TARGET_NAVIDROME), [$s1, $s2, $s3]);
+
+        $syncRepo = $this->createMock(ScrobbleSyncRepository::class);
+        $syncRepo->method('prepareForTarget')->willReturn(3);
+        $syncRepo->method('streamPending')->willReturnCallback(function () use ($syncs): \Generator {
+            yield from $syncs;
+        });
+
+        $ndRepo = new NavidromeRepository($this->ndDbPath, 'admin');
+        $matcher = $this->createMock(ScrobbleMatcher::class);
+        $matcher->method('match')->willThrowException(new \App\LastFm\LastFmApiException(29, 'Rate limit exceeded'));
+
+        $backup = $this->createMock(NavidromeDbBackup::class);
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('contains')->willReturn(false);
+
+        $service = new NavidromeSyncService($syncRepo, $matcher, $ndRepo, $backup, $em, maxConsecutiveApiErrors: 2);
+        $report = $service->process();
+
+        $this->assertTrue($report->abortedOnApiErrors);
+        $this->assertSame(2, $report->apiErrors);
+        $this->assertSame(2, $report->considered, 'stopped on the 2nd consecutive error, 3rd never reached');
+        $this->assertSame(0, $report->matched);
+    }
+
     private function makeScrobble(string $artist, string $title, string $playedAt): Scrobble
     {
         return new Scrobble(


### PR DESCRIPTION
## Problème

Une **seule** erreur API Last.fm transitoire (ex. `track.getInfo` « Response body is empty ») faisait **planter tout le run** de sync/rematch (exit 1) → rollback complet par le wrapper → des heures de matching perdues.

## Correctif

Sur une erreur Last.fm transitoire pendant le matching d'un scrobble, on **saute** ce scrobble (laissé en *pending*, **sans** écrire d'entrée négative dans le cache) et on **continue**. Le run se termine normalement (exit 0) → pas de rollback, le travail déjà committé est conservé. Un **disjoncteur** arrête proprement le run après trop d'erreurs consécutives (Last.fm clairement indisponible), en gardant l'acquis et en le signalant.

- **`LastFmRequestException`** (`extends \RuntimeException`) pour les échecs transport après retries, levée par `LastFmClient::call()`. Rétro-compatible avec les `catch (\RuntimeException)` existants (sous-classe).
- **`NavidromeSyncService`** : `try/catch (LastFmRequestException | LastFmApiException)` autour de `match()` par scrobble → compteur `apiErrors`, `abortedOnApiErrors`, et seuil `maxConsecutiveApiErrors` (défaut 25, injectable).
- Métrique **`api_errors`** exposée partout (rematch + sync, CLI + handlers), + un `warning` CLI listant les scrobbles ignorés (« relancez pour réessayer »).

## Vérification

- Tests : (1) un scrobble dont `match()` jette une erreur transitoire est sauté, le suivant matche et est inséré (`apiErrors=1`, `matched=1`, run OK) ; (2) disjoncteur — après N erreurs consécutives, `abortedOnApiErrors=true` et l'itération s'arrête.
- `composer ci` : **294 tests** verts, phpcs clean, phpstan au baseline. **Twig lint** vert.

Combiné aux backups checkpoint (#237) : même si un cas non prévu fait échouer le run, la perte est plafonnée au dernier checkpoint. Et pour le cas courant (blip réseau), il n'y a plus d'échec du tout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_