### PR TITLE
feat(scrobbles): requeue-unmatched + rematch ne reset plus + wrapper playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,14 +139,20 @@ Points d'attention (prod) :
   (config + helpers). La notif Gotify est lue depuis le `.env` du projet (pas de
   secret dans les scripts) ; les chemins hôte se règlent en tête de la lib.
   Entrées indépendantes :
-  - `navidrome-sync.sh` — sync scrobbles + loves ;
+  - `navidrome-sync.sh` — cycle de maintenance complet (loves, fetch, alias,
+    stats, playlists, reco, purge) — SAUF rematch et sync des scrobbles ;
+  - `navidrome-unmatched-requeue.sh` — re-queue les non-matchés (reset → pending
+    + purge des négatifs du cache) SANS traitement ; DB outils uniquement, donc
+    pas d'arrêt du conteneur ni de backup ;
   - `navidrome-rematch.sh` — rematch par lots (traite ≤ `REMATCH_LIMIT`, défaut
     5000, morceaux en attente, sans re-queue) ;
-  - `navidrome-rematch-full.sh` — rematch complet (re-queue TOUS les non-matchés) ;
+  - `navidrome-rematch-full.sh` — rematch complet (re-queue TOUS les non-matchés
+    puis cascade sur l'ensemble) ;
   - `navidrome-backup.sh` — snapshot + garde d'intégrité.
 
-  Chacune arrête le conteneur, sauvegarde, et ne rollback que sur corruption
-  réelle (vers le backup sain le plus récent, checkpoints de l'app inclus).
+  Les scripts qui écrivent dans Navidrome arrêtent le conteneur, sauvegardent, et
+  ne rollback que sur corruption réelle (vers le backup sain le plus récent,
+  checkpoints de l'app inclus).
 
 ---
 
@@ -285,15 +291,27 @@ arrêté).
 | `--force` | outrepasse le pré-vol conteneur Navidrome |
 | `--auto-stop` | arrête puis redémarre automatiquement le conteneur Navidrome |
 
-#### `app:scrobbles:rematch`
-Re-tente le matching des scrobbles **non-matchés** (remet `unmatched` → `pending`
-puis relance le sync). Utile après ajout de pistes, création d'alias, ou
-amélioration des heuristiques.
+#### `app:scrobbles:requeue-unmatched`
+Re-queue les scrobbles **non-matchés** : remet `unmatched` → `pending` et purge
+les négatifs du cache de matching (cible `navidrome`), **sans lancer la
+cascade**. Ne touche QUE la DB outils (`scrobble_sync` + `lastfm_match_cache`),
+jamais navidrome.db → aucun arrêt de conteneur ni backup. À lancer après ajout
+de pistes / création d'alias, puis laisser `rematch` (ou `sync-navidrome`)
+traiter le backlog.
 
 | Option | Description |
 |---|---|
 | `--target` / `-t` | `navidrome` (défaut) ou `strawberry` |
-| `--dry-run` | reset + match sans écrire |
+
+#### `app:scrobbles:rematch`
+Re-joue la cascade de matching sur les scrobbles **déjà en attente** (`pending`).
+**Ne reset plus** les non-matchés (c'est le rôle de `requeue-unmatched`) :
+non destructif, relançable sans risque, éventuellement par lots via `--limit`.
+
+| Option | Description |
+|---|---|
+| `--target` / `-t` | `navidrome` (défaut) ou `strawberry` |
+| `--dry-run` | matche sans écrire |
 | `--limit` | nombre max de lignes (`0` = illimité) |
 | `--force` | outrepasse le pré-vol conteneur Navidrome |
 | `--auto-stop` | arrête/redémarre Navidrome automatiquement |
@@ -303,8 +321,8 @@ amélioration des heuristiques.
 les scrobbles non-matchés. Lit Navidrome en lecture seule, n'écrit que les
 tables d'alias (`lastfm_alias` / `lastfm_artist_alias`) et purge le cache de
 matching concerné. **Idempotente.** Écarte les couples qu'un simple rematch
-résoudrait déjà (statut périmé). Lancer `app:scrobbles:rematch` ensuite pour
-appliquer.
+résoudrait déjà (statut périmé). Lancer `app:scrobbles:requeue-unmatched` puis
+`app:scrobbles:rematch` ensuite pour appliquer.
 
 Stratégies (chaque alias par la première qui aboutit) :
 
@@ -347,7 +365,8 @@ Stratégie :
 
 Throttle obligatoire (MB exige ≈ 1 req/s par UA) ; UA contact-bearing
 **requis** dans `MUSICBRAINZ_USER_AGENT` (cf. section *MusicBrainz* plus haut).
-Lancer `app:scrobbles:rematch` ensuite pour appliquer les alias créés.
+Lancer `app:scrobbles:requeue-unmatched` puis `app:scrobbles:rematch` ensuite
+pour appliquer les alias créés.
 
 | Option | Description |
 |---|---|
@@ -435,7 +454,9 @@ php bin/console app:aliases:musicbrainz               # applique les unique-matc
 # 3. Matcher + insérer dans Navidrome (Navidrome arrêté, ou --auto-stop)
 php bin/console app:scrobbles:sync-navidrome --auto-stop
 
-# 4. Re-tenter les non-matchés (après ajout de pistes / alias)
+# 4. Re-tenter les non-matchés (après ajout de pistes / alias) :
+#    requeue-unmatched les remet en attente, rematch les traite.
+php bin/console app:scrobbles:requeue-unmatched --target navidrome
 php bin/console app:scrobbles:rematch --target navidrome --auto-stop
 
 # 5. Synchroniser les favoris
@@ -443,10 +464,11 @@ php bin/console app:loves:lastfm-to-navidrome --auto-stop
 ```
 
 Ordre recommandé pour les alias : **`app:aliases:generate` →
-`app:aliases:musicbrainz` → `app:scrobbles:rematch`** (les deux générateurs
-n'écrivent pas dans Navidrome — l'offline d'abord puisqu'il ne coûte rien et
-épuise les cas faciles, l'online ensuite pour ce qui reste ; le rematch
-applique les alias et insère les écoutes nouvellement résolues).
+`app:aliases:musicbrainz` → `app:scrobbles:requeue-unmatched` →
+`app:scrobbles:rematch`** (les deux générateurs n'écrivent pas dans Navidrome —
+l'offline d'abord puisqu'il ne coûte rien et épuise les cas faciles, l'online
+ensuite pour ce qui reste ; `requeue-unmatched` remet les non-matchés en attente,
+puis le rematch applique les alias et insère les écoutes nouvellement résolues).
 
 ### Note sur le compteur de lecture Navidrome
 

--- a/scripts/navidrome-rematch-full.sh
+++ b/scripts/navidrome-rematch-full.sh
@@ -2,14 +2,16 @@
 # -----------------------------------------------------------------------------
 # navidrome-rematch-full.sh — REMATCH COMPLET.
 #
-# Re-queue TOUS les non-matchés (reset unmatched → pending + purge des négatifs
-# du cache) puis relance la cascade sur l'ensemble. Lourd : à cronner rarement
-# (ex. après avoir ajouté des morceaux / créé des alias, ou déployé un matcher
-# amélioré). Pour éplucher le backlog par lots ensuite, voir navidrome-rematch.sh.
+# Re-queue TOUS les non-matchés (requeue-unmatched : reset unmatched → pending +
+# purge des négatifs du cache) puis relance la cascade sur l'ensemble (rematch,
+# qui ne reset plus de lui-même). Lourd : à cronner rarement (ex. après avoir
+# ajouté des morceaux / créé des alias, ou déployé un matcher amélioré). Pour
+# éplucher le backlog par lots ensuite, voir navidrome-rematch.sh.
 #
-# Flow : stop → backup baseline → app:scrobbles:rematch → quick_check → start →
-#        purge. Résilient aux erreurs Last.fm transitoires ; checkpoints
-#        intermédiaires côté app pendant le run.
+# Flow : stop → backup baseline → app:scrobbles:requeue-unmatched →
+#        app:scrobbles:rematch → quick_check → start → purge. Résilient aux
+#        erreurs Last.fm transitoires ; checkpoints intermédiaires côté app
+#        pendant le run.
 #
 # Codes de sortie : 0 OK · 1 config · 2 stop KO · 3 commande KO (DB intègre →
 #                   conservé ; sinon rollback) · 4 quick_check KO · 5 start KO.
@@ -30,7 +32,13 @@ nd_register_trap
 nd_stop
 take_backup   # baseline ; l'app prend aussi des checkpoints pendant le run
 
-log "Rematch complet ${REMATCH_TARGET} (re-queue de tous les non-matchés)…"
+log "Re-queue de tous les non-matchés (${REMATCH_TARGET})…"
+# DB outils uniquement (reset → pending + purge du cache) : sûr conteneur arrêté.
+if ! "${PHP_BIN[@]}" bin/console app:scrobbles:requeue-unmatched --target "$REMATCH_TARGET" --no-interaction; then
+    on_command_failure "Échec du re-queue des non-matchés ${REMATCH_TARGET}."
+fi
+
+log "Rematch complet ${REMATCH_TARGET} (cascade sur l'ensemble)…"
 # Pas de --auto-stop (conteneur déjà arrêté). Ajouter --force si l'app ne peut
 # pas vérifier l'état du conteneur (socket Docker indisponible côté outils).
 if ! "${PHP_BIN[@]}" bin/console app:scrobbles:rematch --target "$REMATCH_TARGET" --no-interaction; then

--- a/scripts/navidrome-unmatched-requeue.sh
+++ b/scripts/navidrome-unmatched-requeue.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-unmatched-requeue.sh — RE-QUEUE des non-matchés (sans traitement).
+#
+# Remet les non-matchés en attente (reset → pending + purge des négatifs du
+# cache), SANS lancer la cascade. Le prochain navidrome-rematch.sh (par lots)
+# les traitera. N'écrit QUE la DB outils → pas d'arrêt du conteneur Navidrome
+# ni de backup.
+#
+# Usage type : le lancer après avoir ajouté des morceaux / créé des alias, puis
+# laisser navidrome-rematch.sh éplucher le backlog run après run.
+#
+# Codes de sortie : 0 OK · 1 config · 3 commande KO.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-unmatched-requeue"
+
+# Cible : navidrome (défaut) ou strawberry.
+: "${REQUEUE_TARGET:=navidrome}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    log "docker absent du PATH."; exit 1
+fi
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    log "COMPOSE_FILE introuvable : $COMPOSE_FILE"; exit 1
+fi
+cd "$PROJECT_DIR"
+
+log "Re-queue des non-matchés (${REQUEUE_TARGET})…"
+if ! "${PHP_BIN[@]}" bin/console app:scrobbles:requeue-unmatched --target "$REQUEUE_TARGET" --no-interaction; then
+    msg="Échec du re-queue des non-matchés (${REQUEUE_TARGET})."
+    log "$msg"; notify_failure "$msg"; exit 3
+fi
+
+log "Re-queue terminé."
+exit 0

--- a/src/Command/GenerateAliasesCommand.php
+++ b/src/Command/GenerateAliasesCommand.php
@@ -20,8 +20,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * per-strategy rules.
  *
  * Reads Navidrome read-only (no need to stop the container); writes only the
- * tools DB (alias + match-cache tables). Run `app:scrobbles:rematch` afterwards
- * to actually re-resolve the unmatched scrobbles through the new aliases.
+ * tools DB (alias + match-cache tables). Run `app:scrobbles:requeue-unmatched`
+ * then `app:scrobbles:rematch` afterwards to actually re-resolve the unmatched
+ * scrobbles through the new aliases.
  */
 #[AsCommand(
     name: 'app:aliases:generate',
@@ -134,7 +135,7 @@ class GenerateAliasesCommand extends Command
             $report->artistAliasesCreated,
             $report->trackAliasesCreated(),
             $report->playsCoveredArtist + $report->playsCoveredTrack,
-            $report->dryRun ? ' Re-run without --dry-run to persist.' : ' Run app:scrobbles:rematch to apply them.',
+            $report->dryRun ? ' Re-run without --dry-run to persist.' : ' Run app:scrobbles:requeue-unmatched then app:scrobbles:rematch to apply them.',
         ));
 
         return Command::SUCCESS;

--- a/src/Command/RematchCommand.php
+++ b/src/Command/RematchCommand.php
@@ -8,8 +8,6 @@ use App\Entity\RunHistory;
 use App\Entity\ScrobbleSync;
 use App\Navidrome\NavidromeSyncReport;
 use App\Navidrome\NavidromeSyncService;
-use App\Repository\LastFmMatchCacheRepository;
-use App\Repository\ScrobbleSyncRepository;
 use App\Service\RunHistoryRecorder;
 use App\Strawberry\StrawberrySyncReport;
 use App\Strawberry\StrawberrySyncService;
@@ -21,10 +19,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Re-attempt matching for unmatched scrobbles of a given target.
- * Resets unmatched → pending then runs the sync service.
- * Useful after adding tracks to the library, creating aliases, or
- * deploying improved matching heuristics.
+ * Re-attempt matching for the scrobbles left PENDING of a given target.
+ *
+ * Ne (re-)remet PLUS les non-matchés en attente : c'est désormais le rôle de
+ * `app:scrobbles:requeue-unmatched` (reset unmatched → pending + purge des
+ * négatifs du cache). Cette commande ne fait que RE-JOUER la cascade sur les
+ * lignes déjà en attente — non destructive, relançable sans risque.
+ *
+ * Flux type : `app:scrobbles:requeue-unmatched` (une fois, après avoir ajouté
+ * des morceaux / créé des alias / déployé un matcher amélioré) puis `rematch`
+ * (autant de fois que nécessaire, éventuellement par lots via --limit).
  */
 #[AsCommand(
     name: 'app:scrobbles:rematch',
@@ -33,12 +37,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class RematchCommand extends Command
 {
     public function __construct(
-        private readonly ScrobbleSyncRepository $syncRepo,
         private readonly NavidromeSyncService $navidromeSync,
         private readonly StrawberrySyncService $strawberrySync,
         private readonly RunHistoryRecorder $recorder,
         private readonly NavidromeContainerManager $container,
-        private readonly LastFmMatchCacheRepository $matchCache,
     ) {
         parent::__construct();
     }
@@ -47,7 +49,7 @@ class RematchCommand extends Command
     {
         $this
             ->addOption('target', 't', InputOption::VALUE_REQUIRED, 'Target: navidrome or strawberry.', 'navidrome')
-            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Reset and match without writing.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Match pending rows without writing.')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Max rows to process (0 = no limit).', '0')
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Bypass Navidrome container pre-flight.')
             ->addOption('auto-stop', null, InputOption::VALUE_NONE, 'Auto-stop Navidrome (only relevant for navidrome target).');
@@ -88,15 +90,10 @@ class RematchCommand extends Command
                 reference: 'unmatched',
                 label: $label,
                 action: function (RunHistory $entry) use ($target, $limit, $dryRun): NavidromeSyncReport|StrawberrySyncReport {
-                    // Bust the Last.fm match-cache negatives for the couples
-                    // we're about to retry — otherwise the matcher hits its
-                    // own fresh negative entries (TTL 30d) and the rematch is
-                    // a no-op. Positives are preserved. Mirrors
-                    // RematchMessageHandler (the web/async path).
-                    if ($target === ScrobbleSync::TARGET_NAVIDROME) {
-                        $this->matchCache->purgeUnmatchedNegatives($target);
-                    }
-                    $this->syncRepo->resetUnmatchedToPending($target);
+                    // Ne reset PLUS les non-matchés ni ne purge le cache : on
+                    // ne fait que ré-jouer la cascade sur les lignes déjà en
+                    // attente. Pour re-queuer les non-matchés,
+                    // `app:scrobbles:requeue-unmatched`.
                     if ($target === ScrobbleSync::TARGET_NAVIDROME) {
                         return $this->navidromeSync->process(limit: $limit, dryRun: $dryRun, run: $entry);
                     }

--- a/src/Command/RequeueUnmatchedCommand.php
+++ b/src/Command/RequeueUnmatchedCommand.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\RunHistory;
+use App\Entity\ScrobbleSync;
+use App\Repository\LastFmMatchCacheRepository;
+use App\Repository\ScrobbleSyncRepository;
+use App\Service\RunHistoryRecorder;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Re-queue les scrobbles non-matchés : reset unmatched → pending (+ purge des
+ * négatifs du cache de matching pour la cible navidrome), SANS lancer la
+ * cascade. Un `app:scrobbles:sync-navidrome` / `rematch` ultérieur traitera
+ * ensuite les lignes remises en attente, par lots.
+ *
+ * Bon marché et sûr : ne touche QUE la DB outils (scrobble_sync +
+ * lastfm_match_cache), jamais la DB Navidrome — donc aucun arrêt de conteneur
+ * ni backup nécessaire.
+ */
+#[AsCommand(
+    name: 'app:scrobbles:requeue-unmatched',
+    description: 'Re-queue (reset → pending) les scrobbles non-matchés, sans les traiter.',
+)]
+class RequeueUnmatchedCommand extends Command
+{
+    public function __construct(
+        private readonly ScrobbleSyncRepository $syncRepo,
+        private readonly LastFmMatchCacheRepository $matchCache,
+        private readonly RunHistoryRecorder $recorder,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption('target', 't', InputOption::VALUE_REQUIRED, 'Target: navidrome or strawberry.', 'navidrome');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $target = (string) $input->getOption('target');
+
+        if (!in_array($target, [ScrobbleSync::TARGET_NAVIDROME, ScrobbleSync::TARGET_STRAWBERRY], true)) {
+            $io->error(sprintf('Invalid target "%s". Use "navidrome" or "strawberry".', $target));
+            return Command::INVALID;
+        }
+
+        $type = $target === ScrobbleSync::TARGET_NAVIDROME
+            ? RunHistory::TYPE_NAVIDROME_REQUEUE
+            : RunHistory::TYPE_STRAWBERRY_REQUEUE;
+
+        try {
+            $requeued = $this->recorder->record(
+                type: $type,
+                reference: 'unmatched',
+                label: sprintf('%s re-queue non-matchés', $target),
+                action: function () use ($target): int {
+                    // Purge des négatifs du cache de matching (navidrome
+                    // uniquement — Strawberry n'a pas ce cache) pour que les
+                    // lignes soient réellement ré-évaluées au prochain traitement.
+                    if ($target === ScrobbleSync::TARGET_NAVIDROME) {
+                        $this->matchCache->purgeUnmatchedNegatives($target);
+                    }
+
+                    return $this->syncRepo->resetUnmatchedToPending($target);
+                },
+                extractMetrics: static fn (int $n): array => ['requeued' => $n],
+            );
+        } catch (\Throwable $e) {
+            $io->error($e->getMessage());
+            return Command::FAILURE;
+        }
+
+        $io->success(sprintf('%s : %d non-matché(s) remis en attente (pending).', ucfirst($target), $requeued));
+
+        return Command::SUCCESS;
+    }
+}

--- a/src/Command/SuggestAliasesMusicBrainzCommand.php
+++ b/src/Command/SuggestAliasesMusicBrainzCommand.php
@@ -28,8 +28,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * everything without writing.
  *
  * Reads Navidrome read-only (no need to stop the container); writes only the
- * tools DB. Run `app:scrobbles:rematch` afterwards to re-resolve the
- * unmatched scrobbles through the new aliases.
+ * tools DB. Run `app:scrobbles:requeue-unmatched` then `app:scrobbles:rematch`
+ * afterwards to re-resolve the unmatched scrobbles through the new aliases.
  */
 #[AsCommand(
     name: 'app:aliases:musicbrainz',
@@ -168,7 +168,7 @@ class SuggestAliasesMusicBrainzCommand extends Command
             ucfirst($verb),
             $report->aliasesCreated,
             $report->playsCovered,
-            $report->dryRun ? ' Re-run without --dry-run to persist.' : ' Run app:scrobbles:rematch to apply them.',
+            $report->dryRun ? ' Re-run without --dry-run to persist.' : ' Run app:scrobbles:requeue-unmatched then app:scrobbles:rematch to apply them.',
         ));
     }
 }

--- a/src/Entity/RunHistory.php
+++ b/src/Entity/RunHistory.php
@@ -19,6 +19,8 @@ class RunHistory
     public const TYPE_LOVES_NAVIDROME_TO_LASTFM = 'loves-navidrome-to-lastfm';
     public const TYPE_NAVIDROME_SYNC = 'navidrome-sync';
     public const TYPE_NAVIDROME_REMATCH = 'navidrome-rematch';
+    public const TYPE_NAVIDROME_REQUEUE = 'navidrome-requeue';
+    public const TYPE_STRAWBERRY_REQUEUE = 'strawberry-requeue';
     public const TYPE_NAVIDROME_ALIAS_MUSICBRAINZ = 'navidrome-alias-musicbrainz';
     public const TYPE_NAVIDROME_WIPE = 'navidrome-wipe';
     public const TYPE_STRAWBERRY_SYNC = 'strawberry-sync';


### PR DESCRIPTION
## Contexte

Suite à l'ajout du script `navidrome-unmatched-requeue`, on sépare proprement le
**re-queue** des non-matchés du **traitement** — et, comme demandé, la commande
`app:scrobbles:rematch` ne reset plus les non-matchés d'elle-même. Ajout aussi
d'un wrapper de génération des playlists pour le crontab.

## Changements

- **`app:scrobbles:requeue-unmatched` (nouvelle commande)** : remet `unmatched`
  → `pending` et purge les négatifs du cache de matching (cible `navidrome`),
  **sans lancer la cascade**. Ne touche QUE la DB outils (`scrobble_sync` +
  `lastfm_match_cache`), jamais `navidrome.db` → aucun arrêt de conteneur ni
  backup.
- **`app:scrobbles:rematch`** : **ne reset/purge plus** — ne fait que ré-jouer
  la cascade sur les lignes déjà en attente (`pending`). Non destructif,
  relançable, éventuellement par lots via `--limit`. Dépendances
  `ScrobbleSyncRepository` / `LastFmMatchCacheRepository` retirées du
  constructeur (devenues inutiles).
- **`scripts/navidrome-unmatched-requeue.sh`** : wrapper cron du requeue (DB
  outils uniquement, pas de stop conteneur).
- **`scripts/navidrome-rematch-full.sh`** : enchaîne désormais
  `requeue-unmatched` puis `rematch` pour conserver son rôle « re-queue tous +
  cascade sur l'ensemble ».
- **`scripts/navidrome-playlists.sh` (nouveau)** : wrapper de
  `app:playlists:generate --all` (écriture via l'API Subsonic → conteneur
  Navidrome **démarré** requis, n'arrête rien). À cronner après le rematch de la
  nuit pour refléter les écoutes fraîchement insérées.
- **RunHistory** : nouveaux types `navidrome-requeue` / `strawberry-requeue`.
- **Docs** : README (liste commandes/scripts, workflow alias) et messages des
  commandes `aliases:generate` / `aliases:musicbrainz` pointent maintenant vers
  `requeue-unmatched` **puis** `rematch`.

Le bouton web **« Rematcher tous »** (`RematchMessageHandler`) est laissé tel
quel : il reste le one-click « requeue + traitement ».

## Vérification

- `composer ci` (lint-twig · phpcs · phpstan · phpunit) OK — 294 tests,
  PHPStan au baseline (11 erreurs connues), 32 templates Twig parsés.
- `bash -n` OK sur les scripts modifiés/ajoutés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)