### PR TITLE
feat: wrapper playlists + rematch affiche avancement & matchs (-v)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ Points d'attention (prod) :
     5000, morceaux en attente, sans re-queue) ;
   - `navidrome-rematch-full.sh` — rematch complet (re-queue TOUS les non-matchés
     puis cascade sur l'ensemble) ;
+  - `navidrome-playlists.sh` — (re)génère les playlists via l'API Subsonic
+    (conteneur DÉMARRÉ requis, n'arrête rien) ; à lancer après le rematch pour
+    refléter les écoutes fraîchement insérées ;
   - `navidrome-backup.sh` — snapshot + garde d'intégrité.
 
   Les scripts qui écrivent dans Navidrome arrêtent le conteneur, sauvegardent, et

--- a/scripts/navidrome-playlists.sh
+++ b/scripts/navidrome-playlists.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-playlists.sh — (RE)GÉNÈRE les playlists.
+#
+# Recalcule et pousse toutes les playlists gérées via l'API Subsonic
+# (app:playlists:generate --all). Le conteneur Navidrome doit être DÉMARRÉ
+# (écriture via l'API HTTP, pas d'accès direct à la DB) → n'arrête rien et ne
+# backup rien.
+#
+# À cronner APRÈS le dernier rematch de la nuit (avec `flock -w` sur le même
+# verrou) pour que les playlists reflètent les écoutes fraîchement insérées.
+#
+# Codes de sortie : 0 OK · 1 config · 3 commande KO.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-playlists"
+
+if ! command -v docker >/dev/null 2>&1; then
+    log "docker absent du PATH."; exit 1
+fi
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    log "COMPOSE_FILE introuvable : $COMPOSE_FILE"; exit 1
+fi
+cd "$PROJECT_DIR"
+
+log "Génération des playlists…"
+if ! "${PHP_BIN[@]}" bin/console app:playlists:generate --all --no-interaction; then
+    msg="Échec de la génération des playlists (conteneur Navidrome démarré ?)."
+    log "$msg"; notify_failure "$msg"; exit 3
+fi
+
+log "Playlists générées."
+exit 0

--- a/src/Command/RematchCommand.php
+++ b/src/Command/RematchCommand.php
@@ -29,6 +29,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Flux type : `app:scrobbles:requeue-unmatched` (une fois, après avoir ajouté
  * des morceaux / créé des alias / déployé un matcher amélioré) puis `rematch`
  * (autant de fois que nécessaire, éventuellement par lots via --limit).
+ *
+ * Affiche l'avancement (compteurs) tous les 50 scrobbles ; en mode verbeux
+ * (-v), liste en plus chaque match résolu (✓ matched / ≈ doublon + stratégie).
  */
 #[AsCommand(
     name: 'app:scrobbles:rematch',
@@ -84,19 +87,38 @@ class RematchCommand extends Command
             ? RunHistory::TYPE_NAVIDROME_REMATCH
             : RunHistory::TYPE_STRAWBERRY_REMATCH;
 
+        // Avancement (compteurs) affiché tous les 50 scrobbles — toujours visible.
+        $progress = function (int $c, int $m, int $d, int $u) use ($io): void {
+            $io->writeln(sprintf('  considered=%d matched=%d duplicates=%d unmatched=%d', $c, $m, $d, $u));
+        };
+        // Détail des matchs résolus au fil de l'eau — visible seulement en mode
+        // verbeux (-v) pour ne pas noyer les logs cron lors des gros rematch.
+        $onMatch = function (ScrobbleSync $sync, string $status, ?string $strategy) use ($io): void {
+            $scrobble = $sync->getScrobble();
+            $io->writeln(sprintf(
+                '  %s %s — %s%s',
+                $status === ScrobbleSync::STATUS_DUPLICATE ? '≈' : '✓',
+                $scrobble->getArtist(),
+                $scrobble->getTitle(),
+                $strategy !== null ? sprintf('  [%s]', $strategy) : '',
+            ), OutputInterface::VERBOSITY_VERBOSE);
+        };
+
         try {
             $runProcess = fn () => $this->recorder->record(
                 type: $type,
                 reference: 'unmatched',
                 label: $label,
-                action: function (RunHistory $entry) use ($target, $limit, $dryRun): NavidromeSyncReport|StrawberrySyncReport {
+                action: function (RunHistory $entry) use ($target, $limit, $dryRun, $progress, $onMatch): NavidromeSyncReport|StrawberrySyncReport {
                     // Ne reset PLUS les non-matchés ni ne purge le cache : on
                     // ne fait que ré-jouer la cascade sur les lignes déjà en
                     // attente. Pour re-queuer les non-matchés,
                     // `app:scrobbles:requeue-unmatched`.
                     if ($target === ScrobbleSync::TARGET_NAVIDROME) {
-                        return $this->navidromeSync->process(limit: $limit, dryRun: $dryRun, run: $entry);
+                        return $this->navidromeSync->process(limit: $limit, dryRun: $dryRun, run: $entry, progress: $progress, onMatch: $onMatch);
                     }
+                    // Strawberry : progression à 3 compteurs (sans doublons),
+                    // signature différente — pas d'affichage détaillé ici.
                     return $this->strawberrySync->process(limit: $limit, dryRun: $dryRun, run: $entry);
                 },
                 extractMetrics: static function (NavidromeSyncReport|StrawberrySyncReport $r): array {

--- a/src/Navidrome/NavidromeSyncService.php
+++ b/src/Navidrome/NavidromeSyncService.php
@@ -53,6 +53,7 @@ class NavidromeSyncService
         int $toleranceSeconds = 60,
         ?RunHistory $run = null,
         ?callable $progress = null,
+        ?callable $onMatch = null,
     ): NavidromeSyncReport {
         if (!$this->navidrome->hasScrobblesTable()) {
             throw new \RuntimeException('Navidrome scrobbles table not found. Upgrade Navidrome to >= 0.55.');
@@ -111,6 +112,13 @@ class NavidromeSyncService
                     $dryRun,
                     $report,
                 );
+
+                // Signale les matchs résolus (matched / doublon) au fil de l'eau,
+                // pour un affichage détaillé côté commande. Les non-matchés et
+                // ignorés ne sont pas remontés ici.
+                if ($onMatch !== null && ($status === ScrobbleSync::STATUS_MATCHED || $status === ScrobbleSync::STATUS_DUPLICATE)) {
+                    $onMatch($sync, $status, $strategy);
+                }
 
                 if (!$dryRun) {
                     $batch[] = [


### PR DESCRIPTION
Deux petites améliorations outillage (empilées faute de pouvoir ouvrir 2 PR sur
la même branche tant que la première n'est pas mergée).

## 1. `scripts/navidrome-playlists.sh` (nouveau)

Créneau cron dédié à `app:playlists:generate --all`. Écrit via l'**API Subsonic**
→ conteneur Navidrome **démarré** requis, donc pas de stop ni de backup. À
cronner après le dernier rematch de la nuit (`flock -w` sur le verrou partagé)
pour que les playlists reflètent les écoutes fraîchement insérées.

## 2. `app:scrobbles:rematch` — affichage pendant l'exécution

La commande n'affichait rien avant la fin. Désormais :

- **Avancement** (toujours) : compteurs `considered/matched/duplicates/unmatched`
  tous les 50 scrobbles, comme `sync-navidrome`.
- **Détail des matchs** (mode verbeux `-v`) : chaque match résolu listé au fil de
  l'eau — `✓` matched / `≈` doublon, avec la stratégie. Gardé hors du mode normal
  pour ne pas noyer les logs cron sur les gros rematch.

`NavidromeSyncService::process()` gagne un hook `onMatch` optionnel (appelé pour
chaque ligne matchée/doublon). Le chemin Strawberry est inchangé.

## Vérification

- `composer ci` OK — 294 tests, PHPStan au baseline (11 erreurs connues), 32
  templates Twig, phpcs clean.
- `bash -n scripts/navidrome-playlists.sh` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)