### PR TITLE
feat(playlists): « Pépites redécouvertes » (rejoué après un long silence) (1.3.0)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -116,7 +116,7 @@ HELP_COMPOSE_SERVICE=navidrome-tools-web
 #                     pepites-oubliees, coups-de-coeur, kickstart,
 #                     happy-birthday, hit-parade, top-de-lannee,
 #                     decouvertes-recentes, fideles-compagnons, mix-semaine,
-#                     tres-vieilles-pepites
+#                     tres-vieilles-pepites, pepites-redecouvertes
 # Default track cap (Top du mois / Top all-time / Coups de cœur / Pépites).
 PLAYLIST_DEFAULT_LIMIT=50
 # « Retour en arrière » — max years back, window length (days) ending at
@@ -131,6 +131,12 @@ PLAYLIST_PEPITES_SILENCE_MONTHS=12
 # « Très vieilles pépites » — même logique, mais silence beaucoup plus long
 # (par défaut 60 mois ≈ 5 ans). Réutilise PLAYLIST_PEPITES_MIN_PLAYS.
 PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS=60
+# « Pépites redécouvertes » — morceaux rejoués dans les RECENT_MONTHS derniers
+# mois après un silence de SILENCE_MONTHS, et déjà écoutés avant ce silence
+# (dans la fenêtre WINDOW_MONTHS). En aléatoire.
+PLAYLIST_PEPITES_REDECOUVERTES_WINDOW_MONTHS=24
+PLAYLIST_PEPITES_REDECOUVERTES_SILENCE_MONTHS=12
+PLAYLIST_PEPITES_REDECOUVERTES_RECENT_MONTHS=1
 # « Happy birthday » — jour anniversaire (mois / jour) dont on tire au
 # hasard les morceaux les plus écoutés, toutes années confondues.
 PLAYLIST_BIRTHDAY_MONTH=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ et le projet suit le [versionnage sémantique](https://semver.org/lang/fr/).
 
 <!-- Ajouter ici les changements de la prochaine version, sous Ajouté / Modifié / Corrigé / Supprimé. -->
 
+## [1.3.0] - 2026-07-17
+
+### Ajouté
+
+- **Playlist « Pépites redécouvertes »** — morceaux rejoués dans le dernier mois
+  après ~12 mois de silence, et déjà écoutés avant ce silence (fenêtre de 24
+  mois) : de vraies re-découvertes, en aléatoire. Nouvelle
+  `PepitesRedecouvertesDefinition` +
+  `NavidromeRepository::findRediscoveredGems()` (requête sur l'historique par
+  écoute `scrobbles`). Fenêtres configurables via
+  `PLAYLIST_PEPITES_REDECOUVERTES_{WINDOW,SILENCE,RECENT}_MONTHS`.
+
 ## [1.2.0] - 2026-07-01
 
 ### Ajouté
@@ -79,7 +91,8 @@ L'ancienne POC reste accessible via le tag `poc-v0`.
   `BackupService`, sessions persistantes ; CI (phpcs, PHPStan, PHPUnit, lint
   Twig, build Docker).
 
-[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.2.0...HEAD
+[Non publié]: https://github.com/kgaut/navidrome-tools/compare/1.3.0...HEAD
+[1.3.0]: https://github.com/kgaut/navidrome-tools/compare/1.2.0...1.3.0
 [1.2.0]: https://github.com/kgaut/navidrome-tools/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/kgaut/navidrome-tools/compare/1.0.0...1.1.0
 [1.0.0]: https://github.com/kgaut/navidrome-tools/releases/tag/1.0.0

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -11,6 +11,9 @@ parameters:
     env(PLAYLIST_PEPITES_MIN_PLAYS): '5'
     env(PLAYLIST_PEPITES_SILENCE_MONTHS): '12'
     env(PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS): '60'
+    env(PLAYLIST_PEPITES_REDECOUVERTES_WINDOW_MONTHS): '24'
+    env(PLAYLIST_PEPITES_REDECOUVERTES_SILENCE_MONTHS): '12'
+    env(PLAYLIST_PEPITES_REDECOUVERTES_RECENT_MONTHS): '1'
     # Sync/rematch : intervalle (s) entre deux backups « checkpoint » pendant
     # un run long. 0 = à chaque batch, négatif = désactivé. Défaut 10 min.
     env(NAVIDROME_SYNC_BACKUP_INTERVAL_SECONDS): '600'
@@ -81,6 +84,9 @@ parameters:
     playlist.pepites.min_plays: '%env(int:PLAYLIST_PEPITES_MIN_PLAYS)%'
     playlist.pepites.silence_months: '%env(int:PLAYLIST_PEPITES_SILENCE_MONTHS)%'
     playlist.tres_vieilles_pepites.silence_months: '%env(int:PLAYLIST_TRES_VIEILLES_PEPITES_SILENCE_MONTHS)%'
+    playlist.pepites_redecouvertes.window_months: '%env(int:PLAYLIST_PEPITES_REDECOUVERTES_WINDOW_MONTHS)%'
+    playlist.pepites_redecouvertes.silence_months: '%env(int:PLAYLIST_PEPITES_REDECOUVERTES_SILENCE_MONTHS)%'
+    playlist.pepites_redecouvertes.recent_months: '%env(int:PLAYLIST_PEPITES_REDECOUVERTES_RECENT_MONTHS)%'
     playlist.birthday.month: '%env(int:PLAYLIST_BIRTHDAY_MONTH)%'
     playlist.birthday.day: '%env(int:PLAYLIST_BIRTHDAY_DAY)%'
     playlist.hitparade.weeks: '%env(int:PLAYLIST_HITPARADE_WEEKS)%'
@@ -203,6 +209,13 @@ services:
         arguments:
             $minPlays: '%playlist.pepites.min_plays%'
             $silenceMonths: '%playlist.tres_vieilles_pepites.silence_months%'
+            $limit: '%playlists.default_limit%'
+
+    App\Playlist\Definition\PepitesRedecouvertesDefinition:
+        arguments:
+            $windowMonths: '%playlist.pepites_redecouvertes.window_months%'
+            $silenceMonths: '%playlist.pepites_redecouvertes.silence_months%'
+            $recentMonths: '%playlist.pepites_redecouvertes.recent_months%'
             $limit: '%playlists.default_limit%'
 
     App\Playlist\Definition\MixSemaineDefinition:

--- a/src/Navidrome/NavidromeRepository.php
+++ b/src/Navidrome/NavidromeRepository.php
@@ -555,6 +555,64 @@ class NavidromeRepository
     }
 
     /**
+     * « Pépites redécouvertes » : tracks played again in the last month after
+     * a silence of ~12 months, having been listened to BEFORE that silence
+     * (within the 24-month window) — a genuine re-discovery, not a fresh find.
+     *
+     * Three epoch windows over per-play scrobbles:
+     *   - [recent, now)          : ≥1 play (the rediscovery),
+     *   - [silence, recent)      : 0 play (the ~12-month silence),
+     *   - [window, silence)      : ≥1 play (known before the silence).
+     * Deterministic order (most recent rediscovery first); the shuffle for
+     * serendipity is done caller-side. Requires the scrobbles table (per-play
+     * history) — returns [] on Navidrome < 0.55.
+     *
+     * @return string[] media_file ids
+     */
+    public function findRediscoveredGems(
+        \DateTimeInterface $windowStart,
+        \DateTimeInterface $silenceStart,
+        \DateTimeInterface $recentSince,
+        int $limit,
+    ): array {
+        if (!$this->hasScrobblesTable()) {
+            return [];
+        }
+
+        $userId = $this->resolveUserId();
+        $sql = <<<'SQL'
+            SELECT s.media_file_id AS id
+            FROM scrobbles s
+            WHERE s.user_id = :uid
+            GROUP BY s.media_file_id
+            HAVING SUM(CASE WHEN s.submission_time >= :recent THEN 1 ELSE 0 END) > 0
+               AND SUM(CASE WHEN s.submission_time >= :silence AND s.submission_time < :recent THEN 1 ELSE 0 END) = 0
+               AND SUM(CASE WHEN s.submission_time >= :window AND s.submission_time < :silence THEN 1 ELSE 0 END) > 0
+            ORDER BY MAX(s.submission_time) DESC
+            LIMIT :lim
+        SQL;
+
+        $rows = $this->connection()->fetchAllAssociative(
+            $sql,
+            [
+                'uid' => $userId,
+                'recent' => $recentSince->getTimestamp(),
+                'silence' => $silenceStart->getTimestamp(),
+                'window' => $windowStart->getTimestamp(),
+                'lim' => $limit,
+            ],
+            [
+                'recent' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'silence' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'window' => \Doctrine\DBAL\ParameterType::INTEGER,
+                'lim' => \Doctrine\DBAL\ParameterType::INTEGER,
+            ],
+        );
+
+        return array_map(static fn (array $r): string => (string) $r['id'], $rows);
+    }
+
+    /**
      * « Fidèles compagnons » : tracks played across the MOST DISTINCT days
      * (regularity, not raw volume — a track heard once a week for a year
      * beats one binged 50× in a day). Requires the scrobbles table; returns

--- a/src/Playlist/Definition/PepitesRedecouvertesDefinition.php
+++ b/src/Playlist/Definition/PepitesRedecouvertesDefinition.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Playlist\Definition;
+
+use App\Navidrome\NavidromeRepository;
+use App\Playlist\PlaylistContext;
+use App\Playlist\PlaylistDefinitionInterface;
+
+/**
+ * « Pépites redécouvertes » — tracks played again in the last `recentMonths`
+ * after a silence of `silenceMonths`, having already been listened to before
+ * that silence (within the `windowMonths` window). A genuine re-discovery.
+ * Reuses {@see NavidromeRepository::findRediscoveredGems()} then shuffles for
+ * a serendipitous order (like the other « pépites »).
+ */
+final class PepitesRedecouvertesDefinition implements PlaylistDefinitionInterface
+{
+    public function __construct(
+        private readonly NavidromeRepository $navidrome,
+        private readonly int $windowMonths = 24,
+        private readonly int $silenceMonths = 12,
+        private readonly int $recentMonths = 1,
+        private readonly int $limit = 50,
+    ) {
+    }
+
+    public function getSlug(): string
+    {
+        return 'pepites-redecouvertes';
+    }
+
+    public function getName(): string
+    {
+        return 'Pépites redécouvertes';
+    }
+
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Morceaux rejoués dans le dernier mois après %d mois de silence '
+            . '(et déjà écoutés avant, sur %d mois), en aléatoire.',
+            $this->silenceMonths,
+            $this->windowMonths,
+        );
+    }
+
+    public function build(PlaylistContext $context): array
+    {
+        $recentSince = $context->now->modify(sprintf('-%d months', $this->recentMonths));
+        $silenceStart = $context->now->modify(sprintf('-%d months', $this->recentMonths + $this->silenceMonths));
+        $windowStart = $context->now->modify(sprintf('-%d months', $this->windowMonths));
+
+        $ids = $this->navidrome->findRediscoveredGems($windowStart, $silenceStart, $recentSince, $this->limit);
+        shuffle($ids);
+
+        return $ids;
+    }
+}

--- a/tests/Playlist/DefinitionsTest.php
+++ b/tests/Playlist/DefinitionsTest.php
@@ -10,6 +10,7 @@ use App\Playlist\Definition\HappyBirthdayDefinition;
 use App\Playlist\Definition\HitParadeDefinition;
 use App\Playlist\Definition\KickstartDefinition;
 use App\Playlist\Definition\PepitesOublieesDefinition;
+use App\Playlist\Definition\PepitesRedecouvertesDefinition;
 use App\Playlist\Definition\TresVieillesPepitesDefinition;
 use App\Playlist\Definition\TopAllTimeDefinition;
 use App\Playlist\Definition\TopDeLanneeDefinition;
@@ -83,6 +84,31 @@ class DefinitionsTest extends TestCase
 
         $this->assertSame('tres-vieilles-pepites', $def->getSlug());
         $this->assertSame(['mf-ancient'], $def->build($this->ctx('2026-06-27')));
+    }
+
+    public function testPepitesRedecouvertesUsesThreeWindows(): void
+    {
+        $navidrome = $this->createMock(NavidromeRepository::class);
+        // now = 2026-06-27, recent=1mo, silence=12mo, window=24mo →
+        //   recentSince  = 2026-05-27
+        //   silenceStart = 2025-05-27 (now - 13 months)
+        //   windowStart  = 2024-06-27 (now - 24 months)
+        $navidrome->expects($this->once())
+            ->method('findRediscoveredGems')
+            ->with(
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2024-06-27'),
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2025-05-27'),
+                $this->callback(static fn (\DateTimeInterface $d): bool => $d->format('Y-m-d') === '2026-05-27'),
+                50,
+            )
+            ->willReturn(['mf-x', 'mf-y']);
+
+        $def = new PepitesRedecouvertesDefinition($navidrome, windowMonths: 24, silenceMonths: 12, recentMonths: 1, limit: 50);
+
+        $this->assertSame('pepites-redecouvertes', $def->getSlug());
+        $ids = $def->build($this->ctx('2026-06-27'));
+        sort($ids); // shuffled → assert the set.
+        $this->assertSame(['mf-x', 'mf-y'], $ids);
     }
 
     public function testCoupsDeCoeurCollectsStarredAndCapsAtLimit(): void


### PR DESCRIPTION
## Contexte

Nouvelle playlist : les morceaux **redécouverts** — rejoués récemment après une
longue absence. Sémantique retenue (choix utilisateur) :
- une écoute dans **le dernier mois** (la reprise),
- **aucune** écoute pendant les **12 mois** juste avant (le silence),
- au moins une écoute **avant** ce silence, dans la fenêtre de **24 mois** (une
  vraie *re*-découverte, pas une simple découverte récente),
- ordre **aléatoire** (comme les autres « pépites »).

Les « pépites » existantes s'appuient sur `annotation.play_date` (dernière écoute
seulement) → incapables de détecter « trou puis reprise ». Cette playlist
interroge donc l'historique par écoute (`scrobbles`).

## Changements

- **`NavidromeRepository::findRediscoveredGems()`** — requête sur `scrobbles`
  avec 3 fenêtres epoch (reprise `>= recent`, silence `[silence, recent)` vide,
  connu-avant `[window, silence)` non vide). Modelée sur
  `getRecentlyDiscoveredTracks` (guard `hasScrobblesTable`, `resolveUserId`,
  binds `INTEGER`).
- **`PepitesRedecouvertesDefinition`** (auto-taguée `app.playlist_definition`) —
  calcule les 3 seuils depuis `$context->now`, appelle le repo, `shuffle()`.
  Slug `pepites-redecouvertes`, nom unique « Pépites redécouvertes ».
- **Config** — `config/services.yaml` (params + fallbacks env + entrée service),
  fenêtres configurables `PLAYLIST_PEPITES_REDECOUVERTES_{WINDOW,SILENCE,RECENT}_MONTHS`,
  documentées dans `.env.dist`.
- **Test** — `DefinitionsTest::testPepitesRedecouvertesUsesThreeWindows` (vérifie
  les 3 seuils datés + le slug).
- **CHANGELOG** — entrée `1.3.0`.

## Vérification

- `composer ci` OK — **295 tests** (nouveau test inclus), PHPStan baseline (11
  connues), phpcs clean, 32 templates Twig.
- `config/services.yaml` re-parsé : entrée service + params + fallbacks env
  cohérents (args = constructeur de la définition).
- Dry-run à valider au déploiement :
  `php bin/console app:playlists:generate --slug pepites-redecouvertes --dry-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013NxqLFjFWHLuRJoQWNeWXJ)_