### PR TITLE
feat(scripts): navidrome-stats.sh — recalcul des stats sans arrêt (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 <!-- Ajouter ici les changements de la prochaine version, sous Ajouté / Modifié / Corrigé / Supprimé. -->
 
+## [1.1.0] - 2026-07-01
+
+### Ajouté
+
+- **`scripts/navidrome-stats.sh`** — wrapper cron dédié au recalcul des stats
+  (`app:stats:compute`, `app:lastfm:stats:compute`, `app:navidrome:stats:compute`).
+  Lecture seule, n'arrête pas Navidrome et ne fait pas de backup → cronnable
+  fréquemment, y compris en journée. Best-effort (un échec n'interrompt pas les
+  autres).
+
 ## [1.0.0] - 2026-07-01
 
 Première version taguée de la réécriture v2 (Symfony 7 / PHP 8.4 / FrankenPHP).
@@ -57,5 +67,6 @@ L'ancienne POC reste accessible via le tag `poc-v0`.
   `BackupService`, sessions persistantes ; CI (phpcs, PHPStan, PHPUnit, lint
   Twig, build Docker).
 
-[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.0.0...HEAD
+[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.1.0...HEAD
+[1.1.0]: https://github.com/kgaut/navidrome-tools/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/kgaut/navidrome-tools/releases/tag/1.0.0

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ Points d'attention (prod) :
   - `navidrome-playlists.sh` — (re)génère les playlists via l'API Subsonic
     (conteneur DÉMARRÉ requis, n'arrête rien) ; à lancer après le rematch pour
     refléter les écoutes fraîchement insérées ;
+  - `navidrome-stats.sh` — recalcule et met en cache les stats (locales, Last.fm,
+    Navidrome) ; lecture seule, n'arrête rien → cronnable souvent, même en
+    journée ;
   - `navidrome-backup.sh` — snapshot + garde d'intégrité.
 
   Les scripts qui écrivent dans Navidrome arrêtent le conteneur, sauvegardent, et

--- a/scripts/navidrome-stats.sh
+++ b/scripts/navidrome-stats.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# navidrome-stats.sh — (RE)CALCULE et met en cache toutes les statistiques.
+#
+# Recalcule les trois jeux de stats :
+#   - app:stats:compute          (stats locales, table scrobbles outils)
+#   - app:lastfm:stats:compute   (stats Last.fm)
+#   - app:navidrome:stats:compute (stats lues dans navidrome.db, en lecture seule)
+#
+# Ne lit que des DB (aucune écriture dans navidrome.db) → n'arrête RIEN et ne
+# backup rien. Sûr à cronner fréquemment, y compris en journée pendant l'écoute.
+# Best-effort : une commande en échec n'interrompt pas les autres.
+#
+# Codes de sortie : 0 OK · 1 config · 3 au moins une commande KO.
+# -----------------------------------------------------------------------------
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=navidrome-lib.sh
+source "${SCRIPT_DIR}/navidrome-lib.sh"
+NOTIFY_TITLE="navidrome-stats"
+
+if ! command -v docker >/dev/null 2>&1; then
+    log "docker absent du PATH."; exit 1
+fi
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+    log "COMPOSE_FILE introuvable : $COMPOSE_FILE"; exit 1
+fi
+cd "$PROJECT_DIR"
+
+FAILURES=()
+run_stat() {
+    local label="$1"; shift
+    log "→ ${label}…"
+    "$@" || { log "Échec : ${label}."; FAILURES+=("$label"); }
+}
+
+run_stat "stats locales"   "${PHP_BIN[@]}" bin/console app:stats:compute --no-interaction
+run_stat "stats Last.fm"   "${PHP_BIN[@]}" bin/console app:lastfm:stats:compute --no-interaction
+run_stat "stats Navidrome" "${PHP_BIN[@]}" bin/console app:navidrome:stats:compute --no-interaction
+
+if [[ ${#FAILURES[@]} -gt 0 ]]; then
+    msg="Stats : échec(s) sur ${FAILURES[*]}."
+    log "$msg"; notify_failure "$msg"; exit 3
+fi
+
+log "Stats recalculées."
+exit 0


### PR DESCRIPTION
## Changements

- **`scripts/navidrome-stats.sh` (nouveau)** — wrapper cron dédié au recalcul
  des stats : `app:stats:compute`, `app:lastfm:stats:compute`,
  `app:navidrome:stats:compute`. Lit les DB en **lecture seule** → n'arrête pas
  Navidrome et ne fait pas de backup, donc **cronnable fréquemment, même en
  journée**. Best-effort (un échec n'interrompt pas les autres) ; notif Gotify
  via `.env` en cas d'échec.
- **README** — ajout à la liste des wrappers cron.
- **CHANGELOG** — entrée `1.1.0`.

`sync.sh` ne recalculait qu'un seul des trois jeux de stats
(`app:navidrome:stats:compute`) ; ce wrapper les couvre tous et permet un
rafraîchissement plus fréquent, hors du cycle de maintenance nocturne.

## Vérification

- `bash -n scripts/navidrome-stats.sh` OK ; noms de commandes confirmés dans
  `src/Command/`.
- Docs uniquement côté PHP (aucun code applicatif touché).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_