### PR TITLE
feat(unmatched): bouton « Rematcher » par morceau (debug au cas par cas) (1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 <!-- Ajouter ici les changements de la prochaine version, sous Ajouté / Modifié / Corrigé / Supprimé. -->
 
+## [1.2.0] - 2026-07-01
+
+### Ajouté
+
+- **Bouton « ↻ Rematcher » par morceau sur `/navidrome/unmatched`** — pour
+  déboguer au cas par cas : purge le cache négatif du couple, relance une
+  tentative de matching et affiche le résultat (stratégie + cible sur succès,
+  ou raison du diagnostic sur échec). Sur succès, les scrobbles du couple sont
+  remis en `pending` pour insertion au prochain sync. Lecture seule → n'arrête
+  pas Navidrome. Nouvelle route `app_navidrome_unmatched_retry` +
+  `ScrobbleSyncRepository::resetCoupleToPending()`.
+
 ## [1.1.0] - 2026-07-01
 
 ### Ajouté
@@ -67,6 +79,7 @@ L'ancienne POC reste accessible via le tag `poc-v0`.
   `BackupService`, sessions persistantes ; CI (phpcs, PHPStan, PHPUnit, lint
   Twig, build Docker).
 
-[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.1.0...HEAD
+[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/kgaut/navidrome-tools/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/kgaut/navidrome-tools/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/kgaut/navidrome-tools/releases/tag/1.0.0

--- a/src/Controller/NavidromeSyncController.php
+++ b/src/Controller/NavidromeSyncController.php
@@ -3,9 +3,14 @@
 namespace App\Controller;
 
 use App\Entity\ScrobbleSync;
+use App\LastFm\LastFmScrobble;
+use App\LastFm\MatchResult;
+use App\LastFm\ScrobbleMatcher;
 use App\Message\RematchMessage;
 use App\Message\SuggestAliasesMusicBrainzMessage;
 use App\Message\SyncNavidromeMessage;
+use App\Navidrome\NavidromeRepository;
+use App\Repository\LastFmMatchCacheRepository;
 use App\Repository\ScrobbleSyncRepository;
 use App\Service\DisparityStatsService;
 use App\Service\UnmatchedDiagnoser;
@@ -100,6 +105,81 @@ class NavidromeSyncController extends AbstractController
             . 'Les alias uniques haute-confiance sont appliqués automatiquement ; relancez un rematch ensuite.',
         );
         return $this->redirectToRoute('app_history');
+    }
+
+    /**
+     * Per-track « retry match » (debug case-by-case). Purges the negative
+     * cache for the couple, re-runs the matching cascade once on a synthetic
+     * scrobble built from the aggregated row, then reports the outcome. On a
+     * hit, the couple's unmatched rows are re-queued to pending (the actual
+     * write into navidrome.db happens on the next sync/rematch). On a miss,
+     * the diagnostic reason is surfaced. Reads Navidrome read-only → no
+     * container stop.
+     */
+    #[Route('/navidrome/unmatched/retry', name: 'app_navidrome_unmatched_retry', methods: ['POST'])]
+    public function retryMatch(
+        Request $request,
+        ScrobbleMatcher $matcher,
+        ScrobbleSyncRepository $syncRepo,
+        LastFmMatchCacheRepository $cache,
+        UnmatchedDiagnoser $diagnoser,
+        NavidromeRepository $navidrome,
+    ): Response {
+        if (!$this->isCsrfTokenValid('navidrome_unmatched_retry', (string) $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException();
+        }
+
+        $artist = trim((string) $request->request->get('artist', ''));
+        $title = trim((string) $request->request->get('title', ''));
+        $album = trim((string) $request->request->get('album', ''));
+
+        $back = $request->headers->get('referer') ?: $this->generateUrl('app_navidrome_unmatched');
+
+        if ($artist === '' || $title === '') {
+            $this->addFlash('error', 'Artiste ou titre manquant.');
+            return $this->redirect($back);
+        }
+
+        // Purge the negative cache entry so the cascade actually re-runs
+        // instead of short-circuiting on its own memoized miss.
+        $cache->purgeByCouple($artist, $title);
+
+        $result = $matcher->match(new LastFmScrobble(
+            artist: $artist,
+            title: $title,
+            album: $album,
+            mbid: null,
+            playedAt: new \DateTimeImmutable(),
+        ));
+
+        if ($result->status === MatchResult::STATUS_MATCHED && $result->mediaFileId !== null) {
+            $meta = $navidrome->getMediaFileMetadata([$result->mediaFileId]);
+            $label = $meta !== []
+                ? sprintf('%s — %s', $meta[0]['artist'], $meta[0]['album'] !== '' ? $meta[0]['album'] : '?')
+                : $result->mediaFileId;
+            $reset = $syncRepo->resetCoupleToPending(ScrobbleSync::TARGET_NAVIDROME, $artist, $title);
+            $this->addFlash('success', sprintf(
+                '« %s — %s » matché (stratégie %s → %s). %d scrobble(s) remis en pending : lancez un sync pour les insérer dans Navidrome.',
+                $artist,
+                $title,
+                $result->strategy ?? '?',
+                $label,
+                $reset,
+            ));
+        } else {
+            $diag = $diagnoser->diagnose($artist, $title);
+            $reason = match ($diag['reason'] ?? '') {
+                'artist_unknown' => 'artiste inconnu de la bibliothèque',
+                'artist_near_match' => 'artiste proche (voir suggestions d’alias)',
+                'title_near_match' => 'titre proche (voir suggestions d’alias)',
+                'track_missing' => 'artiste présent mais titre absent de la bibliothèque',
+                'matcher_gap' => 'track présente mais ratée par la cascade',
+                default => 'inconnue',
+            };
+            $this->addFlash('warning', sprintf('« %s — %s » toujours non-matché. Raison : %s.', $artist, $title, $reason));
+        }
+
+        return $this->redirect($back);
     }
 
     #[Route('/navidrome/unmatched', name: 'app_navidrome_unmatched', methods: ['GET'])]

--- a/src/Repository/ScrobbleSyncRepository.php
+++ b/src/Repository/ScrobbleSyncRepository.php
@@ -220,6 +220,29 @@ class ScrobbleSyncRepository extends ServiceEntityRepository
     }
 
     /**
+     * Reset the unmatched rows of a single (artist, title) couple back to
+     * pending — used by the per-track « retry match » button on
+     * /navidrome/unmatched. Exact match on the raw scrobble artist/title
+     * (as displayed in the aggregated list). Returns the number of rows
+     * re-queued.
+     */
+    public function resetCoupleToPending(string $target, string $artist, string $title): int
+    {
+        return (int) $this->em->getConnection()->executeStatement(
+            'UPDATE scrobble_sync SET status = :pending, attempted_at = NULL, synced_at = NULL, run_id = NULL
+             WHERE target = :target AND status = :unmatched
+               AND scrobble_id IN (SELECT id FROM scrobbles WHERE artist = :artist AND title = :title)',
+            [
+                'pending' => ScrobbleSync::STATUS_PENDING,
+                'target' => $target,
+                'unmatched' => ScrobbleSync::STATUS_UNMATCHED,
+                'artist' => $artist,
+                'title' => $title,
+            ],
+        );
+    }
+
+    /**
      * Reset every non-pending row for $target back to pending. Wipes
      * target_id and strategy too so the next sync starts from a clean
      * slate (they will be re-resolved by the matching cascade anyway).

--- a/templates/navidrome/unmatched.html.twig
+++ b/templates/navidrome/unmatched.html.twig
@@ -94,6 +94,14 @@
                     <td class="num">{{ row.count }}</td>
                     <td class="num mono">{{ row.last_played_at|date('d/m/Y') }}</td>
                     <td class="right nowrap">
+                        <form method="post" action="{{ path('app_navidrome_unmatched_retry') }}" class="inline">
+                            <input type="hidden" name="_token" value="{{ csrf_token('navidrome_unmatched_retry') }}">
+                            <input type="hidden" name="artist" value="{{ row.artist }}">
+                            <input type="hidden" name="title" value="{{ row.title }}">
+                            <input type="hidden" name="album" value="{{ row.album ?? '' }}">
+                            <button type="submit" class="mono fs-11 t-teal" style="background:none;border:0;padding:0;cursor:pointer;"
+                                    title="Purger le cache négatif et relancer une tentative de matching sur ce couple">↻ Rematcher</button>
+                        </form>
                         {% if lidarr %}
                             <a href="{{ lidarr }}" target="_blank" rel="noopener" class="mono fs-11 muted" title="Chercher dans Lidarr">⇗ Lidarr</a>
                         {% endif %}


### PR DESCRIPTION
## Contexte

Pour déboguer les non-matchés au cas par cas, chaque ligne de
`/navidrome/unmatched` a désormais un bouton **↻ Rematcher**.

Rappel utile issu de l'analyse du cas « album décoré » (`… ((Bande Originale…))`) :
le fallback **couple** (artiste+titre) utilise `LIMIT 1` avec tie-break
déterministe → il ne renvoie jamais `null` sur ambiguïté. **Une différence
d'album seule ne peut donc pas provoquer un unmatched** ; si un morceau reste
non-matché, c'est l'artiste ou le titre qui diffère. Le bouton + le diagnostic
révèlent le vrai blocage.

## Changements

- **Route `app_navidrome_unmatched_retry`** (`POST /navidrome/unmatched/retry`) :
  purge le cache négatif du couple, relance `ScrobbleMatcher::match()` sur un
  scrobble synthétique (artiste/titre/album de la ligne agrégée), puis :
  - **succès** → flash avec la stratégie + la cible Navidrome, et les scrobbles
    du couple sont remis en `pending` (insertion réelle au prochain sync) ;
  - **échec** → flash avec la raison du diagnostic (`UnmatchedDiagnoser`).
  Lecture seule → **n'arrête pas Navidrome**, pas de backup.
- **`ScrobbleSyncRepository::resetCoupleToPending()`** — reset ciblé d'un couple.
- **Template** — bouton par ligne dans la colonne Actions (form POST + CSRF).
- **CHANGELOG** — entrée `1.2.0`.

## Vérification

- `composer ci` OK — 294 tests, PHPStan baseline (11 connues), phpcs clean, 32
  templates Twig parsés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_