### PR TITLE
docs(scripts): découpe backup / rematch / sync en wrappers cron séparés

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ Points d'attention (prod) :
 - Ne **pas** partager `APP_CACHE_DIR` entre les conteneurs web et worker.
 - `NAVIDROME_USER` doit correspondre au compte Navidrome réel (sinon les
   commandes de sync échouent avec « user not found »).
-- `scripts/navidrome-sync.sh.example` : wrapper bash pour orchestrer un cycle
-  complet en crontab.
+- `scripts/*.sh.example` : wrappers bash pour le crontab (à recopier sans le
+  suffixe `.example`, avec `navidrome-lib.sh` — config + helpers partagés — à
+  côté). Trois entrées indépendantes : `navidrome-sync.sh` (scrobbles + loves),
+  `navidrome-rematch.sh` (rematch seul, peut être long), `navidrome-backup.sh`
+  (snapshot + garde d'intégrité). Chacune arrête le conteneur, sauvegarde, et
+  ne rollback que sur corruption réelle (vers le backup sain le plus récent).
 
 ---
 

--- a/scripts/navidrome-backup.sh.example
+++ b/scripts/navidrome-backup.sh.example
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-backup.sh — snapshot horodaté de la DB Navidrome (rien d'autre).
+#
+# Recopier en `navidrome-backup.sh` (gitignoré), avec `navidrome-lib.sh` à côté.
+#
+# Flow : stop conteneur → quick_check → backup (si DB saine) → start → purge.
+# Si la DB live est déjà corrompue : restaure le backup sain le plus récent.
+#
+# Codes de sortie : 0 OK · 1 config · 2 stop KO · 4 corruption (restaurée) ·
+#                   5 start KO après backup.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-backup"
+
+nd_preflight
+nd_register_trap
+
+nd_stop
+
+# Ne pas snapshotter une DB corrompue — la vérifier d'abord.
+if quick_check_ok "$NAVIDROME_DB_PATH"; then
+    take_backup
+    purge_old_backups
+    if ! nd_start_if_stopped; then
+        msg="Backup OK mais impossible de redémarrer ${COMPOSE_SERVICE}."
+        log "$msg"; notify_failure "$msg"; exit 5
+    fi
+    log "Backup terminé avec succès."
+    exit 0
+fi
+
+msg="quick_check KO sur la DB live — corruption détectée."
+log "$msg"
+rollback_db || true
+nd_start_if_stopped || true
+notify_failure "$msg DB restaurée depuis le backup sain le plus récent."
+exit 4

--- a/scripts/navidrome-lib.sh.example
+++ b/scripts/navidrome-lib.sh.example
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-lib.sh — config + helpers partagés par les wrappers crontab
+# (navidrome-backup.sh, navidrome-rematch.sh, navidrome-sync.sh).
+#
+# Recopier en `navidrome-lib.sh` (gitignoré), adapter la config ci-dessous,
+# puis `source` depuis chaque point d'entrée. Ce fichier ne FAIT rien tout
+# seul : il ne définit que des variables et des fonctions.
+# -----------------------------------------------------------------------------
+
+# === Config (override possible via variables d'env avant le source) =========
+: "${PROJECT_DIR:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+# Chemin du fichier SQLite Navidrome — la VRAIE DB, pas un montage read-only.
+: "${NAVIDROME_DB_PATH:=${PROJECT_DIR}/var/navidrome.db}"
+# Où stocker les backups du wrapper (créé si absent).
+: "${BACKUP_DIR:=${PROJECT_DIR}/backups}"
+# Rétention en jours (find -mtime) pour la purge des backups du wrapper.
+: "${BACKUP_RETENTION_DAYS:=7}"
+# Docker compose : fichier + nom du service Navidrome.
+: "${COMPOSE_FILE:=${PROJECT_DIR}/docker-compose.yml}"
+: "${COMPOSE_SERVICE:=navidrome}"
+# Binaire PHP pour bin/console (chemin absolu si php n'est pas dans le PATH cron).
+: "${PHP_BIN:=php}"
+# Notification d'échec — laisser GOTIFY_URL vide pour désactiver.
+: "${GOTIFY_URL:=}"
+: "${GOTIFY_TOKEN:=}"
+: "${GOTIFY_PRIORITY:=8}"
+
+# Préfixe affiché dans les logs / notifs (chaque entrée peut le surcharger).
+: "${NOTIFY_TITLE:=navidrome}"
+
+# === État partagé ============================================================
+STOPPED=0
+BACKUP_PATH=""
+
+# === Helpers =================================================================
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
+}
+
+notify_failure() {
+    local message="$1"
+    if [[ -z "$GOTIFY_URL" || -z "$GOTIFY_TOKEN" ]]; then
+        return 0
+    fi
+    # Best-effort : ne pas masquer l'erreur d'origine si la notif rate.
+    curl --silent --show-error --max-time 10 \
+        --data "title=${NOTIFY_TITLE}" \
+        --data "message=${message}" \
+        --data "priority=${GOTIFY_PRIORITY}" \
+        "${GOTIFY_URL%/}/message?token=${GOTIFY_TOKEN}" \
+        >/dev/null 2>&1 || true
+
+    # Exemples — décommenter et remplir pour un autre canal :
+    # curl -X POST -H 'Content-type: application/json' --max-time 10 \
+    #     --data "{\"text\": \"${NOTIFY_TITLE}: ${message}\"}" \
+    #     "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
+}
+
+# Pré-flight commun. Appeler en début de chaque entrée.
+nd_preflight() {
+    if [[ ! -f "$NAVIDROME_DB_PATH" ]]; then
+        log "NAVIDROME_DB_PATH introuvable : $NAVIDROME_DB_PATH"; exit 1
+    fi
+    if [[ ! -f "$COMPOSE_FILE" ]]; then
+        log "COMPOSE_FILE introuvable : $COMPOSE_FILE"; exit 1
+    fi
+    if ! command -v sqlite3 >/dev/null 2>&1; then
+        log "sqlite3 absent du PATH — requis pour le quick_check."; exit 1
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
+        log "docker absent du PATH."; exit 1
+    fi
+    mkdir -p "$BACKUP_DIR"
+    cd "$PROJECT_DIR"
+}
+
+nd_stop() {
+    log "Stop ${COMPOSE_SERVICE}…"
+    if ! docker compose -f "$COMPOSE_FILE" stop "$COMPOSE_SERVICE" >/dev/null; then
+        local msg="Échec de l'arrêt du conteneur ${COMPOSE_SERVICE}."
+        log "$msg"; notify_failure "$msg"; exit 2
+    fi
+    STOPPED=1
+}
+
+nd_start_if_stopped() {
+    if [[ "$STOPPED" -eq 1 ]]; then
+        log "Redémarrage du conteneur ${COMPOSE_SERVICE}…"
+        if docker compose -f "$COMPOSE_FILE" start "$COMPOSE_SERVICE" >/dev/null; then
+            STOPPED=0
+        else
+            log "Impossible de redémarrer ${COMPOSE_SERVICE}."; return 1
+        fi
+    fi
+}
+
+# Filet de sécurité : relancer le conteneur si le script meurt après le stop.
+nd_register_trap() {
+    trap '
+        code=$?
+        if [[ "$STOPPED" -eq 1 ]]; then
+            log "Sortie inattendue (code=$code) avec conteneur arrêté — tentative de redémarrage."
+            docker compose -f "$COMPOSE_FILE" start "$COMPOSE_SERVICE" >/dev/null 2>&1 || true
+        fi
+        exit "$code"
+    ' EXIT
+}
+
+quick_check_ok() {
+    [[ "$(sqlite3 "$1" 'PRAGMA quick_check;' 2>/dev/null)" == "ok" ]]
+}
+
+# Backup horodaté de la DB (+ WAL/SHM si présents) dans BACKUP_DIR.
+# Renseigne BACKUP_PATH.
+take_backup() {
+    local ts
+    ts="$(date +%Y%m%d_%H%M%S)"
+    BACKUP_PATH="${BACKUP_DIR}/navidrome-${ts}.db"
+    log "Backup → $BACKUP_PATH"
+    cp -p "$NAVIDROME_DB_PATH" "$BACKUP_PATH"
+    cp -p "${NAVIDROME_DB_PATH}-wal" "${BACKUP_PATH}-wal" 2>/dev/null || true
+    cp -p "${NAVIDROME_DB_PATH}-shm" "${BACKUP_PATH}-shm" 2>/dev/null || true
+}
+
+# Backup SAIN le plus récent, parmi : les backups du wrapper
+# ($BACKUP_DIR/navidrome-*.db) ET les checkpoints intermédiaires écrits par
+# l'app à côté de la DB (${NAVIDROME_DB_PATH}.backup-*). Trié par date
+# décroissante ; renvoie le premier qui passe quick_check.
+latest_sound_backup() {
+    local files=() f sorted
+    shopt -s nullglob
+    for f in "${BACKUP_DIR}"/navidrome-*.db "${NAVIDROME_DB_PATH}".backup-*; do
+        [[ "$f" == *-wal || "$f" == *-shm ]] && continue
+        [[ -f "$f" ]] && files+=("$f")
+    done
+    shopt -u nullglob
+    [[ ${#files[@]} -eq 0 ]] && return 1
+
+    sorted="$(stat --format='%Y	%n' "${files[@]}" 2>/dev/null | sort -rn | cut -f2-)"
+    while IFS= read -r f; do
+        [[ -z "$f" || ! -f "$f" ]] && continue
+        if quick_check_ok "$f"; then
+            printf '%s\n' "$f"; return 0
+        fi
+    done <<< "$sorted"
+    return 1
+}
+
+rollback_db() {
+    local src
+    src="$(latest_sound_backup || true)"
+    if [[ -z "$src" || ! -f "$src" ]]; then
+        log "Aucun backup sain à restaurer."; return 1
+    fi
+    log "Rollback DB depuis $src…"
+    cp -p "$src" "$NAVIDROME_DB_PATH"
+    if [[ -f "${src}-wal" ]]; then cp -p "${src}-wal" "${NAVIDROME_DB_PATH}-wal"; else rm -f "${NAVIDROME_DB_PATH}-wal"; fi
+    if [[ -f "${src}-shm" ]]; then cp -p "${src}-shm" "${NAVIDROME_DB_PATH}-shm"; else rm -f "${NAVIDROME_DB_PATH}-shm"; fi
+}
+
+# Politique sur échec d'une commande de write (sync / rematch) : les écritures
+# sont committées par lots et atomiques, donc un échec laisse une DB cohérente.
+# On conserve le travail si la DB est intègre ; rollback seulement si corrompue.
+on_command_failure() {
+    local msg="$1"
+    log "$msg"
+    if quick_check_ok "$NAVIDROME_DB_PATH"; then
+        log "DB intègre — travail partiel conservé (les restants repasseront au prochain run)."
+        nd_start_if_stopped || true
+        notify_failure "$msg Travail partiel conservé (DB intègre)."
+        exit 3
+    fi
+    log "DB corrompue — rollback vers le backup sain le plus récent."
+    rollback_db || true
+    nd_start_if_stopped || true
+    notify_failure "$msg DB corrompue → restaurée depuis un backup sain."
+    exit 3
+}
+
+purge_old_backups() {
+    log "Purge des backups > ${BACKUP_RETENTION_DAYS} j dans $BACKUP_DIR…"
+    find "$BACKUP_DIR" \
+        -maxdepth 1 -type f \
+        \( -name 'navidrome-*.db' -o -name 'navidrome-*.db-wal' -o -name 'navidrome-*.db-shm' \) \
+        -mtime +"${BACKUP_RETENTION_DAYS}" \
+        -delete
+}

--- a/scripts/navidrome-rematch.sh.example
+++ b/scripts/navidrome-rematch.sh.example
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-rematch.sh — relance le matching des scrobbles non-matchés.
+#
+# Recopier en `navidrome-rematch.sh` (gitignoré), avec `navidrome-lib.sh` à côté.
+# À cronner séparément de la sync (le rematch peut être long).
+#
+# Flow : stop conteneur → backup baseline → rematch (résilient aux erreurs
+#        Last.fm, checkpoints intermédiaires) → quick_check → start → purge.
+#
+# Codes de sortie : 0 OK · 1 config · 2 stop KO · 3 commande KO (DB intègre →
+#                   travail conservé ; sinon rollback) · 4 quick_check KO
+#                   (rollback) · 5 start KO après rematch.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-rematch"
+
+# Cible du rematch : navidrome (défaut) ou strawberry. Surcharge via env.
+: "${REMATCH_TARGET:=navidrome}"
+
+nd_preflight
+nd_register_trap
+
+nd_stop
+take_backup   # baseline ; l'app prend aussi des checkpoints pendant le run
+
+log "Rematch ${REMATCH_TARGET}…"
+# Pas de --auto-stop (le conteneur est déjà arrêté par ce script). Ajouter
+# --force si l'app ne peut pas vérifier l'état du conteneur (accès socket
+# Docker indisponible depuis le conteneur outils).
+if ! "$PHP_BIN" bin/console app:scrobbles:rematch --target "$REMATCH_TARGET" --no-interaction; then
+    on_command_failure "Échec du rematch ${REMATCH_TARGET}."
+fi
+
+if ! quick_check_ok "$NAVIDROME_DB_PATH"; then
+    msg="quick_check KO après rematch."
+    log "$msg"; rollback_db || true; nd_start_if_stopped || true
+    notify_failure "$msg DB restaurée depuis le backup sain le plus récent."
+    exit 4
+fi
+log "quick_check OK."
+
+if ! nd_start_if_stopped; then
+    msg="Rematch OK mais impossible de redémarrer ${COMPOSE_SERVICE}."
+    log "$msg"; notify_failure "$msg"; exit 5
+fi
+
+purge_old_backups
+log "Rematch terminé avec succès."
+exit 0

--- a/scripts/navidrome-sync.sh.example
+++ b/scripts/navidrome-sync.sh.example
@@ -1,290 +1,54 @@
 #!/usr/bin/env bash
 # -----------------------------------------------------------------------------
-# navidrome-sync.sh — point d'entrée crontab pour la sync Last.fm → Navidrome.
+# navidrome-sync.sh — sync Last.fm → Navidrome (scrobbles + loves).
 #
-# Recopier ce fichier en `navidrome-sync.sh` (gitignoré), adapter les chemins,
-# le webhook éventuel, puis l'invoquer via cron.
+# Recopier en `navidrome-sync.sh` (gitignoré), avec `navidrome-lib.sh` à côté.
+# Le rematch a son propre script (navidrome-rematch.sh), à cronner séparément
+# — il n'est PLUS inclus ici.
 #
-# Flow :
-#   1. stop conteneur Navidrome (docker compose)
-#   2. backup horodaté de la DB (+ WAL/SHM si présents)
-#   3. sync scrobbles + sync loves Last.fm → Navidrome
-#   4. PRAGMA quick_check ; rollback (backup sain le + récent) + notif si KO
-#   5. start conteneur Navidrome
-#   6. purge des backups au-delà de BACKUP_RETENTION_DAYS
+# Flow : stop conteneur → backup → sync scrobbles + loves → quick_check →
+#        start → purge.
 #
-# Politique de rollback (depuis navidrome-tools ≥ refonte sync) :
-#   - Les commandes de sync committent par lots (BEGIN IMMEDIATE → COMMIT) et
-#     tolèrent les erreurs Last.fm transitoires (le scrobble fautif est laissé
-#     en pending, le run continue puis se termine en code 0). Elles prennent
-#     aussi des backups « checkpoint » intermédiaires pendant les longs runs.
-#   - Conséquence : un échec de commande ne corrompt PAS la DB. On ne fait donc
-#     PLUS de rollback systématique (qui jetterait des heures de travail déjà
-#     committé). On rollback UNIQUEMENT si `quick_check` détecte une vraie
-#     corruption — et on restaure alors le backup SAIN le plus récent (y
-#     compris un checkpoint intermédiaire), pas le backup de début de run.
-#
-# Codes de sortie :
-#   0  succès
-#   1  erreur de configuration (DB / compose introuvable, sqlite3 absent)
-#   2  docker compose stop a échoué
-#   3  une commande de sync a échoué (DB intègre → travail conservé ; sinon
-#                                      rollback vers le backup sain le + récent)
-#   4  quick_check KO          (rollback vers le backup sain le + récent)
-#   5  docker compose start a échoué après une sync OK
+# Codes de sortie : 0 OK · 1 config · 2 stop KO · 3 commande KO (DB intègre →
+#                   travail conservé ; sinon rollback) · 4 quick_check KO
+#                   (rollback) · 5 start KO après sync.
 # -----------------------------------------------------------------------------
 
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-sync"
 
-# === Config ==================================================================
-# Racine du projet (par défaut : parent du dossier qui contient ce script).
-PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+nd_preflight
+nd_register_trap
 
-# Chemin du fichier SQLite Navidrome. Doit pointer sur la VRAIE DB, pas un
-# montage read-only.
-NAVIDROME_DB_PATH="${PROJECT_DIR}/var/navidrome.db"
+nd_stop
+take_backup
 
-# Où stocker les backups. Créé si absent.
-BACKUP_DIR="${PROJECT_DIR}/backups"
-
-# Rétention en jours (find -mtime). Les .db / -wal / -shm plus vieux sont
-# supprimés en fin de run.
-BACKUP_RETENTION_DAYS=7
-
-# Docker compose : fichier + nom du service Navidrome.
-COMPOSE_FILE="${PROJECT_DIR}/docker-compose.yml"
-COMPOSE_SERVICE="navidrome"
-
-# Binaire PHP utilisé pour bin/console (chemin absolu si php n'est pas dans le
-# PATH du cron).
-PHP_BIN="php"
-
-# Notification en cas d'échec — laisser GOTIFY_URL vide pour désactiver, ou
-# remplacer la fonction notify_failure() ci-dessous par un POST vers
-# Slack/Discord/Pushover.
-GOTIFY_URL=""
-GOTIFY_TOKEN=""
-GOTIFY_PRIORITY=8
-
-# === Helpers =================================================================
-
-log() {
-    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" >&2
-}
-
-notify_failure() {
-    local message="$1"
-    if [[ -z "$GOTIFY_URL" || -z "$GOTIFY_TOKEN" ]]; then
-        return 0
-    fi
-    # Best-effort : ne pas masquer l'erreur d'origine si la notif rate.
-    curl --silent --show-error --max-time 10 \
-        --data "title=navidrome-sync" \
-        --data "message=${message}" \
-        --data "priority=${GOTIFY_PRIORITY}" \
-        "${GOTIFY_URL%/}/message?token=${GOTIFY_TOKEN}" \
-        >/dev/null 2>&1 || true
-
-    # Exemples — décommenter et remplir si vous préférez un autre canal :
-    # curl -X POST -H 'Content-type: application/json' --max-time 10 \
-    #     --data "{\"text\": \"navidrome-sync: ${message}\"}" \
-    #     "$SLACK_WEBHOOK_URL" >/dev/null 2>&1 || true
-    # curl -X POST -H 'Content-type: application/json' --max-time 10 \
-    #     --data "{\"content\": \"navidrome-sync: ${message}\"}" \
-    #     "$DISCORD_WEBHOOK_URL" >/dev/null 2>&1 || true
-}
-
-# État partagé avec les fonctions de cleanup.
-BACKUP_PATH=""
-STOPPED=0
-
-start_container_if_stopped() {
-    if [[ "$STOPPED" -eq 1 ]]; then
-        log "Redémarrage du conteneur ${COMPOSE_SERVICE}…"
-        if docker compose -f "$COMPOSE_FILE" start "$COMPOSE_SERVICE" >/dev/null; then
-            STOPPED=0
-        else
-            log "Impossible de redémarrer ${COMPOSE_SERVICE}."
-            return 1
-        fi
-    fi
-}
-
-# Backup SAIN le plus récent, parmi : les backups de ce wrapper
-# ($BACKUP_DIR/navidrome-*.db) ET les checkpoints intermédiaires écrits par
-# l'app à côté de la DB (${NAVIDROME_DB_PATH}.backup-*). On les trie par date
-# décroissante et on renvoie le premier qui passe quick_check.
-latest_sound_backup() {
-    local files=() f sorted
-    shopt -s nullglob
-    for f in "${BACKUP_DIR}"/navidrome-*.db "${NAVIDROME_DB_PATH}".backup-*; do
-        [[ "$f" == *-wal || "$f" == *-shm ]] && continue
-        [[ -f "$f" ]] && files+=("$f")
-    done
-    shopt -u nullglob
-    [[ ${#files[@]} -eq 0 ]] && return 1
-
-    sorted="$(stat --format='%Y	%n' "${files[@]}" 2>/dev/null | sort -rn | cut -f2-)"
-    while IFS= read -r f; do
-        [[ -z "$f" || ! -f "$f" ]] && continue
-        if [[ "$(sqlite3 "$f" 'PRAGMA quick_check;' 2>/dev/null)" == "ok" ]]; then
-            printf '%s\n' "$f"
-            return 0
-        fi
-    done <<< "$sorted"
-    return 1
-}
-
-rollback_db() {
-    local src
-    src="$(latest_sound_backup || true)"
-    if [[ -z "$src" || ! -f "$src" ]]; then
-        log "Aucun backup sain à restaurer."
-        return 1
-    fi
-    log "Rollback DB depuis $src…"
-    cp -p "$src" "$NAVIDROME_DB_PATH"
-    if [[ -f "${src}-wal" ]]; then
-        cp -p "${src}-wal" "${NAVIDROME_DB_PATH}-wal"
-    else
-        rm -f "${NAVIDROME_DB_PATH}-wal"
-    fi
-    if [[ -f "${src}-shm" ]]; then
-        cp -p "${src}-shm" "${NAVIDROME_DB_PATH}-shm"
-    else
-        rm -f "${NAVIDROME_DB_PATH}-shm"
-    fi
-}
-
-# Filet de sécurité : si le script est interrompu (CTRL-C, kill) après le stop
-# mais avant le start, on tente quand même de relancer le conteneur pour ne pas
-# laisser Navidrome down.
-cleanup_on_exit() {
-    local code=$?
-    if [[ "$STOPPED" -eq 1 ]]; then
-        log "Sortie inattendue (code=$code) avec conteneur arrêté — tentative de redémarrage."
-        docker compose -f "$COMPOSE_FILE" start "$COMPOSE_SERVICE" >/dev/null 2>&1 || true
-    fi
-    exit "$code"
-}
-trap cleanup_on_exit EXIT
-
-# === Pré-flight ==============================================================
-
-if [[ ! -f "$NAVIDROME_DB_PATH" ]]; then
-    log "NAVIDROME_DB_PATH introuvable : $NAVIDROME_DB_PATH"
-    exit 1
-fi
-if [[ ! -f "$COMPOSE_FILE" ]]; then
-    log "COMPOSE_FILE introuvable : $COMPOSE_FILE"
-    exit 1
-fi
-if ! command -v sqlite3 >/dev/null 2>&1; then
-    log "sqlite3 absent du PATH — requis pour le quick_check."
-    exit 1
-fi
-if ! command -v docker >/dev/null 2>&1; then
-    log "docker absent du PATH."
-    exit 1
-fi
-
-mkdir -p "$BACKUP_DIR"
-cd "$PROJECT_DIR"
-
-# === 1. Stop conteneur =======================================================
-
-log "Stop ${COMPOSE_SERVICE}…"
-if ! docker compose -f "$COMPOSE_FILE" stop "$COMPOSE_SERVICE" >/dev/null; then
-    msg="Échec de l'arrêt du conteneur ${COMPOSE_SERVICE}."
-    log "$msg"
-    notify_failure "$msg"
-    exit 2
-fi
-STOPPED=1
-
-# === 2. Backup ==============================================================
-
-TS="$(date +%Y%m%d_%H%M%S)"
-BACKUP_PATH="${BACKUP_DIR}/navidrome-${TS}.db"
-log "Backup → $BACKUP_PATH"
-cp -p "$NAVIDROME_DB_PATH" "$BACKUP_PATH"
-# WAL/SHM ne sont pas toujours présents (SQLite peut les avoir fusionnés au
-# stop) — best-effort, pas d'erreur fatale s'ils manquent.
-cp -p "${NAVIDROME_DB_PATH}-wal" "${BACKUP_PATH}-wal" 2>/dev/null || true
-cp -p "${NAVIDROME_DB_PATH}-shm" "${BACKUP_PATH}-shm" 2>/dev/null || true
-
-# === 3. Sync Last.fm → Navidrome ============================================
-
-run_sync() {
+run_step() {
     local label="$1"
     shift
     log "Sync ${label}…"
-    if ! "$@"; then
-        local msg="Échec de la commande ${label}."
-        log "$msg"
-        # Les écritures sont committées par lots et atomiques : un échec laisse
-        # une DB cohérente avec le travail déjà fait. On NE rollback PAS si la
-        # DB est intègre — les scrobbles restants repasseront au prochain run.
-        # Rollback seulement en cas de vraie corruption.
-        if [[ "$(sqlite3 "$NAVIDROME_DB_PATH" 'PRAGMA quick_check;' 2>/dev/null)" == "ok" ]]; then
-            log "DB intègre — travail partiel conservé (pas de rollback)."
-            start_container_if_stopped || true
-            notify_failure "$msg Travail partiel conservé (DB intègre, restants au prochain run)."
-            exit 3
-        fi
-        log "DB corrompue — rollback vers le backup sain le plus récent."
-        rollback_db || true
-        start_container_if_stopped || true
-        notify_failure "$msg DB corrompue → restaurée depuis un backup sain."
-        exit 3
-    fi
+    "$@" || on_command_failure "Échec de la commande ${label}."
 }
 
-run_sync "scrobbles → Navidrome" \
-    "$PHP_BIN" bin/console app:scrobbles:sync-navidrome --no-interaction
-run_sync "loves Last.fm → Navidrome" \
-    "$PHP_BIN" bin/console app:loves:lastfm-to-navidrome --no-interaction
+run_step "scrobbles → Navidrome" "$PHP_BIN" bin/console app:scrobbles:sync-navidrome --no-interaction
+run_step "loves Last.fm → Navidrome" "$PHP_BIN" bin/console app:loves:lastfm-to-navidrome --no-interaction
 
-# === 4. Intégrité ============================================================
-
-log "PRAGMA quick_check…"
-if ! check_output="$(sqlite3 "$NAVIDROME_DB_PATH" 'PRAGMA quick_check;' 2>&1)"; then
-    msg="quick_check n'a pas pu s'exécuter : ${check_output}"
-    log "$msg"
-    rollback_db || true
-    start_container_if_stopped || true
-    notify_failure "$msg DB restaurée depuis le backup sain le plus récent."
-    exit 4
-fi
-if [[ "$check_output" != "ok" ]]; then
-    msg="quick_check KO : ${check_output}"
-    log "$msg"
-    rollback_db || true
-    start_container_if_stopped || true
+if ! quick_check_ok "$NAVIDROME_DB_PATH"; then
+    msg="quick_check KO après sync."
+    log "$msg"; rollback_db || true; nd_start_if_stopped || true
     notify_failure "$msg DB restaurée depuis le backup sain le plus récent."
     exit 4
 fi
 log "quick_check OK."
 
-# === 5. Restart conteneur ===================================================
-
-log "Start ${COMPOSE_SERVICE}…"
-if ! docker compose -f "$COMPOSE_FILE" start "$COMPOSE_SERVICE" >/dev/null; then
+if ! nd_start_if_stopped; then
     msg="Sync OK mais impossible de redémarrer ${COMPOSE_SERVICE}."
-    log "$msg"
-    notify_failure "$msg"
-    exit 5
+    log "$msg"; notify_failure "$msg"; exit 5
 fi
-STOPPED=0
 
-# === 6. Purge des backups vieux =============================================
-
-log "Purge des backups > ${BACKUP_RETENTION_DAYS} j dans $BACKUP_DIR…"
-find "$BACKUP_DIR" \
-    -maxdepth 1 -type f \
-    \( -name 'navidrome-*.db' -o -name 'navidrome-*.db-wal' -o -name 'navidrome-*.db-shm' \) \
-    -mtime +"${BACKUP_RETENTION_DAYS}" \
-    -delete
-
+purge_old_backups
 log "Sync terminée avec succès."
 exit 0


### PR DESCRIPTION
## Objectif

Séparer les opérations en wrappers cron **indépendants** : un pour le **backup seul**, un pour le **rematch seul**, et la **sync sans rematch**.

## Changements

Boilerplate commun factorisé dans **`scripts/navidrome-lib.sh.example`** (config + `nd_stop`/`nd_start`, `take_backup`, `quick_check_ok`, `latest_sound_backup`, `rollback_db`, `on_command_failure`, `purge_old_backups`, trap de sécurité). Puis trois points d'entrée fins qui la sourcent :

- **`navidrome-backup.sh.example`** — snapshot seul + garde d'intégrité : stop → `quick_check` → backup (si saine) → start → purge. Si la DB live est déjà corrompue, restaure le backup sain le plus récent.
- **`navidrome-rematch.sh.example`** — rematch seul (peut être long ; bénéficie de la résilience Last.fm #238 + des checkpoints #237). Cible `navidrome` (défaut) ou `strawberry` via `REMATCH_TARGET`.
- **`navidrome-sync.sh.example`** — réécrit : sync **scrobbles + loves uniquement**, le rematch n'y est **plus** (il a son script).

Politique commune : rollback **seulement** si `quick_check` détecte une vraie corruption, vers le **backup sain le plus récent** (backups du wrapper **+** checkpoints de l'app).

## Vérification

- `bash -n` OK sur les 4 fichiers.
- Logique de sélection `latest_sound_backup` validée sur des fichiers réels : prend le plus récent non-corrompu, ignore les siblings `-wal`/`-shm`, considère les deux emplacements.
- `sqlite3` requis à l'exécution (vérifié par `nd_preflight`).

## Déploiement (ta copie)

Recopier les 4 fichiers sans `.example` (lib + 3 entrées) dans le même dossier, éditer la config en tête de `navidrome-lib.sh`, puis cronner séparément (ex. sync quotidienne, rematch hebdo, backup avant tout). README mis à jour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_